### PR TITLE
chore(sonar): mark 6 ReDoS+random hotspots as Safe via NOSONAR

### DIFF
--- a/scripts/calibrate_modifiers_t30.py
+++ b/scripts/calibrate_modifiers_t30.py
@@ -337,7 +337,9 @@ def bootstrap_spearman_ci(
 
     rhos = []
     for _ in range(n_resamples):
-        idx = [rng.randint(0, n - 1) for _ in range(n)]
+        idx = [
+            rng.randint(0, n - 1) for _ in range(n)
+        ]  # NOSONAR statistical bootstrap, not security
         bx = [xs[i] for i in idx]
         by = [ys[i] for i in idx]
         if len(set(bx)) < 2 or len(set(by)) < 2:

--- a/scripts/validate_brief.py
+++ b/scripts/validate_brief.py
@@ -71,7 +71,7 @@ NEWS_CONTEXT_PATTERNS = [
 NEWS_CONTEXT_RE = re.compile("|".join(NEWS_CONTEXT_PATTERNS), re.IGNORECASE)
 
 TICKER_RE = re.compile(r"\$([A-Z][A-Z0-9]+(?:\.[A-Z]+)?)")
-PCT_RE = re.compile(r"([+-]\d+\.?\d*)%")
+PCT_RE = re.compile(r"([+-]\d+\.?\d*)%")  # NOSONAR linear regex on trusted draft text
 PRICE_RE = re.compile(r"\$(\d[\d,]*\.?\d*)")
 
 # Map display names in post text to yfinance tickers for instrument-aware validation

--- a/trade_modules/committee_html.py
+++ b/trade_modules/committee_html.py
@@ -275,9 +275,9 @@ def _clean_name(raw):
     if not raw:
         return raw
     # Remove share class / listing suffixes
-    raw = re.sub(r"\s+ORD\s+\d+P$", "", raw, flags=re.I)
-    raw = re.sub(r"\s+CLASS\s+[A-C]$", "", raw, flags=re.I)
-    raw = re.sub(r"\s+CL\s+[A-C]$", "", raw, flags=re.I)
+    raw = re.sub(r"\s+ORD\s+\d+P$", "", raw, flags=re.I)  # NOSONAR linear, trusted yfinance name
+    raw = re.sub(r"\s+CLASS\s+[A-C]$", "", raw, flags=re.I)  # NOSONAR linear, trusted yfinance name
+    raw = re.sub(r"\s+CL\s+[A-C]$", "", raw, flags=re.I)  # NOSONAR linear, trusted yfinance name
     # Remove common suffixes for brevity
     for suffix in [
         ", Inc.",

--- a/trade_modules/committee_qa.py
+++ b/trade_modules/committee_qa.py
@@ -253,7 +253,7 @@ def normalize_agent_reports(
                     break
         if not ind.get("us_10y_yield"):
             for src_text in [str(ri.get("yield_curve_context", "")), str(ri)]:
-                m = re.search(
+                m = re.search(  # NOSONAR linear regex on trusted MCP-news context
                     r"10[- ]?year\s+(?:Treasury\s+)?(?:near|at|~)?\s*(\d+\.?\d*)\s*%",
                     src_text,
                     re.IGNORECASE,


### PR DESCRIPTION
## Summary
Reviews and suppresses the 6 NEW security hotspots flagged on master. All 6 are false-positives — each line was inspected individually before adding the comment.

## Hotspots reviewed

**python:S5852 (ReDoS, MEDIUM) — 5×, all linear regex on trusted input:**
- `scripts/validate_brief.py:74` — `PCT_RE = r"([+-]\d+\.?\d*)%"`. Bounded `\d+\.?\d*`, no nested quantifiers, no alternation. Input = our own draft text.
- `trade_modules/committee_html.py:278-280` — stock-name-suffix strippers (` ORD 5P`, ` CLASS A`, ` CL B`). Anchored to `$`, character classes are bounded. Input = `yfinance.info` `longName` field.
- `trade_modules/committee_qa.py:257` — `r"10[- ]?year\s+(?:Treasury\s+)?(?:near|at|~)?\s*(\d+\.?\d*)\s*%"`. Non-overlapping optional groups, no nested quantifiers. Input = our own MCP news context.

**python:S2245 (`random` not for crypto, MEDIUM) — 1×:**
- `scripts/calibrate_modifiers_t30.py:340` — `rng.randint()` inside bootstrap resampling for Spearman ρ. Statistical use, not security tokens. `random.Random(seed)` is the correct primitive here.

## Effect on quality gate
Should bring `new_security_hotspots_reviewed` from 25% → 100%. Coverage condition (58.7% / 80%) not addressed by this PR — that's a separate, larger test-debt cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)