### PR TITLE
fix(daily-signals): shard market scan to clear GitHub's 6h job cap

### DIFF
--- a/.github/workflows/daily-signals.yml
+++ b/.github/workflows/daily-signals.yml
@@ -2,11 +2,10 @@ name: Daily Trading Signals
 
 on:
   schedule:
-    # Run at 22:00 UTC daily (after US market close at 21:00 UTC)
-    # This is 00:00 Athens time (winter) or 01:00 Athens time (summer)
-    # Trade takes ~4-5 hours, so finishes by ~02:00-03:00 UTC
-    # Census runs at 00:00 UTC (~02:00-03:00 UTC actual)
-    # Both complete well before morning briefing at 12:00 UTC (07:00 ET)
+    # Run at 22:00 UTC daily (after US market close at 21:00 UTC).
+    # 00:00 Athens (winter) / 01:00 (summer). The market scan is sharded across
+    # parallel jobs so each finishes well under GitHub's hard 6h per-job cap;
+    # the merge job recombines the slices, derives buy/sell/hold, and commits.
     - cron: '0 22 * * *'
   workflow_dispatch: # Allow manual triggering
 
@@ -19,9 +18,64 @@ permissions:
   contents: read
 
 jobs:
-  generate-signals:
+  # ---------------------------------------------------------------------------
+  # Stage 1 — scan the universe in parallel shards, each safely under the 6h cap.
+  # Pure compute: no secrets, no push. Each shard uploads its slice as an artifact.
+  # ---------------------------------------------------------------------------
+  scan:
     runs-on: ubuntu-latest
-    timeout-minutes: 540  # ~9h; universe grew from 5K to 12.5K tickers
+    timeout-minutes: 330  # 5.5h — under GitHub's hard 6h hosted-runner cap, so a
+                          # genuinely stuck shard fails cleanly instead of being
+                          # opaquely killed at 6h.
+    env:
+      SHARD_COUNT: "6"  # MUST equal the length of matrix.shard below
+    strategy:
+      fail-fast: false  # one slow/failed shard shouldn't abort the others
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install production deps (hashed lockfile)
+        run: |
+          pip install --only-binary :all: --require-hashes -r requirements-lock.txt
+
+      - name: Validate configuration
+        run: python trade.py --validate-config
+
+      - name: Run market/eToro signals for this shard (trade e)
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}  # SHARD_COUNT inherited from job env
+        run: |
+          echo "Scanning shard ${SHARD_INDEX}/${SHARD_COUNT}..."
+          python trade.py -o e
+          mv yahoofinance/output/etoro.csv "etoro_shard_${SHARD_INDEX}.csv"
+          echo "Shard ${SHARD_INDEX} complete: $(wc -l < etoro_shard_${SHARD_INDEX}.csv) lines"
+
+      - name: Upload shard output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: etoro-shard-${{ matrix.shard }}
+          path: etoro_shard_${{ matrix.shard }}.csv
+          retention-days: 1
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Stage 2 — merge shard slices into etoro.csv, refresh portfolio, derive
+  # buy/sell/hold, health-check, and commit. Needs secrets + write; runs once,
+  # only after every shard succeeds.
+  # ---------------------------------------------------------------------------
+  merge:
+    runs-on: ubuntu-latest
+    needs: scan
+    timeout-minutes: 45
     permissions:
       contents: write  # Required for git push
 
@@ -43,6 +97,19 @@ jobs:
 
       - name: Validate configuration
         run: python trade.py --validate-config
+
+      - name: Download shard outputs
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: etoro-shard-*
+          path: shards
+          merge-multiple: true
+
+      - name: Merge shards into etoro.csv
+        run: |
+          echo "Merging shard slices..."
+          python scripts/merge_shards.py --shard-dir shards --output yahoofinance/output/etoro.csv
+          echo "Merge complete: $(wc -l < yahoofinance/output/etoro.csv) lines"
 
       - name: Download fresh portfolio from eToro
         env:
@@ -71,12 +138,6 @@ jobs:
           echo "Running portfolio analysis..."
           python trade.py -o p
           echo "Portfolio signals complete"
-
-      - name: Run market/eToro signals (trade e)
-        run: |
-          echo "Running market analysis..."
-          python trade.py -o e
-          echo "Market signals complete"
 
       - name: Generate filtered trade files (buy/sell/hold)
         run: |
@@ -195,10 +256,10 @@ jobs:
             yahoofinance/output/hold.csv
           retention-days: 30
 
-  # Failure notification
+  # Failure notification (fires if any shard or the merge fails)
   notify-failure:
     runs-on: ubuntu-latest
-    needs: generate-signals
+    needs: [scan, merge]
     if: failure()
     permissions:
       contents: read
@@ -209,7 +270,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const runUrl =
+              `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
             const date = new Date().toISOString().split('T')[0];
 
             // Check for existing open issues
@@ -236,7 +299,14 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: `Daily Signals Failed - ${date}`,
-                body: `## Daily Trading Signals Generation Failed\n\n**Date**: ${date}\n**Workflow Run**: ${runUrl}\n\n### Common Issues\n- Yahoo Finance API rate limiting\n- Network timeouts\n- Configuration validation failure\n\n---\n*Auto-created by signals failure alerting*`,
+                body:
+                  `## Daily Trading Signals Generation Failed\n\n` +
+                  `**Date**: ${date}\n**Workflow Run**: ${runUrl}\n\n` +
+                  `### Common Issues\n` +
+                  `- Yahoo Finance API rate limiting\n` +
+                  `- Network timeouts\n` +
+                  `- Configuration validation failure\n\n` +
+                  `---\n*Auto-created by signals failure alerting*`,
                 labels: ['signals-failure', 'automated', 'bug']
               });
             }

--- a/.github/workflows/daily-signals.yml
+++ b/.github/workflows/daily-signals.yml
@@ -14,9 +14,6 @@ concurrency:
   group: daily-signals
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   # ---------------------------------------------------------------------------
   # Stage 1 — scan the universe in parallel shards, each safely under the 6h cap.
@@ -24,6 +21,8 @@ jobs:
   # ---------------------------------------------------------------------------
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # read-only — shards never push (least privilege per S8264)
     timeout-minutes: 330  # 5.5h — under GitHub's hard 6h hosted-runner cap, so a
                           # genuinely stuck shard fails cleanly instead of being
                           # opaquely killed at 6h.

--- a/scripts/merge_shards.py
+++ b/scripts/merge_shards.py
@@ -1,0 +1,42 @@
+"""Merge per-shard market-scan outputs into yahoofinance/output/etoro.csv.
+
+Each parallel CI shard produces an ``etoro_shard_<k>.csv`` (a round-robin slice of
+the universe). This recombines them — concatenate, dedupe on TKR, sort by market
+cap — into the canonical ``output/etoro.csv`` that the downstream trade-filter
+steps (``trade.py -o t -t b|s|h``) consume.
+
+Usage:
+    python scripts/merge_shards.py
+    python scripts/merge_shards.py --shard-dir . --output yahoofinance/output/etoro.csv
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from trade_modules.sharding import merge_shard_csvs
+
+logger = logging.getLogger(__name__)
+
+_ROOT = Path(__file__).parent.parent
+_DEFAULT_OUTPUT = str(_ROOT / "yahoofinance" / "output" / "etoro.csv")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shard-dir", default=".", help="Directory containing etoro_shard_*.csv files"
+    )
+    parser.add_argument("--output", default=_DEFAULT_OUTPUT, help="Merged output path")
+    parser.add_argument("--pattern", default="etoro_shard_*.csv", help="Shard filename glob")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    rows = merge_shard_csvs(args.shard_dir, args.output, pattern=args.pattern)
+    logger.info("Merged %d tickers into %s", rows, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/trade_modules/test_sharding.py
+++ b/tests/unit/trade_modules/test_sharding.py
@@ -1,0 +1,136 @@
+"""
+Test suite for trade_modules.sharding module.
+
+Covers the daily-signals sharding helpers:
+- shard_tickers: deterministic round-robin slice of the universe
+- apply_shard_from_env: env-gated wrapper used by the `trade -o e` path
+- merge_shard_frames / merge_shard_csvs: recombine per-shard outputs into etoro.csv
+"""
+
+import pandas as pd
+import pytest
+
+from trade_modules.sharding import (
+    apply_shard_from_env,
+    merge_shard_csvs,
+    merge_shard_frames,
+    shard_tickers,
+)
+
+# --- shard_tickers ---------------------------------------------------------
+
+
+@pytest.fixture
+def universe():
+    # 20 tickers, not divisible by most shard counts -> exposes balance bugs
+    return [f"T{i}" for i in range(20)]
+
+
+def test_count_one_returns_identity(universe):
+    assert shard_tickers(universe, 0, 1) == universe
+
+
+def test_count_zero_or_negative_returns_full(universe):
+    # count<=1 means "no sharding"
+    assert shard_tickers(universe, 0, 0) == universe
+    assert shard_tickers(universe, 0, -3) == universe
+
+
+@pytest.mark.parametrize("count", [1, 3, 6, 8])
+def test_full_coverage_no_overlap(universe, count):
+    shards = [shard_tickers(universe, i, count) for i in range(count)]
+    # every ticker covered exactly once
+    flattened = [t for s in shards for t in s]
+    assert sorted(flattened) == sorted(universe)
+    assert len(flattened) == len(set(flattened))  # no duplicates
+
+
+@pytest.mark.parametrize("count", [3, 6, 8])
+def test_shards_balanced(universe, count):
+    sizes = [len(shard_tickers(universe, i, count)) for i in range(count)]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_index_out_of_range_raises(universe):
+    with pytest.raises(ValueError):
+        shard_tickers(universe, 6, 6)  # index must be < count
+    with pytest.raises(ValueError):
+        shard_tickers(universe, -1, 6)
+
+
+def test_empty_universe():
+    assert shard_tickers([], 2, 6) == []
+
+
+def test_deterministic(universe):
+    assert shard_tickers(universe, 2, 6) == shard_tickers(universe, 2, 6)
+
+
+# --- apply_shard_from_env --------------------------------------------------
+
+
+def test_env_unset_returns_full(universe):
+    assert apply_shard_from_env(universe, env={}) == universe
+
+
+def test_env_count_one_returns_full(universe):
+    assert apply_shard_from_env(universe, env={"SHARD_COUNT": "1"}) == universe
+
+
+def test_env_applies_shard(universe):
+    got = apply_shard_from_env(universe, env={"SHARD_COUNT": "6", "SHARD_INDEX": "2"})
+    assert got == shard_tickers(universe, 2, 6)
+
+
+def test_env_index_defaults_to_zero(universe):
+    got = apply_shard_from_env(universe, env={"SHARD_COUNT": "6"})
+    assert got == shard_tickers(universe, 0, 6)
+
+
+# --- merge -----------------------------------------------------------------
+
+COLUMNS = ["TKR", "NAME", "CAP", "BS"]
+
+
+def _frame(rows):
+    return pd.DataFrame(rows, columns=COLUMNS)
+
+
+def test_merge_concatenates_disjoint_shards():
+    f0 = _frame([["AAPL", "Apple", "3T", "B"]])
+    f1 = _frame([["MSFT", "Microsoft", "2T", "H"]])
+    f2 = _frame([["SAP.DE", "SAP", "200B", "S"]])
+    merged = merge_shard_frames([f0, f1, f2])
+    assert len(merged) == 3
+    assert set(merged["TKR"]) == {"AAPL", "MSFT", "SAP.DE"}
+    assert list(merged.columns) == COLUMNS
+
+
+def test_merge_dedupes_overlapping_ticker():
+    f0 = _frame([["AAPL", "Apple", "3T", "B"]])
+    f1 = _frame([["AAPL", "Apple", "3T", "B"], ["MSFT", "Microsoft", "2T", "H"]])
+    merged = merge_shard_frames([f0, f1])
+    assert len(merged) == 2
+    assert sorted(merged["TKR"]) == ["AAPL", "MSFT"]
+
+
+def test_merge_sorts_by_market_cap_desc():
+    f0 = _frame([["SMALL", "Small", "100B", "H"]])
+    f1 = _frame([["BIG", "Big", "2T", "B"], ["MID", "Mid", "500B", "H"]])
+    merged = merge_shard_frames([f0, f1])
+    assert list(merged["TKR"]) == ["BIG", "MID", "SMALL"]
+
+
+def test_merge_csvs_roundtrip(tmp_path):
+    _frame([["AAPL", "Apple", "3T", "B"]]).to_csv(tmp_path / "etoro_shard_0.csv", index=False)
+    _frame([["MSFT", "Microsoft", "2T", "H"]]).to_csv(tmp_path / "etoro_shard_1.csv", index=False)
+    out = tmp_path / "etoro.csv"
+    count = merge_shard_csvs(str(tmp_path), str(out))
+    assert count == 2
+    result = pd.read_csv(out)
+    assert sorted(result["TKR"]) == ["AAPL", "MSFT"]
+
+
+def test_merge_csvs_errors_on_no_shards(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        merge_shard_csvs(str(tmp_path), str(tmp_path / "etoro.csv"))

--- a/tests/unit/trade_modules/test_sharding.py
+++ b/tests/unit/trade_modules/test_sharding.py
@@ -134,3 +134,15 @@ def test_merge_csvs_roundtrip(tmp_path):
 def test_merge_csvs_errors_on_no_shards(tmp_path):
     with pytest.raises(FileNotFoundError):
         merge_shard_csvs(str(tmp_path), str(tmp_path / "etoro.csv"))
+
+
+def test_merge_shards_cli_main(tmp_path):
+    from scripts.merge_shards import main
+
+    _frame([["AAPL", "Apple", "3T", "B"]]).to_csv(tmp_path / "etoro_shard_0.csv", index=False)
+    _frame([["MSFT", "Microsoft", "2T", "H"]]).to_csv(tmp_path / "etoro_shard_1.csv", index=False)
+    out = tmp_path / "etoro.csv"
+    rc = main(["--shard-dir", str(tmp_path), "--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    assert sorted(pd.read_csv(out)["TKR"]) == ["AAPL", "MSFT"]

--- a/trade_modules/sharding.py
+++ b/trade_modules/sharding.py
@@ -1,0 +1,84 @@
+"""Sharding helpers for the daily market scan (``trade.py -o e``).
+
+The eToro universe grew past ~12.5K tickers, pushing the single market-scan job
+over GitHub's hard 6-hour hosted-runner cap. Splitting the universe across N
+parallel jobs keeps each job well under the cap. Each shard writes its own
+``etoro_shard_<k>.csv``; the merge step recombines them into
+``yahoofinance/output/etoro.csv``.
+
+When the SHARD_COUNT/SHARD_INDEX env vars are unset (local runs, the committee,
+the weekly universe refresh), behaviour is identical to the unsharded pipeline.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from collections.abc import Mapping
+
+import pandas as pd
+
+from trade_modules.output_manager import sort_by_market_cap_descending
+
+
+def shard_tickers(tickers: list[str], index: int, count: int) -> list[str]:
+    """Return shard ``index`` of ``count`` via round-robin stride.
+
+    ``count <= 1`` means "no sharding" and returns the full list unchanged.
+    Round-robin (``tickers[index::count]``) guarantees every ticker is covered
+    exactly once across the shards, with shard sizes differing by at most one and
+    slow/fast tickers spread evenly across shards.
+
+    Raises:
+        ValueError: if ``count > 1`` and ``index`` is not in ``[0, count)``.
+    """
+    if count <= 1:
+        return list(tickers)
+    if not (0 <= index < count):
+        raise ValueError(f"shard index {index} out of range for count {count}")
+    return list(tickers)[index::count]
+
+
+def apply_shard_from_env(tickers: list[str], env: Mapping[str, str] | None = None) -> list[str]:
+    """Slice ``tickers`` to the shard named by the SHARD_INDEX/SHARD_COUNT env vars.
+
+    Defaults: SHARD_COUNT=1 (no sharding), SHARD_INDEX=0. Pass ``env`` explicitly
+    in tests; production callers let it default to ``os.environ``.
+    """
+    if env is None:
+        env = os.environ
+    count = int(env.get("SHARD_COUNT", "1"))
+    index = int(env.get("SHARD_INDEX", "0"))
+    return shard_tickers(tickers, index, count)
+
+
+def merge_shard_frames(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Concatenate per-shard DataFrames, dedupe on TKR, and sort by market cap.
+
+    Round-robin sharding guarantees disjoint ticker sets, so the dedupe is a
+    safety net. The final sort reuses the canonical
+    :func:`trade_modules.output_manager.sort_by_market_cap_descending` so the
+    merged ``etoro.csv`` matches the ordering of the unsharded pipeline.
+    """
+    combined = pd.concat(frames, ignore_index=True)
+    if "TKR" in combined.columns:
+        combined = combined.drop_duplicates(subset="TKR", keep="first")
+    combined = sort_by_market_cap_descending(combined)
+    return combined.reset_index(drop=True)
+
+
+def merge_shard_csvs(input_dir: str, output_path: str, pattern: str = "etoro_shard_*.csv") -> int:
+    """Read every shard CSV in ``input_dir``, merge, and write ``output_path``.
+
+    Returns the merged row count.
+
+    Raises:
+        FileNotFoundError: if no files match ``pattern`` in ``input_dir``.
+    """
+    paths = sorted(glob.glob(os.path.join(input_dir, pattern)))
+    if not paths:
+        raise FileNotFoundError(f"No shard files matching {pattern!r} in {input_dir}")
+    frames = [pd.read_csv(p) for p in paths]
+    merged = merge_shard_frames(frames)
+    merged.to_csv(output_path, index=False)
+    return len(merged)

--- a/trade_modules/trade_cli.py
+++ b/trade_modules/trade_cli.py
@@ -23,6 +23,7 @@ from yahoofinance.utils.dependency_injection import registry
 
 from .analysis.tiers import _parse_market_cap
 from .cli import get_user_source_choice
+from .sharding import apply_shard_from_env
 from .utils import get_file_paths
 
 
@@ -1090,6 +1091,15 @@ async def main_async_with_args(args, app_logger=None):
                 app_logger.info("Handling eToro analysis")
 
             tickers = display.load_tickers("E")
+            # Optional sharding: when SHARD_COUNT>1 (set per matrix job in CI),
+            # process only this shard's slice so each parallel job stays under
+            # GitHub's 6h runner cap. No-op for local/committee runs.
+            tickers = apply_shard_from_env(tickers)
+            if app_logger and os.environ.get("SHARD_COUNT", "1") != "1":
+                app_logger.info(
+                    f"Sharded universe: {len(tickers)} tickers "
+                    f"(shard {os.environ.get('SHARD_INDEX', '0')}/{os.environ.get('SHARD_COUNT')})"
+                )
             await display_market_report(
                 display, tickers, "E", verbose=True, get_provider=provider, app_logger=app_logger
             )


### PR DESCRIPTION
## Problem

`etoro.csv` + `buy/sell/hold.csv` have been **frozen since May 25**. Every `Daily Trading Signals` run since then is `cancelled` at exactly **6h0m** — GitHub's hard hosted-runner job cap — before it can commit. Root cause: PR #52 grew the universe ~5K → **12,545 tickers**, and the single `trade.py -o e` scan now needs >6h. The `timeout-minutes: 540` bump was **inert** (the 6h platform cap overrides any higher value).

(Holdings stayed fresh because the daily committee refreshes `portfolio.csv` itself; only the full-universe screen was stale.)

## Fix

Split the scan into **6 parallel matrix jobs** (~2.1K tickers each, ~1.5–2h), then a **merge job** recombines the slices and runs the existing downstream steps + commit. Daily cadence preserved; scales as the universe grows.

- **`trade_modules/sharding.py`** — `shard_tickers` (round-robin stride: exact coverage, balanced ≤1), `apply_shard_from_env`, `merge_shard_frames`/`merge_shard_csvs` (reuses the canonical market-cap sort).
- **`trade_modules/trade_cli.py`** — env-gated shard slice in the `-o e` path. **No-op when `SHARD_COUNT` is unset**, so local runs, the committee, and `weekly-universe-refresh` are unchanged.
- **`scripts/merge_shards.py`** — thin CLI over the merge helpers.
- **`.github/workflows/daily-signals.yml`** — `scan` (matrix, no secrets, `contents: read`, `timeout-minutes: 330`) → `merge` (`needs: scan`, secrets + `contents: write`, commit/push) → `notify-failure` on either stage.

## Tests

`tests/unit/trade_modules/test_sharding.py` — shard coverage/balance/edge cases (N∈{1,3,6,8}) + merge dedupe/sort/roundtrip. Verified coverage is exact and balanced over the real 12,544-ticker universe (`[2091×4, 2090×2]`).

## Validation after merge

Trigger once to backfill today's stale data and prove end-to-end:
`gh workflow run daily-signals.yml --ref master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)