### PR TITLE
fix(pipeline-v2): argparse help breaks on Python 3.14

### DIFF
--- a/scripts/trading_pipeline_v2.py
+++ b/scripts/trading_pipeline_v2.py
@@ -182,7 +182,7 @@ def main() -> None:  # pragma: no cover
         "--cash-pct",
         type=float,
         default=None,
-        help="Override cash % (e.g. 0.20 = 20%%). Auto-derived from portfolio if omitted.",
+        help="Override cash fraction, e.g. 0.20 for 20 percent; auto-derived from portfolio if omitted.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
One-line fix: the VPS runs Python 3.14 whose argparse rejects a bare % in a help string. Reword the --cash-pct help. Unblocks the v2 pipeline on VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)