### PR TITLE
fix(deps+ci): pydantic-settings 2.14.2, codeql 4.36.3 (unsplit), relock joserfc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Group all GitHub Actions bumps into a single PR. codeql-action/init and
+    # codeql-action/analyze are pinned to the same SHA and MUST move together;
+    # separate PRs leave the steps on different versions and fail the analyze job.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4

--- a/poetry.lock
+++ b/poetry.lock
@@ -4233,14 +4233,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]

--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -1025,9 +1025,9 @@ jinja2==3.1.6 ; python_version >= "3.10" and python_version < "4.0" \
 joblib==1.5.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713 \
     --hash=sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3
-joserfc==1.6.8 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:22fb31a69094a5e6f44632002a9df2c30c941fc6c8ce1b037e92c03de954cf9f \
-    --hash=sha256:878620c553a6ebdd76ccdc356782fee3f735f21a356d079a546b42a4670ace5f
+joserfc==1.6.5 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48 \
+    --hash=sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e
 kiwisolver==1.5.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9 \
     --hash=sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679 \
@@ -2360,9 +2360,9 @@ pydantic-core==2.46.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
-pydantic-settings==2.14.1 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de \
-    --hash=sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+pydantic-settings==2.14.2 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
 pydantic==2.13.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba \
     --hash=sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1789,9 +1789,9 @@ pydantic-core==2.46.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
-pydantic-settings==2.14.1 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de \
-    --hash=sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+pydantic-settings==2.14.2 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
 pydantic==2.13.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba \
     --hash=sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6

--- a/requirements-smoketest-lock.txt
+++ b/requirements-smoketest-lock.txt
@@ -1795,9 +1795,9 @@ pydantic-core==2.46.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
-pydantic-settings==2.14.1 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de \
-    --hash=sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+pydantic-settings==2.14.2 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
 pydantic==2.13.4 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba \
     --hash=sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6


### PR DESCRIPTION
## What
- **pydantic-settings 2.14.1 → 2.14.2** — clears the 4 remaining open Dependabot alerts (#58–#61, GHSA-4xgf-cpjx-pc3j: `NestedSecretsSettingsSource` symlink escape) across `poetry.lock` + all three requirements exports. `pydantic` stays 2.13.4 (respects the `<2.14` cap).
- **codeql-action `init` + `analyze` → 4.36.3** in one commit (`54f647b`). Dependabot split the bump into #121/#122; each alone leaves the two steps on different SHAs and fails the `analyze` job with a version-mismatch. **Supersedes #121 and #122.**
- **`dependabot.yml`** — group all github-actions bumps into a single PR so codeql's `init`+`analyze` can never split again.
- **Relock joserfc** — re-exporting from `poetry.lock` aligned the stale `requirements-dev-lock.txt` joserfc pin (1.6.8) to the resolver's actual 1.6.5. This **fixes master's currently-red `lockfile sync` job** (drift introduced upstream). joserfc is transitive, has no open alert, and 1.6.5 is what `poetry export` produces.

## Why now
The 3 original security PRs (#111 / #112 / #102) already merged. These were the leftovers: 4 residual alerts, 2 stuck codeql PRs, and a red `lockfile sync` on master.

## Verification
- [ ] CI green (test 3.10–3.12, `lockfile sync`, quality-gates, `analyze`)
- After merge: Dependabot auto-closes #121/#122; alerts #58–#61 clear → **0 open alerts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)