### PR TITLE
fix(signals-v2): fp guard in exit_bucket_alpha — unblock CI

### DIFF
--- a/scripts/signals_v2_validate.py
+++ b/scripts/signals_v2_validate.py
@@ -208,7 +208,10 @@ def exit_bucket_alpha(rows: list[dict]) -> dict:
         }
 
     exit_mean = float(sum(exit_alphas) / len(exit_alphas))
-    exit_justified = exit_mean < universe_mean
+    # Strict underperformance with a floating-point guard: means that are equal
+    # up to fp rounding (e.g. identical alphas summed over EXIT vs the larger
+    # universe) are NOT an edge → not justified.
+    exit_justified = exit_mean < universe_mean - 1e-12
 
     return {
         "exit_mean_alpha": exit_mean,


### PR DESCRIPTION
## Root-cause CI fix — unblocks Dependabot security updates

etorotrade CI has been red, which (via branch protection) blocked **all** Dependabot security-update PRs from auto-merging — letting alerts pile up (joserfc HIGH, pydantic-settings, etc.).

**Sole failing test:** `TestExitBucketAlpha::test_exit_equal_to_universe_justified_false` (`assert True is False`).

`exit_bucket_alpha` computes `exit_mean` (sum over EXIT rows, n=20) and `universe_mean` (sum over all rows, n=60). With identical alphas the two float sums differ by ~1 ULP, so strict `exit_mean < universe_mean` returned True for conceptually-equal means. Fix: a `1e-12` guard so equal-up-to-fp-rounding is treated as **no edge (not justified)** — matching the documented semantics and the test.

Once green + merged, the Dependabot security PRs (#111 joserfc→1.6.8 HIGH, #112 prod group incl pydantic-settings→2.14.2, #102 dev group) rebase & auto-merge. `nltk` alerts dismissed separately (no patched release exists yet).

17/17 tests in `test_signals_v2_validate.py` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)