### PR TITLE
fix: add ETORO_USERNAME to daily-signals workflow

### DIFF
--- a/.github/workflows/daily-signals.yml
+++ b/.github/workflows/daily-signals.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           ETORO_API_KEY: ${{ secrets.ETORO_API_KEY }}
           ETORO_USER_KEY: ${{ secrets.ETORO_USER_KEY }}
+          ETORO_USERNAME: ${{ secrets.ETORO_USERNAME }}
         run: |
           echo "Downloading portfolio from eToro..."
           python trade.py -o p -t n


### PR DESCRIPTION
## Summary
- Adds `ETORO_USERNAME` env var (from secrets) to the portfolio download step
- Required after the security fix that removed the hardcoded default username
- Without this, the daily signals workflow will fail on portfolio download

## Urgency
This needs to be merged before the next daily signals run (22:00 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)