### PR TITLE
fix(merge-shards): bootstrap repo root for script-mode import

### DIFF
--- a/scripts/merge_shards.py
+++ b/scripts/merge_shards.py
@@ -15,11 +15,15 @@ import logging
 import sys
 from pathlib import Path
 
-from trade_modules.sharding import merge_shard_csvs
+_ROOT = Path(__file__).resolve().parent.parent
+# Running as a script (`python scripts/merge_shards.py`) puts scripts/ on
+# sys.path, not the repo root — bootstrap the root so trade_modules imports.
+sys.path.insert(0, str(_ROOT))
+
+from trade_modules.sharding import merge_shard_csvs  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
-_ROOT = Path(__file__).parent.parent
 _DEFAULT_OUTPUT = str(_ROOT / "yahoofinance" / "output" / "etoro.csv")
 
 

--- a/tests/unit/trade_modules/test_sharding.py
+++ b/tests/unit/trade_modules/test_sharding.py
@@ -7,6 +7,8 @@ Covers the daily-signals sharding helpers:
 - merge_shard_frames / merge_shard_csvs: recombine per-shard outputs into etoro.csv
 """
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -146,3 +148,32 @@ def test_merge_shards_cli_main(tmp_path):
     assert rc == 0
     assert out.exists()
     assert sorted(pd.read_csv(out)["TKR"]) == ["AAPL", "MSFT"]
+
+
+def test_merge_shards_runs_as_script(tmp_path):
+    """`python scripts/merge_shards.py` (how CI invokes it) must resolve the
+    trade_modules import. Script mode puts scripts/ on sys.path, not the repo
+    root, so the script must bootstrap the root itself. Importing main() (above)
+    can't catch this regression — only executing the script as a subprocess does."""
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[3]
+    _frame([["AAPL", "Apple", "3T", "B"]]).to_csv(tmp_path / "etoro_shard_0.csv", index=False)
+    _frame([["MSFT", "Microsoft", "2T", "H"]]).to_csv(tmp_path / "etoro_shard_1.csv", index=False)
+    out = tmp_path / "etoro.csv"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "merge_shards.py"),
+            "--shard-dir",
+            str(tmp_path),
+            "--output",
+            str(out),
+        ],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.exists()


### PR DESCRIPTION
## Problem

The sharded daily-signals **merge job failed** (run 26657813712): all 6 scan shards succeeded, but `python scripts/merge_shards.py` raised `ModuleNotFoundError: No module named 'trade_modules'` and the merge never committed — so `etoro.csv` stayed stale.

**Root cause:** running a script as `python scripts/merge_shards.py` puts `scripts/` on `sys.path`, not the repo root, so `from trade_modules.sharding import …` can't resolve. The unit test imported `main()` (pytest already has the repo root on `sys.path`), so it never exercised the script-mode path.

## Fix

- `scripts/merge_shards.py`: insert the repo root on `sys.path` before importing `trade_modules` (self-contained; matches the `python scripts/X.py` convention used elsewhere).
- `tests`: add a **subprocess** test that runs the script exactly as CI does — reproduces the failure (verified RED) and guards against regression. 23 tests pass.

## Impact

Unblocks the merge job. Once on master, tonight's 22:00 UTC scheduled run (already sharded) will recombine + commit fresh full-universe signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)