### PR TITLE
S1: universe & quality filter (routing + gates, referee-validated)

### DIFF
--- a/scripts/universe_filter_report.py
+++ b/scripts/universe_filter_report.py
@@ -1,0 +1,438 @@
+"""
+universe_filter_report.py — S1 Universe Filter Validation & Live Effect Report
+
+Two goals:
+  A) LIVE effect: run filter_universe on today's etoro.csv → show counts
+     (eligible / price_only / excluded), per-gate drop counts, dropped-name list.
+  B) Referee-backed validation on the ONE dim present in history (tier/region):
+     compare_tier_region_filters() runs harness.evaluate on (i) full set,
+     (ii) excl-micro/small, (iii) each region alone → ranks by OOS alpha@T+30.
+     Honest caveat: analyst/earnings/trend gates are NOT in historical rows
+     → forward-gated only, no OOS claim.
+
+Usage:
+    python3 -m scripts.universe_filter_report
+
+All I/O is inside main(). # pragma: no cover applied to all I/O + CLI code.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no I/O
+# ---------------------------------------------------------------------------
+
+
+def summarize_filter_result(result: dict) -> dict:
+    """Compute high-level summary counts from a filter_universe result.
+
+    Returns a dict with keys:
+        eligible, price_only, excluded, fundamental_total, eligible_pct
+    """
+    summary = result["summary"]
+    fundamental_total = summary["fundamental"]
+    eligible = summary["eligible"]
+    pct = (eligible / fundamental_total * 100.0) if fundamental_total > 0 else 0.0
+    return {
+        "eligible": eligible,
+        "price_only": summary["price_only"],
+        "excluded": summary["excluded"],
+        "fundamental_total": fundamental_total,
+        "eligible_pct": round(pct, 1),
+    }
+
+
+def aggregate_gate_counts(result: dict) -> dict:
+    """Return the per-gate failure counts from a filter_universe result."""
+    return dict(result["summary"]["gate_failures"])
+
+
+def aggregate_dropped_names(result: dict) -> list[dict]:
+    """Return list of {ticker, reason} for every fundamental name that FAILED.
+
+    Price-only assets (crypto, ETFs) are routed — they are NOT in this list.
+    Excluded assets (no usable price) ARE in this list.
+    """
+    dropped: list[dict] = []
+    # Fundamental failures: reasons dict, non-empty reasons list = failed
+    reasons = result["reasons"]
+    for tkr, rsns in reasons.items():
+        if rsns:  # non-empty = failed at least one gate
+            dropped.append({"ticker": tkr, "reason": "; ".join(rsns)})
+    # Excluded (no price): always show
+    excluded = result["excluded"]
+    for tkr, reason in excluded.items():
+        dropped.append({"ticker": tkr, "reason": reason})
+    return dropped
+
+
+def compare_tier_region_filters(
+    results_rows: list[dict],
+    harness_evaluate,
+) -> list[dict]:
+    """Compare universe quality across tier/region subsets via the referee.
+
+    Subsets compared:
+      - "full" — all rows
+      - "excl_micro_small" — rows where tier not in {micro, small}
+      - "region_us", "region_eu", "region_hk" — region-only slices
+
+    Each subset is evaluated with harness_evaluate (same signature as
+    trade_modules.validation.harness.evaluate).  Ranked by:
+      1. OOS alpha at T+30 (from the first material family with OOS computed),
+         or overall DSR if OOS not computed, or -999 sentinel.
+
+    Args:
+        results_rows: list of dicts from backtest_results.csv.
+        harness_evaluate: callable with signature (rows: list[dict]) -> dict.
+            Must return a dict with an "overall" key.
+
+    Returns:
+        Sorted list of dicts (best first), each with:
+            name, subset_desc, n_rows, score, rank, passed, verdict
+    """
+    subsets: list[tuple[str, str, list[dict]]] = [
+        ("full", "All rows (no tier/region filter)", results_rows),
+        (
+            "excl_micro_small",
+            "Excl. MICRO+SMALL tiers (large/mega/mid only)",
+            [r for r in results_rows if str(r.get("tier", "")).lower() not in ("micro", "small")],
+        ),
+        (
+            "region_us",
+            "US region only",
+            [r for r in results_rows if str(r.get("region", "")).lower() == "us"],
+        ),
+        (
+            "region_eu",
+            "EU region only",
+            [r for r in results_rows if str(r.get("region", "")).lower() == "eu"],
+        ),
+        (
+            "region_hk",
+            "HK region only",
+            [r for r in results_rows if str(r.get("region", "")).lower() == "hk"],
+        ),
+    ]
+
+    entries: list[dict] = []
+    for name, desc, rows in subsets:
+        verdict = harness_evaluate(rows)
+        overall = verdict.get("overall", {})
+        passed = overall.get("passed", False)
+
+        # Extract score: prefer OOS alpha from any material family at T+30,
+        # fallback to overall DSR, fallback to sentinel.
+        score = _extract_score(verdict)
+
+        entries.append(
+            {
+                "name": name,
+                "subset_desc": desc,
+                "n_rows": len(rows),
+                "score": score,
+                "passed": passed,
+                "verdict": overall,
+            }
+        )
+
+    # Sort descending by score (higher = better)
+    entries.sort(key=lambda e: e["score"], reverse=True)
+    for i, e in enumerate(entries, 1):
+        e["rank"] = i
+
+    return entries
+
+
+def _extract_score(verdict: dict) -> float:
+    """Extract a scalar quality score from a harness verdict dict.
+
+    Priority:
+      1. First material family's OOS alpha (T+30) when computed.
+      2. Overall pooled DSR.
+      3. Direct _subset_score (injected by fake harness in tests).
+      4. Sentinel -999.0 (no data / not computed).
+    """
+    # Injected by fake harness in tests
+    if "_subset_score" in verdict:
+        raw = verdict["_subset_score"]
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            pass
+
+    # OOS alpha from material families
+    families = verdict.get("families", {})
+    for _fam, fstats in families.items():
+        if fstats.get("insufficient_data"):
+            continue
+        oos = fstats.get("oos", {})
+        if oos.get("computed"):
+            oa = oos.get("oos_alpha")
+            if oa is not None:
+                try:
+                    return float(oa)
+                except (TypeError, ValueError):
+                    pass
+
+    # Fallback: pooled DSR
+    overall = verdict.get("overall", {})
+    dsr = overall.get("dsr")
+    if dsr is not None:
+        try:
+            return float(dsr)
+        except (TypeError, ValueError):
+            pass
+
+    return -999.0
+
+
+def _format_report(  # pragma: no cover
+    live_summary: dict,
+    gate_counts: dict,
+    dropped_names: list[dict],
+    price_only_sample: list[str],
+    tier_region_rankings: list[dict],
+    data_date: str,
+    n_total: int,
+    forward_gated_pass_rates: dict,
+) -> str:
+    """Format the markdown report."""
+    lines = [
+        "# S1 Universe Filter — Validation & Live Effect Report",
+        "",
+        f"**Data date:** {data_date}  **Total universe:** {n_total:,} instruments",
+        "",
+        "---",
+        "",
+        "## A) Live Filter Effect (today's universe)",
+        "",
+        "### Routing Summary",
+        "",
+        "| Category | Count | % of total |",
+        "|---|---|---|",
+        f"| Fundamental-eligible (all gates pass) | {live_summary['eligible']:,} | "
+        f"{live_summary['eligible'] / n_total * 100:.1f}% |",
+        f"| Fundamental-assessed (all fundamental rows) | {live_summary['fundamental_total']:,} | "
+        f"{live_summary['fundamental_total'] / n_total * 100:.1f}% |",
+        f"| Price-only (crypto/ETF/leveraged) | {live_summary['price_only']:,} | "
+        f"{live_summary['price_only'] / n_total * 100:.1f}% |",
+        f"| Excluded (no usable price) | {live_summary['excluded']:,} | "
+        f"{live_summary['excluded'] / n_total * 100:.1f}% |",
+        f"| Eligible % of fundamental assessed | {live_summary['eligible_pct']}% | — |",
+        "",
+        "### Per-Gate Drop Counts (fundamental rows only)",
+        "",
+        "| Gate | Names dropped |",
+        "|---|---|",
+        f"| Cap floor <$2B (min_cap) | {gate_counts['min_cap']:,} |",
+        f"| Analyst coverage <5 (min_analysts) | {gate_counts['min_analysts']:,} |",
+        f"| Negative/missing earnings (positive_earnings) | {gate_counts['positive_earnings']:,} |",
+        f"| Melting 52W <30 (trend) | {gate_counts['trend']:,} |",
+        "",
+        "> **Note on forward-gated gates:** analyst, earnings, and trend data are",
+        "> point-in-time and NOT preserved in `backtest_results.csv` historical rows.",
+        "> These gates are applied for correctness/prudence and accrue forward evidence,",
+        "> but are not presented as historically validated.",
+        "",
+        "### Forward-Gated Pass Rates (live, no OOS claim)",
+        "",
+        "| Gate | Pass rate (today) |",
+        "|---|---|",
+        f"| Min analysts ≥5 | {forward_gated_pass_rates.get('analysts_pass_pct', 'N/A')} |",
+        f"| Positive earnings (PET/PEF/FCF) | {forward_gated_pass_rates.get('earnings_pass_pct', 'N/A')} |",
+        f"| Not melting (52W ≥30) | {forward_gated_pass_rates.get('trend_pass_pct', 'N/A')} |",
+        "",
+    ]
+
+    # Dropped names (top 30 by first gate fail)
+    lines += [
+        "### Dropped Names (fundamental, sample — up to 30)",
+        "",
+        "| Ticker | Reason |",
+        "|---|---|",
+    ]
+    for d in dropped_names[:30]:
+        lines.append(f"| {d['ticker']} | {d['reason']} |")
+    if len(dropped_names) > 30:
+        lines.append(f"| … | (+{len(dropped_names) - 30} more) |")
+    lines.append("")
+
+    # Price-only sample
+    lines += [
+        "### Price-Only Routed (sample — up to 20)",
+        "",
+        ", ".join(price_only_sample[:20]),
+        "",
+        "---",
+        "",
+        "## B) Referee-Backed Validation — Tier/Region Filter Ranking",
+        "",
+        "> **Honest caveat:** only `tier` and `region` are present in",
+        "> `backtest_results.csv`. OOS evidence covers ONLY these dimensions.",
+        "> Analyst/earnings/trend gates are forward-gated (see § A above).",
+        f"> History: {n_total:,} rows across {len(tier_region_rankings)} subsets.",
+        "",
+        "| Rank | Subset | N rows | Score (OOS α or DSR) | PASS |",
+        "|---|---|---|---|---|",
+    ]
+    for e in tier_region_rankings:
+        score_str = f"{e['score']:.4f}" if e["score"] != -999.0 else "N/A (no data)"
+        passed_str = "✓" if e["passed"] else "✗"
+        lines.append(
+            f"| {e['rank']} | {e['subset_desc']} | {e['n_rows']:,} | {score_str} | {passed_str} |"
+        )
+
+    lines += [
+        "",
+        "> **Score definition:** OOS alpha at T+30 (first material family with OOS computed);",
+        "> fallback to pooled DSR; fallback to −999 (insufficient data).",
+        "> Short-history caveat: all S0 DSR/OOS estimates carry single-regime risk",
+        "> (~5 months of data, all bull market). Rankings are directional only.",
+        "",
+        "---",
+        "",
+        "## Interpretation",
+        "",
+        "- The live filter produces a **clean, routed universe** with explicit reasons",
+        "  for every pass/fail decision.",
+        "- The tier/region ranking shows which subsets the S0 referee scores best",
+        "  on historical alpha/OOS — but with the short-history caveat.",
+        "- Analyst/earnings/trend gates accrue evidence going forward.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main (pragma: no cover — all I/O)
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:  # pragma: no cover
+    """Load data, run filter, run referee comparison, write report."""
+    import csv
+    import subprocess
+    from pathlib import Path
+
+    import pandas as pd
+
+    from trade_modules.universe.filter import filter_universe
+    from trade_modules.validation.harness import evaluate as harness_evaluate
+
+    # ------------------------------------------------------------------
+    # Paths
+    # ------------------------------------------------------------------
+    repo_root = Path(__file__).parent.parent
+    etoro_csv = repo_root / "yahoofinance" / "output" / "etoro.csv"
+    backtest_csv = repo_root / "yahoofinance" / "output" / "backtest_results.csv"
+
+    # ------------------------------------------------------------------
+    # A) Live filter on etoro.csv
+    # ------------------------------------------------------------------
+    print(f"Loading {etoro_csv} …")
+    df = pd.read_csv(etoro_csv)
+    data_date_raw = (
+        subprocess.run(
+            ["git", "log", "-1", "--format=%cd", "--date=short", str(etoro_csv)],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        ).stdout.strip()
+        or "unknown"
+    )
+
+    result = filter_universe(df)
+    live_summary = summarize_filter_result(result)
+    gate_counts = aggregate_gate_counts(result)
+    dropped_names = aggregate_dropped_names(result)
+    price_only_sample = result["price_only"]
+
+    # Forward-gated pass rates (live, point-in-time)
+    fundamental_total = live_summary["fundamental_total"]
+
+    def _pct(n: int) -> str:
+        if fundamental_total == 0:
+            return "N/A"
+        return f"{n:,} / {fundamental_total:,} ({n / fundamental_total * 100:.1f}%)"
+
+    analysts_pass = fundamental_total - gate_counts["min_analysts"]
+    earnings_pass = fundamental_total - gate_counts["positive_earnings"]
+    trend_pass = fundamental_total - gate_counts["trend"]
+    forward_gated_pass_rates = {
+        "analysts_pass_pct": _pct(analysts_pass),
+        "earnings_pass_pct": _pct(earnings_pass),
+        "trend_pass_pct": _pct(trend_pass),
+    }
+
+    # ------------------------------------------------------------------
+    # B) Tier/region referee comparison
+    # ------------------------------------------------------------------
+    print(f"Loading {backtest_csv} …")
+    results_rows: list[dict] = []
+    with open(backtest_csv, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                row["horizon"] = int(float(row["horizon"]))
+            except (ValueError, KeyError):
+                pass
+            for key in ("alpha", "net_alpha", "future_price", "stock_return", "spy_return"):
+                try:
+                    row[key] = float(row[key]) if row.get(key) else None
+                except (ValueError, TypeError):
+                    row[key] = None
+            results_rows.append(row)
+
+    def _wrapped_evaluate(rows: list[dict]) -> dict:
+        """Wrap harness.evaluate with standard kwargs."""
+        if not rows:
+            return {"overall": {"passed": False, "dsr": None, "reasons": ["no rows"]}}
+        return harness_evaluate(rows, family_key="signal", min_obs=30)
+
+    print("Running referee comparison across tier/region subsets …")
+    rankings = compare_tier_region_filters(results_rows, _wrapped_evaluate)
+
+    # ------------------------------------------------------------------
+    # Format + write report
+    # ------------------------------------------------------------------
+    report_md = _format_report(
+        live_summary=live_summary,
+        gate_counts=gate_counts,
+        dropped_names=dropped_names,
+        price_only_sample=price_only_sample,
+        tier_region_rankings=rankings,
+        data_date=data_date_raw,
+        n_total=len(df),
+        forward_gated_pass_rates=forward_gated_pass_rates,
+    )
+
+    ts = subprocess.run(
+        ["date", "+%Y%m%d%H%M"],
+        capture_output=True,
+        text=True,
+        env={"TZ": "Europe/Athens", "PATH": "/bin:/usr/bin"},
+    ).stdout.strip()
+    out_path = Path.home() / "Downloads" / f"{ts}_universe_filter_report.md"
+    out_path.write_text(report_md, encoding="utf-8")
+    print(f"\nReport written to: {out_path}")
+
+    # Print summary to stdout
+    print("\n=== LIVE COUNTS ===")
+    print(f"  Fundamental-eligible: {live_summary['eligible']:,}")
+    print(f"  Fundamental-assessed: {live_summary['fundamental_total']:,}")
+    print(f"  Price-only:           {live_summary['price_only']:,}")
+    print(f"  Excluded:             {live_summary['excluded']:,}")
+    print("\n=== GATE DROPS ===")
+    for gate, count in gate_counts.items():
+        print(f"  {gate}: {count:,}")
+    print("\n=== TIER/REGION RANKING ===")
+    for e in rankings:
+        score_str = f"{e['score']:.4f}" if e["score"] != -999.0 else "N/A"
+        print(
+            f"  #{e['rank']} {e['name']:<20} n={e['n_rows']:>6,}  score={score_str}  passed={e['passed']}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/universe_filter_report.py
+++ b/scripts/universe_filter_report.py
@@ -187,7 +187,7 @@ def _extract_score(verdict: dict) -> float:
     return -999.0
 
 
-def _format_report(  # pragma: no cover
+def _format_report(
     live_summary: dict,
     gate_counts: dict,
     dropped_names: list[dict],
@@ -196,6 +196,7 @@ def _format_report(  # pragma: no cover
     data_date: str,
     n_total: int,
     forward_gated_pass_rates: dict,
+    results_rows: int = 0,
 ) -> str:
     """Format the markdown report."""
     lines = [
@@ -271,7 +272,7 @@ def _format_report(  # pragma: no cover
         "> **Honest caveat:** only `tier` and `region` are present in",
         "> `backtest_results.csv`. OOS evidence covers ONLY these dimensions.",
         "> Analyst/earnings/trend gates are forward-gated (see § A above).",
-        f"> History: {n_total:,} rows across {len(tier_region_rankings)} subsets.",
+        f"> History: {results_rows:,} rows across {len(tier_region_rankings)} subsets.",
         "",
         "| Rank | Subset | N rows | Score (OOS α or DSR) | PASS |",
         "|---|---|---|---|---|",
@@ -405,6 +406,7 @@ def main() -> None:  # pragma: no cover
         data_date=data_date_raw,
         n_total=len(df),
         forward_gated_pass_rates=forward_gated_pass_rates,
+        results_rows=len(results_rows),
     )
 
     ts = subprocess.run(

--- a/tests/unit/trade_modules/test_universe_filter.py
+++ b/tests/unit/trade_modules/test_universe_filter.py
@@ -59,28 +59,54 @@ class TestRouteAssetCrypto:
 
 
 class TestRouteAssetLeveraged:
+    """True leveraged/inverse ETPs have no analyst coverage AND no earnings data."""
+
     def test_ultra_in_name(self):
-        row = _row(TKR="UPRO", NAME="ProShares UltraPro S&P500", **{"#A": "--"})
+        row = _row(
+            TKR="UPRO",
+            NAME="ProShares UltraPro S&P500",
+            **{"#A": "--", "PET": "--", "PEF": "--", "FCF": "--"},
+        )
         assert route_asset(row) == "price_only"
 
     def test_inverse_in_name(self):
-        row = _row(TKR="SH", NAME="ProShares Inverse S&P500", **{"#A": "--"})
+        row = _row(
+            TKR="SH",
+            NAME="ProShares Inverse S&P500",
+            **{"#A": "--", "PET": "--", "PEF": "--", "FCF": "--"},
+        )
         assert route_asset(row) == "price_only"
 
     def test_2x_in_name(self):
-        row = _row(TKR="SSO", NAME="ProShares 2X S&P500", **{"#A": "--"})
+        row = _row(
+            TKR="SSO",
+            NAME="ProShares 2X S&P500",
+            **{"#A": "--", "PET": "--", "PEF": "--", "FCF": "--"},
+        )
         assert route_asset(row) == "price_only"
 
     def test_3x_in_name(self):
-        row = _row(TKR="TQQQ", NAME="ProShares 3X QQQ", **{"#A": "--"})
+        row = _row(
+            TKR="TQQQ",
+            NAME="ProShares 3X QQQ",
+            **{"#A": "--", "PET": "--", "PEF": "--", "FCF": "--"},
+        )
         assert route_asset(row) == "price_only"
 
     def test_leveraged_in_name(self):
-        row = _row(TKR="FNGU", NAME="MicroSectors Leveraged FANG ETN", **{"#A": "--"})
+        row = _row(
+            TKR="FNGU",
+            NAME="MicroSectors Leveraged FANG ETN",
+            **{"#A": "--", "PET": "--", "PEF": "--", "FCF": "--"},
+        )
         assert route_asset(row) == "price_only"
 
     def test_case_insensitive_ultra(self):
-        row = _row(TKR="X", NAME="ultra something fund", **{"#A": "--"})
+        row = _row(
+            TKR="X",
+            NAME="ultra something fund",
+            **{"#A": "--", "PET": "--", "PEF": "--", "FCF": "--"},
+        )
         assert route_asset(row) == "price_only"
 
 
@@ -346,10 +372,17 @@ class TestFilterUniversePositiveEarnings:
         reasons = result["reasons"]["LOSS"]
         assert any("negative earnings" in r.lower() for r in reasons)
 
-    def test_positive_pet_passes(self):
-        df = _make_df(_passing_row(TKR="PETOK", PET="20.0", PEF="-5.0", FCF="-2.0%"))
+    def test_positive_pet_passes_when_not_clear_loss_maker(self):
+        """PET positive, PEF negative but FCF positive → not a clear loss-maker → passes."""
+        df = _make_df(_passing_row(TKR="PETOK", PET="20.0", PEF="-5.0", FCF="2.0%"))
         result = filter_universe(df)
         assert "PETOK" in result["eligible"]["TKR"].values
+
+    def test_positive_pet_both_pef_and_fcf_negative_is_clear_loss_maker(self):
+        """PET positive, PEF<0 AND FCF<0 → clear loss-maker → fails gate (Fix 3)."""
+        df = _make_df(_passing_row(TKR="LOSERPET", PET="20.0", PEF="-5.0", FCF="-2.0%"))
+        result = filter_universe(df)
+        assert "LOSERPET" not in result["eligible"]["TKR"].values
 
     def test_positive_fcf_passes(self):
         df = _make_df(_passing_row(TKR="FCFOK", PET="-5.0", PEF="-5.0", FCF="3.0%"))
@@ -479,3 +512,194 @@ class TestFilterUniverseEdgeCases:
         df = _make_df(*rows)
         result = filter_universe(df)
         assert result["summary"]["gate_failures"]["min_cap"] == 3
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 REGRESSION — name-heuristic must not misroute real equities
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetLeveragedNameHeuristicGuard:
+    """Real operating companies with 'ULTRA'/'2X'/'3X' in their name must NOT
+    be routed to price_only when they have analyst coverage or earnings data."""
+
+    def test_vvx_ultra_name_with_analysts_is_fundamental(self):
+        """VVX — 'V2X, INC.' has 10 analysts and PET 26.6 → fundamental."""
+        row = {
+            "TKR": "VVX",
+            "NAME": "V2X, INC.",
+            "PRC": "30.0",
+            "CAP": "3B",
+            "#A": "10",
+            "PET": "26.6",
+            "PEF": "--",
+            "FCF": "--",
+            "52W": "55",
+        }
+        assert route_asset(row) == "fundamental"
+
+    def test_uctt_ultra_name_with_analysts_is_fundamental(self):
+        """UCTT — 'Ultra Clean Holdings' has 5 analysts → fundamental."""
+        row = {
+            "TKR": "UCTT",
+            "NAME": "Ultra Clean Holdings Inc",
+            "PRC": "25.0",
+            "CAP": "2.5B",
+            "#A": "5",
+            "PET": "--",
+            "PEF": "18.0",
+            "FCF": "3.5%",
+            "52W": "40",
+        }
+        assert route_asset(row) == "fundamental"
+
+    def test_rare_ultra_name_with_analysts_is_fundamental(self):
+        """RARE — 'Ultragenyx Pharmaceutical' has 20 analysts → fundamental."""
+        row = {
+            "TKR": "RARE",
+            "NAME": "Ultragenyx Pharmaceutical Inc",
+            "PRC": "50.0",
+            "CAP": "3.5B",
+            "#A": "20",
+            "PET": "--",
+            "PEF": "--",
+            "FCF": "1.2%",
+            "52W": "60",
+        }
+        assert route_asset(row) == "fundamental"
+
+    def test_ugp_ultra_name_with_analysts_is_fundamental(self):
+        """UGP — 'Ultrapar Participacoes' has 4 analysts → fundamental."""
+        row = {
+            "TKR": "UGP",
+            "NAME": "Ultrapar Participacoes S.A.",
+            "PRC": "5.0",
+            "CAP": "2.2B",
+            "#A": "4",
+            "PET": "12.0",
+            "PEF": "--",
+            "FCF": "--",
+            "52W": "48",
+        }
+        assert route_asset(row) == "fundamental"
+
+    def test_true_leveraged_etp_no_fundamentals_is_price_only(self):
+        """A genuine leveraged ETP with no analysts/earnings stays price_only."""
+        row = {
+            "TKR": "UPRO",
+            "NAME": "ProShares UltraPro 3X S&P500",
+            "PRC": "55.0",
+            "CAP": "5B",
+            "#A": "--",
+            "PET": "--",
+            "PEF": "--",
+            "FCF": "--",
+            "52W": "65",
+        }
+        assert route_asset(row) == "price_only"
+
+    def test_2x_name_with_earnings_is_fundamental(self):
+        """A real company whose name contains '2X' but has earnings → fundamental."""
+        row = {
+            "TKR": "VVX",
+            "NAME": "V2X, INC.",
+            "PRC": "30.0",
+            "CAP": "3B",
+            "#A": "--",
+            "PET": "26.6",
+            "PEF": "--",
+            "FCF": "--",
+            "52W": "55",
+        }
+        assert route_asset(row) == "fundamental"
+
+    def test_2x_name_no_fundamentals_is_price_only(self):
+        """'2X' in name with no analysts AND no earnings → price_only (true ETP)."""
+        row = {
+            "TKR": "SSO",
+            "NAME": "ProShares 2X S&P500",
+            "PRC": "80.0",
+            "CAP": "4B",
+            "#A": "--",
+            "PET": "--",
+            "PEF": "--",
+            "FCF": "--",
+            "52W": "70",
+        }
+        assert route_asset(row) == "price_only"
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 REGRESSION — 52W domain: values >100 must be fail-open
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseTrendDomainGuard:
+    """52W values outside [0, 100] are meaningless percentiles → fail-open."""
+
+    def test_52w_above_100_is_not_excluded_even_with_high_floor(self):
+        """52W = 10000 (raw data artefact, out-of-domain) → gate must NOT exclude,
+        even when min_52w is set high enough that it would catch a real value."""
+        # With min_52w=9999, a real value of 10000 would pass (10000 >= 9999),
+        # but the spec says out-of-domain (>100) must be fail-open regardless.
+        # Use default config (min_52w=30): 10000 > 100, so it must be treated as
+        # UNKNOWN and the gate must be fail-open (not excluded).
+        df = _make_df(_passing_row(TKR="BIGW", **{"52W": "10000"}))
+        result = filter_universe(df)
+        assert "BIGW" in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["BIGW"]
+        assert not any("melting" in r for r in reasons)
+
+    def test_52w_above_100_treated_as_unknown_fail_open(self):
+        """52W = 11333 (real data point observed) → UNKNOWN → fail-open.
+        Critically: even with min_52w=200 (absurd but shows the gate treats it as unknown)
+        the row must NOT be excluded."""
+        df = _make_df(_passing_row(TKR="OOD", **{"52W": "11333"}))
+        result = filter_universe(df, config={"min_52w": 200})
+        # If current code applies the gate naively: 11333 < 200 is False → passes anyway.
+        # After fix: 11333 > 100 → UNKNOWN → fail-open → passes.
+        # Both arrive at same result here; the distinguishing test is with min_52w < value.
+        # Real distinction: 50 < 10000 but 50 is a valid floor. Use min_52w=99.
+        df2 = _make_df(_passing_row(TKR="OOD2", **{"52W": "150"}))
+        result2 = filter_universe(df2, config={"min_52w": 99})
+        # 150 > 100 → out of domain → UNKNOWN → fail-open → must NOT be excluded
+        assert "OOD2" in result2["eligible"]["TKR"].values
+        reasons2 = result2["reasons"]["OOD2"]
+        assert not any("melting" in r for r in reasons2)
+
+    def test_52w_below_floor_within_domain_is_excluded(self):
+        """52W = 15 (valid percentile 0-100, below 30 floor) → excluded by trend gate."""
+        df = _make_df(_passing_row(TKR="LOWW", **{"52W": "15"}))
+        result = filter_universe(df)
+        assert "LOWW" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["LOWW"]
+        assert any("melting" in r for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 REGRESSION — positive-earnings gate: (PEF<0 AND FCF<0) → fail
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseEarningsClearLossMaker:
+    """Stale positive PET must not rescue a clear loss-maker (PEF<0 AND FCF<0)."""
+
+    def test_positive_pet_negative_pef_and_fcf_fails(self):
+        """{PET:20, PEF:-5, FCF:-3%} → excluded (clear loss-maker)."""
+        df = _make_df(_passing_row(TKR="LOSER", PET="20.0", PEF="-5.0", FCF="-3.0%"))
+        result = filter_universe(df)
+        assert "LOSER" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["LOSER"]
+        assert any("negative earnings" in r.lower() or "loss" in r.lower() for r in reasons)
+
+    def test_positive_pet_negative_pef_positive_fcf_passes(self):
+        """{PET:20, PEF:-5, FCF:+1%} → eligible (FCF positive saves it)."""
+        df = _make_df(_passing_row(TKR="FCFOK2", PET="20.0", PEF="-5.0", FCF="1.0%"))
+        result = filter_universe(df)
+        assert "FCFOK2" in result["eligible"]["TKR"].values
+
+    def test_positive_pet_and_pef_negative_fcf_passes(self):
+        """{PET:20, PEF:15, FCF:-1%} → eligible (PEF positive saves it)."""
+        df = _make_df(_passing_row(TKR="PEFOK", PET="20.0", PEF="15.0", FCF="-1.0%"))
+        result = filter_universe(df)
+        assert "PEFOK" in result["eligible"]["TKR"].values

--- a/tests/unit/trade_modules/test_universe_filter.py
+++ b/tests/unit/trade_modules/test_universe_filter.py
@@ -1,0 +1,481 @@
+"""Unit tests for trade_modules.universe.filter (S1 — Universe & Quality Filter).
+
+All tests are pure: no I/O, no network, no monkey-patching of external systems.
+"""
+
+import pandas as pd
+
+from trade_modules.universe.filter import filter_universe, route_asset
+
+# ---------------------------------------------------------------------------
+# Fixtures — canonical rows
+# ---------------------------------------------------------------------------
+
+
+def _equity_row(**overrides):
+    """A passing fundamental equity row (AAPL-like)."""
+    base = {
+        "TKR": "AAPL",
+        "NAME": "Apple Inc",
+        "CAP": "2.9T",
+        "PRC": "195.5",
+        "#A": "42",
+        "PET": "28.0",
+        "PEF": "25.0",
+        "FCF": "5.2%",
+        "52W": "72",
+        "BS": "B",
+    }
+    base.update(overrides)
+    return base
+
+
+def _row(**overrides):
+    return _equity_row(**overrides)
+
+
+# ---------------------------------------------------------------------------
+# route_asset — crypto
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetCrypto:
+    def test_btc_usd_price_only(self):
+        row = _row(TKR="BTC-USD", NAME="Bitcoin", PET="--", PEF="--", FCF="--", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_eth_usd_price_only(self):
+        row = _row(TKR="ETH-USD", NAME="Ethereum", PET="--", PEF="--", FCF="--", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_arbitrary_usd_suffix(self):
+        row = _row(TKR="SOL-USD", NAME="Solana", PET="", PEF="", FCF="", **{"#A": ""})
+        assert route_asset(row) == "price_only"
+
+
+# ---------------------------------------------------------------------------
+# route_asset — leveraged/inverse by name
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetLeveraged:
+    def test_ultra_in_name(self):
+        row = _row(TKR="UPRO", NAME="ProShares UltraPro S&P500", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_inverse_in_name(self):
+        row = _row(TKR="SH", NAME="ProShares Inverse S&P500", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_2x_in_name(self):
+        row = _row(TKR="SSO", NAME="ProShares 2X S&P500", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_3x_in_name(self):
+        row = _row(TKR="TQQQ", NAME="ProShares 3X QQQ", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_leveraged_in_name(self):
+        row = _row(TKR="FNGU", NAME="MicroSectors Leveraged FANG ETN", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_case_insensitive_ultra(self):
+        row = _row(TKR="X", NAME="ultra something fund", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+
+# ---------------------------------------------------------------------------
+# route_asset — known price-only tickers
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetKnownPriceOnly:
+    def test_uvxy(self):
+        row = _row(TKR="UVXY", NAME="ProShares Ultra VIX Short-Term Futures ETF", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_gld(self):
+        row = _row(TKR="GLD", NAME="SPDR Gold Shares", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+    def test_lyxgre(self):
+        row = _row(TKR="LYXGRE.DE", NAME="Lyxor Greece ETF", **{"#A": "--"})
+        assert route_asset(row) == "price_only"
+
+
+# ---------------------------------------------------------------------------
+# route_asset — plain ETF (no fundamentals)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetPlainETF:
+    def test_etf_no_fundamentals_price_only(self):
+        """Row with price but ALL fundamentals blank → price_only."""
+        row = {
+            "TKR": "XLK",
+            "NAME": "Technology Select Sector SPDR",
+            "PRC": "180.0",
+            "CAP": "50B",
+            "#A": "--",
+            "PET": "--",
+            "PEF": "",
+            "FCF": None,
+            "52W": "65",
+        }
+        assert route_asset(row) == "price_only"
+
+    def test_equity_with_analyst_count_is_fundamental(self):
+        """Row with #A present → fundamental even if PE missing."""
+        row = _row(PET="--", PEF="--", FCF="--")
+        assert route_asset(row) == "fundamental"
+
+
+# ---------------------------------------------------------------------------
+# route_asset — excluded (no usable price)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetExcluded:
+    def test_prc_missing(self):
+        row = _row(PRC=None)
+        assert route_asset(row) == "excluded"
+
+    def test_prc_blank(self):
+        row = _row(PRC="")
+        assert route_asset(row) == "excluded"
+
+    def test_prc_dash(self):
+        row = _row(PRC="--")
+        assert route_asset(row) == "excluded"
+
+    def test_prc_zero(self):
+        row = _row(PRC="0")
+        assert route_asset(row) == "excluded"
+
+    def test_prc_negative(self):
+        row = _row(PRC="-5.0")
+        assert route_asset(row) == "excluded"
+
+    def test_prc_non_numeric(self):
+        row = _row(PRC="N/A")
+        assert route_asset(row) == "excluded"
+
+
+# ---------------------------------------------------------------------------
+# route_asset — fundamental equity
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAssetFundamental:
+    def test_aapl_like_row(self):
+        row = _row()
+        assert route_asset(row) == "fundamental"
+
+    def test_equity_with_only_pet(self):
+        row = _row(PEF="--", FCF="--")
+        assert route_asset(row) == "fundamental"
+
+    def test_european_ticker(self):
+        row = _row(TKR="ASML.AS", NAME="ASML Holding")
+        assert route_asset(row) == "fundamental"
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_df(*rows):
+    return pd.DataFrame(list(rows))
+
+
+def _passing_row(**overrides):
+    """Row that passes all default gates."""
+    base = {
+        "TKR": "AAPL",
+        "NAME": "Apple Inc",
+        "CAP": "2.9T",
+        "PRC": "195.5",
+        "#A": "42",
+        "PET": "28.0",
+        "PEF": "25.0",
+        "FCF": "5.2%",
+        "52W": "72",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — eligible / price_only / excluded routing
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseRouting:
+    def test_passing_equity_in_eligible(self):
+        df = _make_df(_passing_row())
+        result = filter_universe(df)
+        assert "AAPL" in result["eligible"]["TKR"].values
+
+    def test_crypto_goes_to_price_only(self):
+        df = _make_df(
+            _passing_row(),
+            {
+                "TKR": "BTC-USD",
+                "NAME": "Bitcoin",
+                "PRC": "65000",
+                "CAP": "1.2T",
+                "#A": "--",
+                "PET": "--",
+                "PEF": "--",
+                "FCF": "--",
+                "52W": "60",
+            },
+        )
+        result = filter_universe(df)
+        assert "BTC-USD" in result["price_only"]
+        assert "BTC-USD" not in result["eligible"]["TKR"].values
+
+    def test_no_price_goes_to_excluded(self):
+        df = _make_df(_passing_row(TKR="NOPRC", PRC=None))
+        result = filter_universe(df)
+        assert "NOPRC" in result["excluded"]
+
+    def test_summary_counts_consistent(self):
+        df = _make_df(
+            _passing_row(TKR="E1"),
+            _passing_row(TKR="E2", PRC=None),
+            {
+                "TKR": "BTC-USD",
+                "NAME": "Bitcoin",
+                "PRC": "1000",
+                "CAP": "1T",
+                "#A": "",
+                "PET": "",
+                "PEF": "",
+                "FCF": "",
+                "52W": "",
+            },
+        )
+        r = filter_universe(df)
+        assert r["summary"]["total"] == 3
+        assert r["summary"]["excluded"] == 1
+        assert r["summary"]["price_only"] == 1
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — min_cap gate
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseMinCap:
+    def test_below_min_cap_fails(self):
+        df = _make_df(_passing_row(TKR="TINY", CAP="400M"))
+        result = filter_universe(df)
+        assert "TINY" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["TINY"]
+        assert any("cap" in r.lower() for r in reasons)
+
+    def test_above_min_cap_passes(self):
+        df = _make_df(_passing_row(TKR="BIG", CAP="5B"))
+        result = filter_universe(df)
+        assert "BIG" in result["eligible"]["TKR"].values
+
+    def test_config_override_min_cap(self):
+        """Raising the floor should drop a name that was previously eligible."""
+        df = _make_df(_passing_row(TKR="MID", CAP="3B"))
+        r_default = filter_universe(df)
+        r_strict = filter_universe(df, config={"min_cap": 5e9})
+        assert "MID" in r_default["eligible"]["TKR"].values
+        assert "MID" not in r_strict["eligible"]["TKR"].values
+
+    def test_blank_cap_fails(self):
+        df = _make_df(_passing_row(TKR="NOCAP", CAP="--"))
+        result = filter_universe(df)
+        assert "NOCAP" not in result["eligible"]["TKR"].values
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — min_analysts gate (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseMinAnalysts:
+    def test_too_few_analysts_fails(self):
+        df = _make_df(_passing_row(TKR="FEW", **{"#A": "3"}))
+        result = filter_universe(df)
+        assert "FEW" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["FEW"]
+        assert any("analysts 3 < 5" in r for r in reasons)
+
+    def test_exact_threshold_passes(self):
+        df = _make_df(_passing_row(TKR="EXACT", **{"#A": "5"}))
+        result = filter_universe(df)
+        assert "EXACT" in result["eligible"]["TKR"].values
+
+    def test_missing_analysts_fail_closed(self):
+        df = _make_df(_passing_row(TKR="NOANA", **{"#A": None}))
+        result = filter_universe(df)
+        assert "NOANA" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["NOANA"]
+        assert any("unknown" in r.lower() or "missing" in r.lower() for r in reasons)
+
+    def test_dash_analysts_fail_closed(self):
+        df = _make_df(_passing_row(TKR="DASHANA", **{"#A": "--"}))
+        result = filter_universe(df)
+        assert "DASHANA" not in result["eligible"]["TKR"].values
+
+    def test_config_override_min_analysts(self):
+        df = _make_df(_passing_row(TKR="FEW2", **{"#A": "3"}))
+        r_strict = filter_universe(df)
+        r_relaxed = filter_universe(df, config={"min_analysts": 3})
+        assert "FEW2" not in r_strict["eligible"]["TKR"].values
+        assert "FEW2" in r_relaxed["eligible"]["TKR"].values
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — positive_earnings gate (fail-closed when all missing)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniversePositiveEarnings:
+    def test_all_negative_earnings_fails(self):
+        df = _make_df(_passing_row(TKR="LOSS", PET="-5.0", PEF="-3.0", FCF="-1.0%"))
+        result = filter_universe(df)
+        assert "LOSS" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["LOSS"]
+        assert any("negative earnings" in r.lower() for r in reasons)
+
+    def test_positive_pet_passes(self):
+        df = _make_df(_passing_row(TKR="PETOK", PET="20.0", PEF="-5.0", FCF="-2.0%"))
+        result = filter_universe(df)
+        assert "PETOK" in result["eligible"]["TKR"].values
+
+    def test_positive_fcf_passes(self):
+        df = _make_df(_passing_row(TKR="FCFOK", PET="-5.0", PEF="-5.0", FCF="3.0%"))
+        result = filter_universe(df)
+        assert "FCFOK" in result["eligible"]["TKR"].values
+
+    def test_all_earnings_missing_fail_closed(self):
+        df = _make_df(_passing_row(TKR="NOMISSING", PET="--", PEF=None, FCF=""))
+        result = filter_universe(df)
+        assert "NOMISSING" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["NOMISSING"]
+        assert any("missing" in r.lower() for r in reasons)
+
+    def test_require_positive_earnings_false_skips_gate(self):
+        df = _make_df(_passing_row(TKR="NOGATE", PET="-5.0", PEF="-3.0", FCF="-1.0%"))
+        result = filter_universe(df, config={"require_positive_earnings": False})
+        assert "NOGATE" in result["eligible"]["TKR"].values
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — trend / 52W gate
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseTrend:
+    def test_melting_below_floor_fails(self):
+        df = _make_df(_passing_row(TKR="MELT", **{"52W": "18"}))
+        result = filter_universe(df)
+        assert "MELT" not in result["eligible"]["TKR"].values
+        reasons = result["reasons"]["MELT"]
+        assert any("melting" in r.lower() and "18" in r for r in reasons)
+
+    def test_exactly_at_floor_passes(self):
+        df = _make_df(_passing_row(TKR="ATFLOOR", **{"52W": "30"}))
+        result = filter_universe(df)
+        assert "ATFLOOR" in result["eligible"]["TKR"].values
+
+    def test_missing_52w_does_not_fail(self):
+        """Missing 52W → gate is left open (we don't penalise absence of trend data)."""
+        df = _make_df(_passing_row(TKR="NO52W", **{"52W": "--"}))
+        result = filter_universe(df)
+        assert "NO52W" in result["eligible"]["TKR"].values
+
+    def test_config_override_min_52w(self):
+        df = _make_df(_passing_row(TKR="LOW52", **{"52W": "35"}))
+        r_strict = filter_universe(df, config={"min_52w": 50})
+        r_relaxed = filter_universe(df, config={"min_52w": 30})
+        assert "LOW52" not in r_strict["eligible"]["TKR"].values
+        assert "LOW52" in r_relaxed["eligible"]["TKR"].values
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — reasons / human-readable messages
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseReasons:
+    def test_passing_row_has_empty_reasons(self):
+        df = _make_df(_passing_row())
+        result = filter_universe(df)
+        assert result["reasons"]["AAPL"] == []
+
+    def test_multiple_failures_all_listed(self):
+        """A row that fails both min_cap and min_analysts should list both reasons."""
+        df = _make_df(_passing_row(TKR="MULTI", CAP="400M", **{"#A": "2"}))
+        result = filter_universe(df)
+        reasons = result["reasons"]["MULTI"]
+        assert any("cap" in r.lower() for r in reasons)
+        assert any("analysts 2 < 5" in r for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — input not mutated
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseImmutability:
+    def test_input_df_not_mutated(self):
+        df = _make_df(_passing_row())
+        original_cols = list(df.columns)
+        original_values = df.copy()
+        filter_universe(df)
+        assert list(df.columns) == original_cols
+        pd.testing.assert_frame_equal(df, original_values)
+
+
+# ---------------------------------------------------------------------------
+# filter_universe — dash / blank / None robustness
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUniverseEdgeCases:
+    def test_all_dash_fields_fundamental_with_analyst(self):
+        """Row with #A present but PET/PEF/FCF all dashes — routed fundamental,
+        fails positive_earnings gate (all missing → fail-closed)."""
+        row = {
+            "TKR": "DASHROW",
+            "NAME": "Dash Company",
+            "CAP": "10B",
+            "PRC": "50.0",
+            "#A": "8",
+            "PET": "--",
+            "PEF": "--",
+            "FCF": "--",
+            "52W": "55",
+        }
+        df = _make_df(row)
+        result = filter_universe(df)
+        # routed to fundamental (has #A), fails earnings gate
+        assert "DASHROW" in result["reasons"]
+        assert "DASHROW" not in result["eligible"]["TKR"].values
+
+    def test_empty_dataframe_safe(self):
+        df = pd.DataFrame(columns=["TKR", "NAME", "CAP", "PRC", "#A", "PET", "PEF", "FCF", "52W"])
+        result = filter_universe(df)
+        assert len(result["eligible"]) == 0
+        assert result["price_only"] == []
+        assert result["excluded"] == {}
+
+    def test_garbage_cap_fails_gracefully(self):
+        df = _make_df(_passing_row(TKR="GCAP", CAP="xyz"))
+        result = filter_universe(df)
+        assert "GCAP" not in result["eligible"]["TKR"].values
+
+    def test_summary_gate_failures_counted(self):
+        rows = [_passing_row(TKR=f"F{i}", CAP="400M") for i in range(3)]
+        df = _make_df(*rows)
+        result = filter_universe(df)
+        assert result["summary"]["gate_failures"]["min_cap"] == 3

--- a/tests/unit/trade_modules/test_universe_filter_report.py
+++ b/tests/unit/trade_modules/test_universe_filter_report.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pandas as pd
 
 from scripts.universe_filter_report import (
+    _format_report,
     aggregate_dropped_names,
     aggregate_gate_counts,
     compare_tier_region_filters,
@@ -337,3 +338,67 @@ class TestCompareTierRegionFilters:
         # hk region has no rows
         rankings = compare_tier_region_filters(rows, _fake_harness)
         assert isinstance(rankings, list)
+
+
+# ---------------------------------------------------------------------------
+# FIX 4 REGRESSION — Section-B history caption uses results_rows count
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_filter_result() -> dict:
+    """Minimal synthetic filter result for _format_report tests."""
+    return _make_filter_result(
+        eligible_tickers=["AAPL"],
+        price_only=["BTC-USD"],
+        excluded={},
+        reasons={"AAPL": []},
+    )
+
+
+def _make_minimal_rankings() -> list[dict]:
+    """Minimal ranking list for _format_report tests."""
+    return [
+        {
+            "rank": 1,
+            "name": "full",
+            "subset_desc": "All rows",
+            "n_rows": 86368,
+            "score": 0.05,
+            "passed": True,
+            "verdict": {},
+        }
+    ]
+
+
+class TestFormatReportHistoryCaption:
+    """Section-B caption must use results_rows count, not n_total (etoro.csv length)."""
+
+    def test_section_b_uses_results_rows_not_n_total(self):
+        """_format_report Section B caption must display results_rows count (86,368),
+        NOT n_total (12,826 — etoro.csv row count)."""
+        live_summary = summarize_filter_result(_make_minimal_filter_result())
+        gate_counts = aggregate_gate_counts(_make_minimal_filter_result())
+        report = _format_report(
+            live_summary=live_summary,
+            gate_counts=gate_counts,
+            dropped_names=[],
+            price_only_sample=[],
+            tier_region_rankings=_make_minimal_rankings(),
+            data_date="2026-07-01",
+            n_total=12826,
+            results_rows=86368,
+            forward_gated_pass_rates={
+                "analysts_pass_pct": "N/A",
+                "earnings_pass_pct": "N/A",
+                "trend_pass_pct": "N/A",
+            },
+        )
+        # The Section B history caption must show results_rows count, not n_total
+        assert "86,368" in report or "86368" in report
+        # n_total only appears in Section A header, not the Section B history line
+        # Confirm the Section B caveat line specifically mentions results_rows
+        section_b_start = report.find("## B)")
+        assert section_b_start != -1
+        section_b = report[section_b_start:]
+        # The history caveat inside Section B must show 86,368 rows
+        assert "86,368" in section_b or "86368" in section_b

--- a/tests/unit/trade_modules/test_universe_filter_report.py
+++ b/tests/unit/trade_modules/test_universe_filter_report.py
@@ -1,0 +1,339 @@
+"""Unit tests for universe_filter_report.py — pure aggregation logic only.
+
+Tests cover:
+  A) Summary/aggregation helpers on synthetic filter_universe output.
+  B) compare_tier_region_filters — confirms a genuinely better tier subset ranks above
+     the worse subsets when injected with a deterministic fake harness_evaluate.
+
+All tests are pure: no I/O, no CSV reads, no filesystem access.
+pragma: no cover is applied only to IO/live code in the report script itself.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from scripts.universe_filter_report import (
+    aggregate_dropped_names,
+    aggregate_gate_counts,
+    compare_tier_region_filters,
+    summarize_filter_result,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic filter_universe output
+# ---------------------------------------------------------------------------
+
+
+def _make_eligible_df(*tickers: str) -> pd.DataFrame:
+    """Create a minimal eligible DataFrame with TKR and NAME columns."""
+    return pd.DataFrame({"TKR": list(tickers), "NAME": [f"Co {t}" for t in tickers]})
+
+
+def _make_filter_result(
+    eligible_tickers: list[str],
+    price_only: list[str],
+    excluded: dict[str, str],
+    reasons: dict[str, list[str]],
+) -> dict:
+    """Build a synthetic filter_universe result dict."""
+    eligible_df = _make_eligible_df(*eligible_tickers)
+    total = len(eligible_tickers) + len(price_only) + len(excluded) + len(reasons)
+    gate_counts = {
+        "min_cap": sum(1 for rs in reasons.values() if any("cap" in r for r in rs)),
+        "min_analysts": sum(1 for rs in reasons.values() if any("analysts" in r for r in rs)),
+        "positive_earnings": sum(
+            1 for rs in reasons.values() if any("negative earnings" in r for r in rs)
+        ),
+        "trend": sum(1 for rs in reasons.values() if any("melting" in r for r in rs)),
+    }
+    summary = {
+        "total": total,
+        "fundamental": len(reasons),
+        "eligible": len(eligible_tickers),
+        "price_only": len(price_only),
+        "excluded": len(excluded),
+        "gate_failures": gate_counts,
+    }
+    return {
+        "eligible": eligible_df,
+        "price_only": price_only,
+        "excluded": excluded,
+        "reasons": reasons,
+        "summary": summary,
+    }
+
+
+# ---------------------------------------------------------------------------
+# summarize_filter_result
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeFilterResult:
+    def test_basic_counts(self):
+        result = _make_filter_result(
+            eligible_tickers=["AAPL", "MSFT"],
+            price_only=["BTC-USD", "GLD"],
+            excluded={"BADPRC": "no usable price"},
+            reasons={
+                "AAPL": [],
+                "MSFT": [],
+                "TINY": ["cap $0.40B < $2B"],
+            },
+        )
+        summary = summarize_filter_result(result)
+        assert summary["eligible"] == 2
+        assert summary["price_only"] == 2
+        assert summary["excluded"] == 1
+        assert summary["fundamental_total"] == 3  # AAPL + MSFT + TINY
+
+    def test_zero_eligible(self):
+        result = _make_filter_result(
+            eligible_tickers=[],
+            price_only=["BTC-USD"],
+            excluded={},
+            reasons={"FAIL": ["cap $0.01B < $2B"]},
+        )
+        summary = summarize_filter_result(result)
+        assert summary["eligible"] == 0
+        assert summary["fundamental_total"] == 1
+
+    def test_eligible_pct_of_fundamental(self):
+        result = _make_filter_result(
+            eligible_tickers=["A", "B"],
+            price_only=[],
+            excluded={},
+            reasons={"A": [], "B": [], "C": ["cap $0.50B < $2B"]},
+        )
+        summary = summarize_filter_result(result)
+        # 2 eligible out of 3 fundamental rows = 66.7%
+        pct = summary["eligible_pct"]
+        assert 66 < pct < 68
+
+
+# ---------------------------------------------------------------------------
+# aggregate_gate_counts
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateGateCounts:
+    def test_counts_match_gate_failures(self):
+        reasons = {
+            "A": ["cap $0.40B < $2B"],
+            "B": ["analysts 2 < 5"],
+            "C": ["negative earnings (PET=-3.0, PEF=-2.0)"],
+            "D": ["melting: 52W 12 < 30"],
+            "E": ["cap $0.10B < $2B", "analysts 1 < 5"],
+        }
+        gate_failures = {
+            "min_cap": 2,
+            "min_analysts": 2,
+            "positive_earnings": 1,
+            "trend": 1,
+        }
+        result = _make_filter_result(
+            eligible_tickers=["OK"],
+            price_only=[],
+            excluded={},
+            reasons=reasons,
+        )
+        # Override with explicit counts to test the helper directly
+        result["summary"]["gate_failures"] = gate_failures
+        counts = aggregate_gate_counts(result)
+        assert counts["min_cap"] == 2
+        assert counts["min_analysts"] == 2
+        assert counts["positive_earnings"] == 1
+        assert counts["trend"] == 1
+
+    def test_zero_failures_returns_zeros(self):
+        result = _make_filter_result(
+            eligible_tickers=["AAPL"],
+            price_only=[],
+            excluded={},
+            reasons={"AAPL": []},
+        )
+        result["summary"]["gate_failures"] = {
+            "min_cap": 0,
+            "min_analysts": 0,
+            "positive_earnings": 0,
+            "trend": 0,
+        }
+        counts = aggregate_gate_counts(result)
+        assert all(v == 0 for v in counts.values())
+
+
+# ---------------------------------------------------------------------------
+# aggregate_dropped_names
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateDroppedNames:
+    def test_dropped_names_have_ticker_and_reason(self):
+        reasons = {
+            "AAPL": [],
+            "TINY": ["cap $0.30B < $2B"],
+            "NOANA": ["analysts unknown (missing) < 5"],
+        }
+        result = _make_filter_result(
+            eligible_tickers=["AAPL"],
+            price_only=[],
+            excluded={},
+            reasons=reasons,
+        )
+        dropped = aggregate_dropped_names(result)
+        tickers = [d["ticker"] for d in dropped]
+        assert "TINY" in tickers
+        assert "NOANA" in tickers
+        # Passing row (AAPL) must NOT be in the dropped list
+        assert "AAPL" not in tickers
+
+    def test_excluded_names_included(self):
+        result = _make_filter_result(
+            eligible_tickers=[],
+            price_only=[],
+            excluded={"BADPRC": "no usable price"},
+            reasons={},
+        )
+        dropped = aggregate_dropped_names(result)
+        tickers = [d["ticker"] for d in dropped]
+        assert "BADPRC" in tickers
+        assert any("no usable price" in d["reason"] for d in dropped if d["ticker"] == "BADPRC")
+
+    def test_empty_result_returns_empty_list(self):
+        result = _make_filter_result(
+            eligible_tickers=["AAPL"],
+            price_only=[],
+            excluded={},
+            reasons={"AAPL": []},
+        )
+        dropped = aggregate_dropped_names(result)
+        assert dropped == []
+
+    def test_price_only_not_in_dropped(self):
+        """Price-only assets (crypto, ETFs) are routed, not dropped — must not appear."""
+        result = _make_filter_result(
+            eligible_tickers=["AAPL"],
+            price_only=["BTC-USD", "GLD"],
+            excluded={},
+            reasons={"AAPL": []},
+        )
+        dropped = aggregate_dropped_names(result)
+        tickers = [d["ticker"] for d in dropped]
+        assert "BTC-USD" not in tickers
+        assert "GLD" not in tickers
+
+
+# ---------------------------------------------------------------------------
+# compare_tier_region_filters
+# ---------------------------------------------------------------------------
+
+
+def _make_backtest_rows(
+    tiers: list[str],
+    region: str = "us",
+    alpha_val: float = 0.05,
+    n_per_tier: int = 60,
+) -> list[dict]:
+    """Generate synthetic backtest rows with given tier labels and alpha value."""
+    import itertools
+
+    dates = [f"2026-0{(i // 10) + 1}-{(i % 10) + 1:02d}" for i in range(n_per_tier)]
+    rows = []
+    for i, (tier, date) in enumerate(itertools.product(tiers, dates[:n_per_tier])):
+        rows.append(
+            {
+                "ticker": f"T{i}",
+                "signal": "momentum",
+                "signal_date": date,
+                "tier": tier,
+                "region": region,
+                "horizon": 30,
+                "alpha": alpha_val,
+                "net_alpha": alpha_val - 0.005,
+                "future_price": 100.0,
+            }
+        )
+    return rows
+
+
+def _fake_harness(rows: list[dict]) -> dict:
+    """Deterministic fake harness that returns a score based on average net_alpha."""
+    if not rows:
+        return {"overall": {"passed": False, "dsr": None}, "_subset_score": -999.0}
+    alphas = [r.get("net_alpha", 0.0) for r in rows if r.get("net_alpha") is not None]
+    avg = sum(alphas) / len(alphas) if alphas else 0.0
+    passed = avg > 0
+    return {
+        "overall": {"passed": passed, "dsr": avg},
+        "_subset_score": avg,
+    }
+
+
+class TestCompareTierRegionFilters:
+    def test_better_tier_subset_ranks_higher(self):
+        """The large/mega subset has higher alpha → should rank above the full set
+        and the micro/small subset (which has near-zero alpha)."""
+        # Full set: mix of high alpha (large/mega) + low alpha (micro/small)
+        good_rows = _make_backtest_rows(["large", "mega"], alpha_val=0.08)
+        bad_rows = _make_backtest_rows(["micro", "small"], alpha_val=0.001)
+        all_rows = good_rows + bad_rows
+
+        rankings = compare_tier_region_filters(all_rows, _fake_harness)
+
+        # Check we get at least 3 entries: full, excl-micro-small, regions
+        assert len(rankings) >= 3
+
+        # Find the relevant subsets
+        names = [r["name"] for r in rankings]
+        assert any(
+            "large" in n.lower() or "excl" in n.lower() or "mega" in n.lower() for n in names
+        )
+
+        # The subset excluding micro/small should rank above the full set
+        excl_rank = next((r["rank"] for r in rankings if "excl" in r["name"].lower()), None)
+        full_rank = next((r["rank"] for r in rankings if r["name"] == "full"), None)
+        assert excl_rank is not None
+        assert full_rank is not None
+        assert excl_rank < full_rank  # lower rank number = better
+
+    def test_ranking_is_deterministic(self):
+        """Same input → same ranking on repeated calls."""
+        rows = _make_backtest_rows(["large", "mega", "mid", "small", "micro"], alpha_val=0.03)
+        r1 = compare_tier_region_filters(rows, _fake_harness)
+        r2 = compare_tier_region_filters(rows, _fake_harness)
+        assert [e["name"] for e in r1] == [e["name"] for e in r2]
+
+    def test_empty_rows_returns_results(self):
+        """Empty input doesn't crash; all subsets have no data."""
+        rankings = compare_tier_region_filters([], _fake_harness)
+        assert isinstance(rankings, list)
+        # All should have score of -999 or similar "no data" sentinel
+        for r in rankings:
+            assert "name" in r
+            assert "score" in r
+
+    def test_each_entry_has_required_fields(self):
+        rows = _make_backtest_rows(["large", "mid"], alpha_val=0.04)
+        rankings = compare_tier_region_filters(rows, _fake_harness)
+        required = {"name", "subset_desc", "n_rows", "score", "rank", "passed"}
+        for entry in rankings:
+            assert required.issubset(set(entry.keys())), (
+                f"Entry '{entry.get('name')}' missing fields: {required - set(entry.keys())}"
+            )
+
+    def test_regions_included_in_ranking(self):
+        """Each region should appear as its own subset."""
+        rows = _make_backtest_rows(["large"], region="us", alpha_val=0.06) + _make_backtest_rows(
+            ["large"], region="eu", alpha_val=0.02
+        )
+        rankings = compare_tier_region_filters(rows, _fake_harness)
+        names = [r["name"] for r in rankings]
+        assert any("us" in n.lower() for n in names)
+        assert any("eu" in n.lower() for n in names)
+
+    def test_subsets_with_zero_rows_dont_crash(self):
+        """If a region has zero rows, the harness sees an empty list — no crash."""
+        rows = _make_backtest_rows(["large"], region="us", alpha_val=0.05)
+        # hk region has no rows
+        rankings = compare_tier_region_filters(rows, _fake_harness)
+        assert isinstance(rankings, list)

--- a/trade_modules/universe/__init__.py
+++ b/trade_modules/universe/__init__.py
@@ -1,0 +1,5 @@
+"""Universe routing and quality-filter module (S1)."""
+
+from trade_modules.universe.filter import DEFAULT_CONFIG, filter_universe, route_asset
+
+__all__ = ["route_asset", "filter_universe", "DEFAULT_CONFIG"]

--- a/trade_modules/universe/filter.py
+++ b/trade_modules/universe/filter.py
@@ -1,0 +1,324 @@
+"""Universe routing and quality-filter module (S1).
+
+Pure functions — no I/O, no network.  All decisions are explicit and logged in
+the returned 'reasons' dict so every pass/fail can be audited downstream.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.analysis.tiers import _parse_market_cap
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Tickers that are price-only by definition (leveraged/inverse ETPs, plain ETFs
+# with no fundamental data, commodity vehicles, etc.)
+KNOWN_PRICE_ONLY: frozenset[str] = frozenset(
+    {
+        "UVXY",
+        "GLD",
+        "LYXGRE.DE",
+        "SH",
+        "SDS",
+        "QID",
+        "TQQQ",
+        "SQQQ",
+        "SPXU",
+        "SPXS",
+        "XIV",
+        "SVXY",
+        "VXX",
+        "VIXY",
+        "AGG",
+        "BND",
+        "TLT",
+        "IEF",
+        "SLV",
+        "IAU",
+        "USO",
+        "UNG",
+    }
+)
+
+# Name fragments that indicate leveraged/inverse ETPs (case-insensitive)
+_LEVERAGED_INVERSE_FRAGMENTS: tuple[str, ...] = (
+    "ULTRA",
+    "INVERSE",
+    "2X",
+    "3X",
+    "LEVERAGED",
+)
+
+DEFAULT_CONFIG: dict = {
+    "min_cap": 2e9,
+    "min_analysts": 5,
+    "require_positive_earnings": True,
+    "min_52w": 30,
+}
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_blank(value) -> bool:
+    """Return True when value is missing, '--', empty string, or NaN."""
+    if value is None:
+        return True
+    if isinstance(value, float) and pd.isna(value):
+        return True
+    return str(value).strip() in ("", "--", "nan", "NaN", "None")
+
+
+def _get(row, key, default=None):
+    """Safely retrieve a value from a dict-like or Series row."""
+    try:
+        val = row[key] if hasattr(row, "__getitem__") else getattr(row, key, default)
+        return default if _is_blank(val) else val
+    except (KeyError, AttributeError):
+        return default
+
+
+def _parse_fcf(fcf_str) -> float | None:
+    """Parse FCF% string like '4.0%' to float.  Returns None when unparseable."""
+    if _is_blank(fcf_str):
+        return None
+    s = str(fcf_str).strip().rstrip("%")
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _parse_pe(pe_val) -> float | None:
+    """Parse a P/E value; returns None when missing/blank/non-numeric."""
+    if _is_blank(pe_val):
+        return None
+    try:
+        v = float(str(pe_val).strip())
+        return None if pd.isna(v) else v
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_52w(val) -> float | None:
+    """Parse 52-week range position (0-100); returns None when missing."""
+    if _is_blank(val):
+        return None
+    try:
+        v = float(str(val).strip())
+        return None if pd.isna(v) else v
+    except (ValueError, TypeError):
+        return None
+
+
+def _has_any_fundamentals(row) -> bool:
+    """Return True when the row has at least one non-blank fundamental field."""
+    pet = _get(row, "PET")
+    pef = _get(row, "PEF")
+    fcf = _get(row, "FCF")
+    n_analysts = _get(row, "#A")
+    # Any of PET, PEF, FCF, #A present counts as "has fundamentals"
+    return any(v is not None for v in [pet, pef, fcf, n_analysts])
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def route_asset(row) -> str:
+    """Classify a single instrument row.
+
+    Returns
+    -------
+    str
+        'fundamental' | 'price_only' | 'excluded'
+    """
+    # ------------------------------------------------------------------ #
+    # 1. Excluded — no usable price
+    # ------------------------------------------------------------------ #
+    prc = _get(row, "PRC")
+    if prc is None:
+        return "excluded"
+    try:
+        prc_f = float(str(prc).strip())
+        if pd.isna(prc_f) or prc_f <= 0:
+            return "excluded"
+    except (ValueError, TypeError):
+        return "excluded"
+
+    # ------------------------------------------------------------------ #
+    # 2. Price-only — crypto
+    # ------------------------------------------------------------------ #
+    tkr = str(_get(row, "TKR", "")).strip()
+    if tkr.endswith("-USD"):
+        return "price_only"
+
+    # ------------------------------------------------------------------ #
+    # 3. Price-only — leveraged/inverse ETP by name
+    # ------------------------------------------------------------------ #
+    name = str(_get(row, "NAME", "")).strip().upper()
+    if any(frag in name for frag in _LEVERAGED_INVERSE_FRAGMENTS):
+        return "price_only"
+
+    # ------------------------------------------------------------------ #
+    # 4. Price-only — known ticker list
+    # ------------------------------------------------------------------ #
+    if tkr.upper() in KNOWN_PRICE_ONLY:
+        return "price_only"
+
+    # ------------------------------------------------------------------ #
+    # 5. Price-only — plain ETF / index (no fundamentals at all)
+    # ------------------------------------------------------------------ #
+    if not _has_any_fundamentals(row):
+        return "price_only"
+
+    # ------------------------------------------------------------------ #
+    # 6. Fundamental — single-name equity
+    # ------------------------------------------------------------------ #
+    return "fundamental"
+
+
+def filter_universe(df: pd.DataFrame, config: dict | None = None) -> dict:
+    """Route every row and apply quality gates to fundamental names.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        etoro.csv-shaped data.  Not mutated.
+    config : dict, optional
+        Override any key in DEFAULT_CONFIG.
+
+    Returns
+    -------
+    dict with keys:
+        eligible   : DataFrame — fundamental rows passing ALL gates
+        price_only : list of tickers
+        excluded   : {ticker: reason}
+        reasons    : {ticker: [reason_strings]}  (fundamental pass/fail log)
+        summary    : {counts and per-gate stats}
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    working = df.copy()
+
+    eligible_rows: list[int] = []
+    price_only: list[str] = []
+    excluded: dict[str, str] = {}
+    reasons: dict[str, list[str]] = {}
+
+    # per-gate failure counters
+    gate_counts: dict[str, int] = {
+        "min_cap": 0,
+        "min_analysts": 0,
+        "positive_earnings": 0,
+        "trend": 0,
+    }
+
+    for idx, row in working.iterrows():
+        tkr = str(row.get("TKR", idx) if hasattr(row, "get") else idx).strip()
+
+        route = route_asset(row)
+
+        if route == "excluded":
+            excluded[tkr] = "no usable price"
+            continue
+
+        if route == "price_only":
+            price_only.append(tkr)
+            continue
+
+        # ---- fundamental: apply quality gates ----
+        row_reasons: list[str] = []
+        passed = True
+
+        # Gate 1 — min_cap
+        cap_raw = _get(row, "CAP")
+        cap_val = _parse_market_cap(cap_raw) if cap_raw is not None else 0.0
+        if cap_val < cfg["min_cap"]:
+            row_reasons.append(f"cap ${cap_val / 1e9:.2f}B < ${cfg['min_cap'] / 1e9:.0f}B")
+            gate_counts["min_cap"] += 1
+            passed = False
+
+        # Gate 2 — min_analysts (fail-closed: blank/unparseable → FAIL)
+        n_a_raw = _get(row, "#A")
+        if n_a_raw is None:
+            row_reasons.append(f"analysts unknown (missing) < {cfg['min_analysts']}")
+            gate_counts["min_analysts"] += 1
+            passed = False
+        else:
+            try:
+                n_a = int(float(str(n_a_raw).strip()))
+                if n_a < cfg["min_analysts"]:
+                    row_reasons.append(f"analysts {n_a} < {cfg['min_analysts']}")
+                    gate_counts["min_analysts"] += 1
+                    passed = False
+            except (ValueError, TypeError):
+                row_reasons.append(
+                    f"analysts unknown (unparseable: {n_a_raw!r}) < {cfg['min_analysts']}"
+                )
+                gate_counts["min_analysts"] += 1
+                passed = False
+
+        # Gate 3 — positive_earnings (fail-closed: all three missing → FAIL)
+        if cfg.get("require_positive_earnings", True):
+            pet = _parse_pe(_get(row, "PET"))
+            pef = _parse_pe(_get(row, "PEF"))
+            fcf = _parse_fcf(_get(row, "FCF"))
+
+            all_missing = pet is None and pef is None and fcf is None
+            if all_missing:
+                row_reasons.append("negative earnings (all earnings fields missing)")
+                gate_counts["positive_earnings"] += 1
+                passed = False
+            else:
+                pet_ok = pet is not None and pet > 0
+                pef_ok = pef is not None and pef > 0
+                fcf_ok = fcf is not None and fcf > 0
+                if not (pet_ok or pef_ok or fcf_ok):
+                    parts = []
+                    if pet is not None:
+                        parts.append(f"PET={pet}")
+                    if pef is not None:
+                        parts.append(f"PEF={pef}")
+                    if fcf is not None:
+                        parts.append(f"FCF={fcf}%")
+                    row_reasons.append(
+                        f"negative earnings ({', '.join(parts) if parts else 'all ≤0'})"
+                    )
+                    gate_counts["positive_earnings"] += 1
+                    passed = False
+
+        # Gate 4 — trend / 52W (missing → leave open; only fail if present and below floor)
+        w52_raw = _get(row, "52W")
+        w52 = _parse_52w(w52_raw)
+        if w52 is not None and w52 < cfg["min_52w"]:
+            row_reasons.append(f"melting: 52W {w52:.0f} < {cfg['min_52w']}")
+            gate_counts["trend"] += 1
+            passed = False
+
+        reasons[tkr] = row_reasons
+        if passed:
+            eligible_rows.append(idx)
+
+    eligible_df = working.loc[eligible_rows].copy() if eligible_rows else working.iloc[0:0].copy()
+
+    summary = {
+        "total": len(working),
+        "fundamental": len(reasons),
+        "eligible": len(eligible_rows),
+        "price_only": len(price_only),
+        "excluded": len(excluded),
+        "gate_failures": gate_counts,
+    }
+
+    return {
+        "eligible": eligible_df,
+        "price_only": price_only,
+        "excluded": excluded,
+        "reasons": reasons,
+        "summary": summary,
+    }

--- a/trade_modules/universe/filter.py
+++ b/trade_modules/universe/filter.py
@@ -160,10 +160,22 @@ def route_asset(row) -> str:
 
     # ------------------------------------------------------------------ #
     # 3. Price-only — leveraged/inverse ETP by name
+    #    Guard: only fire when the row has NO fundamentals (no analyst
+    #    coverage AND no earnings data).  A real operating company whose
+    #    name happens to contain "ULTRA"/"2X"/etc. must not be misrouted.
     # ------------------------------------------------------------------ #
     name = str(_get(row, "NAME", "")).strip().upper()
     if any(frag in name for frag in _LEVERAGED_INVERSE_FRAGMENTS):
-        return "price_only"
+        # Real companies have analyst coverage OR at least one earnings figure.
+        # Only route to price_only if the row truly has no fundamentals.
+        n_analysts = _get(row, "#A")
+        pet_raw = _get(row, "PET")
+        pef_raw = _get(row, "PEF")
+        fcf_raw = _get(row, "FCF")
+        has_analysts = n_analysts is not None
+        has_earnings = any(v is not None for v in [pet_raw, pef_raw, fcf_raw])
+        if not has_analysts and not has_earnings:
+            return "price_only"
 
     # ------------------------------------------------------------------ #
     # 4. Price-only — known ticker list
@@ -263,7 +275,12 @@ def filter_universe(df: pd.DataFrame, config: dict | None = None) -> dict:
                 gate_counts["min_analysts"] += 1
                 passed = False
 
-        # Gate 3 — positive_earnings (fail-closed: all three missing → FAIL)
+        # Gate 3 — positive_earnings
+        # Fail-closed when all three fields are missing.
+        # Clear loss-maker override: if BOTH forward P/E (PEF) AND FCF are
+        # negative the company is a clear loss-maker regardless of a stale
+        # positive trailing P/E (PET) — fail the gate.
+        # Otherwise pass if ANY of {PET>0, PEF>0, FCF>0}.
         if cfg.get("require_positive_earnings", True):
             pet = _parse_pe(_get(row, "PET"))
             pef = _parse_pe(_get(row, "PEF"))
@@ -275,10 +292,11 @@ def filter_universe(df: pd.DataFrame, config: dict | None = None) -> dict:
                 gate_counts["positive_earnings"] += 1
                 passed = False
             else:
-                pet_ok = pet is not None and pet > 0
-                pef_ok = pef is not None and pef > 0
-                fcf_ok = fcf is not None and fcf > 0
-                if not (pet_ok or pef_ok or fcf_ok):
+                pef_negative = pef is not None and pef < 0
+                fcf_negative = fcf is not None and fcf < 0
+                clear_loss_maker = pef_negative and fcf_negative
+
+                if clear_loss_maker:
                     parts = []
                     if pet is not None:
                         parts.append(f"PET={pet}")
@@ -286,16 +304,34 @@ def filter_universe(df: pd.DataFrame, config: dict | None = None) -> dict:
                         parts.append(f"PEF={pef}")
                     if fcf is not None:
                         parts.append(f"FCF={fcf}%")
-                    row_reasons.append(
-                        f"negative earnings ({', '.join(parts) if parts else 'all ≤0'})"
-                    )
+                    row_reasons.append(f"negative earnings — clear loss-maker ({', '.join(parts)})")
                     gate_counts["positive_earnings"] += 1
                     passed = False
+                else:
+                    pet_ok = pet is not None and pet > 0
+                    pef_ok = pef is not None and pef > 0
+                    fcf_ok = fcf is not None and fcf > 0
+                    if not (pet_ok or pef_ok or fcf_ok):
+                        parts = []
+                        if pet is not None:
+                            parts.append(f"PET={pet}")
+                        if pef is not None:
+                            parts.append(f"PEF={pef}")
+                        if fcf is not None:
+                            parts.append(f"FCF={fcf}%")
+                        row_reasons.append(
+                            f"negative earnings ({', '.join(parts) if parts else 'all ≤0'})"
+                        )
+                        gate_counts["positive_earnings"] += 1
+                        passed = False
 
-        # Gate 4 — trend / 52W (missing → leave open; only fail if present and below floor)
+        # Gate 4 — trend / 52W
+        # Fail-open when: missing, OR value is outside the valid [0, 100] domain
+        # (values >100 appear in raw data as artefacts and are meaningless as
+        # percentiles).  Only apply the melting exclusion when 0 <= w52 <= 100.
         w52_raw = _get(row, "52W")
         w52 = _parse_52w(w52_raw)
-        if w52 is not None and w52 < cfg["min_52w"]:
+        if w52 is not None and 0.0 <= w52 <= 100.0 and w52 < cfg["min_52w"]:
             row_reasons.append(f"melting: 52W {w52:.0f} < {cfg['min_52w']}")
             gate_counts["trend"] += 1
             passed = False


### PR DESCRIPTION
Stage 1 of Trading System v2. **Stacked on #105 (S0)** — retarget to master after #105 merges.

Turns the 12.8K raw instruments into a clean, correctly-routed investable universe.
- `trade_modules/universe/filter.py`: `route_asset` (crypto/ETF/leveraged → **price-only sleeve** — this is how ETH is handled) + `filter_universe` (gates: cap≥2e9, analysts≥5, positive-earnings, 52W not-melting; fail-CLOSED on missing analyst/earnings; every decision logged with a reason).
- `scripts/universe_filter_report.py`: live effect + a **referee-backed** tier/region comparison via the S0 harness (honest: analyst/earnings/trend gates are labeled forward-gated, not historically validated).

**Findings:** live filter → 2,420 fundamental-eligible / 707 price-only / 2,067 excluded. Referee (T+30): excluding micro/small is best OOS; EU ~zero alpha; all FAIL DSR (short history — expected).

**Opus review → fixed:** CRITICAL name-heuristic misroute (VVX "V2X"/Ultra* real equities were silently ejected) — the leveraged-name rule now only fires when a row has NO fundamentals; +52W domain sanitization; +stronger loss-maker earnings gate. 82 tests (15 new regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)