### PR TITLE
fix: exclude ETFs from momentum-based BS signals

### DIFF
--- a/trade_modules/analysis/signals.py
+++ b/trade_modules/analysis/signals.py
@@ -762,9 +762,14 @@ def calculate_action_vectorized(df: pd.DataFrame, option: str = "market") -> pd.
                         )
                         continue
 
-            # For non-equity assets (crypto, ETF, commodity), use momentum-based signals
-            # since analyst coverage is not applicable
-            if asset_type in ("crypto", "etf", "commodity"):
+            # For non-equity assets, use momentum-based signals for crypto/commodity only.
+            # ETFs are excluded — momentum-only classification on passive instruments
+            # produces noise (83 phantom BUYs in a bull market). ETFs lack analyst targets,
+            # PE ratios, and fundamentals that make signals actionable.
+            if asset_type == "etf":
+                actions.loc[idx] = "I"
+                continue
+            if asset_type in ("crypto", "commodity"):
                 # Use price momentum (52-week high %) and technical indicators
                 row_pct_52w = pct_52w.loc[idx]
                 row_above_200dma = above_200dma.loc[idx]


### PR DESCRIPTION
## Summary

ETFs entered the momentum signal path (if 52W >= 85% + above 200DMA → BUY) producing 83 phantom BUY signals. Every broad-market ETF near its 52-week high (SPY, QQQ, VOO, plus ~60 Xetra/Paris ETFs) was classified as BUY despite having zero fundamental data.

**Fix**: ETFs now get INCONCLUSIVE. Crypto and commodities still use the momentum path (by design).

## Test plan
- [x] Signal distribution: 168 BUY → ~85 BUY (real stocks only)
- [x] Tokyo stocks remain BUY (legitimate analyst-based signals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)