### PR TITLE
fix: Python 3.10 compat + remove duplicate imports

### DIFF
--- a/scripts/refresh_etoro_universe.py
+++ b/scripts/refresh_etoro_universe.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import time
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -35,14 +35,9 @@ _USER_AGENT = (
 )
 _INTER_PAGE_DELAY_SEC = 0.5
 
-_DEFAULT_OUTPUT_CSV = str(
-    Path(__file__).parent.parent / "yahoofinance" / "input" / "etoro.csv"
-)
+_DEFAULT_OUTPUT_CSV = str(Path(__file__).parent.parent / "yahoofinance" / "input" / "etoro.csv")
 _DEFAULT_DELTA_LOG = str(
-    Path(__file__).parent.parent
-    / "yahoofinance"
-    / "input"
-    / ".universe-refresh-log.json"
+    Path(__file__).parent.parent / "yahoofinance" / "input" / ".universe-refresh-log.json"
 )
 
 
@@ -62,12 +57,26 @@ _SUFFIX_REMAP = {
     ".LSB": ".LS",
 }
 
-_DROP_SUFFIXES = frozenset({
-    ".RTH", ".DELISTED", ".TEST", ".OLD", ".EXT", ".24-7",
-    ".CALL1", ".CALL2", ".PUT1", ".PUT2",
-    ".TENDER", ".CASHRESERVED", ".MOEX",
-    ".RIGHT", ".WS", ".PFD",
-})
+_DROP_SUFFIXES = frozenset(
+    {
+        ".RTH",
+        ".DELISTED",
+        ".TEST",
+        ".OLD",
+        ".EXT",
+        ".24-7",
+        ".CALL1",
+        ".CALL2",
+        ".PUT1",
+        ".PUT2",
+        ".TENDER",
+        ".CASHRESERVED",
+        ".MOEX",
+        ".RIGHT",
+        ".WS",
+        ".PFD",
+    }
+)
 
 
 def _is_junk_suffix(suffix: str) -> bool:
@@ -180,7 +189,10 @@ def _get_credential(env_var: str, keychain_service: str) -> str | None:
     try:
         result = subprocess.run(
             ["security", "find-generic-password", "-a", "etoro-api", "-s", keychain_service, "-w"],
-            capture_output=True, text=True, timeout=5, check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
         if result.returncode == 0:
             return result.stdout.strip()
@@ -266,7 +278,11 @@ def fetch_all_assets(
             all_items.extend(items)
             logger.info(
                 "  %s page %d: +%d items (running total this class: %d / %d)",
-                asset_class, page, len(items), min(page * page_size, total), total,
+                asset_class,
+                page,
+                len(items),
+                min(page * page_size, total),
+                total,
             )
             if not items or page * page_size >= total:
                 break
@@ -302,7 +318,7 @@ def write_delta_log(
 ) -> None:
     """Write a JSON snapshot of this run's delta."""
     payload = {
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "total_count": total_count,
         "new_count": len(new_symbols),
         "removed_count": len(removed_symbols),
@@ -331,9 +347,7 @@ def main(
     delta_log_path: str = _DEFAULT_DELTA_LOG,
 ) -> int:
     """Run the refresh pipeline. Returns exit code (0 success, 1 error)."""
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
     try:
         api_key, user_key = get_credentials()
@@ -352,9 +366,9 @@ def main(
 
     if len(items) < MIN_INSTRUMENTS_THRESHOLD:
         logger.error(
-            "Refusing to proceed: only %d items returned (threshold %d). "
-            "API may be broken.",
-            len(items), MIN_INSTRUMENTS_THRESHOLD,
+            "Refusing to proceed: only %d items returned (threshold %d). API may be broken.",
+            len(items),
+            MIN_INSTRUMENTS_THRESHOLD,
         )
         return 1
 
@@ -375,15 +389,20 @@ def main(
         if normalized is None:
             skipped_rth += 1
             continue
-        rows.append({
-            "symbol": normalized,
-            "company": item.get("displayName", ""),
-            "exchange": item.get("exchangeName", ""),
-        })
+        rows.append(
+            {
+                "symbol": normalized,
+                "company": item.get("displayName", ""),
+                "exchange": item.get("exchangeName", ""),
+            }
+        )
 
     logger.info(
         "After filters: %d candidates (skipped %d aliases, %d empty, %d RTH)",
-        len(rows), skipped_alias, skipped_no_symbol, skipped_rth,
+        len(rows),
+        skipped_alias,
+        skipped_no_symbol,
+        skipped_rth,
     )
 
     rows = fix_share_classes(rows)
@@ -396,7 +415,9 @@ def main(
     removed_symbols = sorted(existing_symbols - new_symbols_set)
     logger.info(
         "Delta: +%d new, -%d removed (vs %d existing)",
-        len(new_symbols), len(removed_symbols), len(existing_symbols),
+        len(new_symbols),
+        len(removed_symbols),
+        len(existing_symbols),
     )
 
     write_universe_csv(deduped, output_csv_path)

--- a/yahoofinance/analysis/analyst.py
+++ b/yahoofinance/analysis/analyst.py
@@ -11,8 +11,6 @@ from typing import Any
 
 import pandas as pd
 
-from yahoofinance.core.errors import YFinanceError
-
 from ..core.config import POSITIVE_GRADES
 from ..core.errors import YFinanceError
 from ..core.logging import get_logger
@@ -275,7 +273,7 @@ class AnalystData:
     analyst_count: int | None = None
 
 
-from .base_analysis import BaseAnalysisService
+from .base_analysis import BaseAnalysisService  # noqa: E402
 
 
 class AnalystRatingsService(BaseAnalysisService):

--- a/yahoofinance/analysis/earnings.py
+++ b/yahoofinance/analysis/earnings.py
@@ -15,8 +15,6 @@ from typing import Any
 
 import pandas as pd
 
-from yahoofinance.core.errors import YFinanceError
-
 from ..core.errors import YFinanceError
 from ..core.logging import get_logger
 from .base_analysis import BaseAnalysisService

--- a/yahoofinance/analysis/insiders.py
+++ b/yahoofinance/analysis/insiders.py
@@ -9,8 +9,6 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
-from yahoofinance.core.errors import YFinanceError
-
 from ..api import AsyncFinanceDataProvider, FinanceDataProvider, get_provider
 from ..core.errors import YFinanceError
 from ..core.logging import get_logger

--- a/yahoofinance/analysis/market.py
+++ b/yahoofinance/analysis/market.py
@@ -16,9 +16,9 @@ import pandas as pd
 
 # Trading criteria moved to centralized trade configuration
 from trade_modules.trade_config import TradeConfig
-from yahoofinance.core.errors import YFinanceError
 
 from ..api import AsyncFinanceDataProvider, FinanceDataProvider, get_provider
+from ..core.errors import YFinanceError
 from ..core.logging import get_logger
 from ..utils.data.ticker_utils import normalize_ticker
 from .market_filters import (
@@ -29,7 +29,6 @@ from .market_filters import (
 
 # Define constants for repeated strings
 BUY_PERCENTAGE_DISPLAY = "% BUY"
-from ..core.errors import YFinanceError
 
 logger = get_logger(__name__)
 

--- a/yahoofinance/analysis/metrics.py
+++ b/yahoofinance/analysis/metrics.py
@@ -14,8 +14,6 @@ while maintaining the same functionality.
 from dataclasses import dataclass
 from typing import Any
 
-from yahoofinance.core.errors import YFinanceError
-
 from ..api import AsyncFinanceDataProvider, FinanceDataProvider, get_provider
 from ..core.errors import YFinanceError
 from ..core.logging import get_logger

--- a/yahoofinance/utils/market/ticker_utils.py
+++ b/yahoofinance/utils/market/ticker_utils.py
@@ -7,8 +7,6 @@ to ensure they are properly formatted for API calls.
 
 import re
 
-from yahoofinance.core.errors import ValidationError
-
 from ...core.config import SPECIAL_TICKERS
 from ...core.errors import ValidationError
 


### PR DESCRIPTION
## Summary
- Replace `from datetime import UTC` with `timezone.utc` in `refresh_etoro_universe.py` — `datetime.UTC` is Python 3.11+ only, but CI tests against 3.10
- Remove duplicate absolute imports shadowed by relative imports (F811 warnings in `analysis/*.py` and `ticker_utils.py`)
- Move `YFinanceError` import to top of `market.py` (E402)

## Test plan
- [ ] CI passes on Python 3.10, 3.11, 3.12
- [ ] No F811 or E402 ruff warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)