### PR TITLE
fix(deps): joserfc security floor >=1.6.7 (clears GHSA-wphv-vfrh-23q5)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1876,15 +1876,15 @@ files = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.5"
+version = "1.7.2"
 description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"dev\""
 files = [
-    {file = "joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e"},
-    {file = "joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48"},
+    {file = "joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5"},
+    {file = "joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947"},
 ]
 
 [package.dependencies]
@@ -6214,11 +6214,11 @@ nospam = ["requests_cache (>=1.0)", "requests_ratelimiter (>=0.3.1)"]
 repair = ["scipy (>=1.6.3)"]
 
 [extras]
-dev = ["autoflake", "bandit", "black", "cryptography", "detect-secrets", "flake8", "isort", "mypy", "pytest", "pytest-asyncio", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "radon", "safety", "types-PyYAML", "types-requests", "types-setuptools", "types-tabulate"]
+dev = ["autoflake", "bandit", "black", "cryptography", "detect-secrets", "flake8", "isort", "joserfc", "mypy", "pytest", "pytest-asyncio", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "radon", "safety", "types-PyYAML", "types-requests", "types-setuptools", "types-tabulate"]
 ml = ["scikit-learn", "torch", "transformers"]
 smoketest = ["pytest", "pytest-rerunfailures"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "a1b12780253373c9b688cca60f7cfbcdb2f483c05d53f8cde6330435555c703f"
+content-hash = "8a849b3b72f5fa0649d65f14d7676d10e2cbbb4eec9872dec3ac851faf8f6ece"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ dev = [
     # GHSA: cryptography <48.0.1 vuln, pulled transitively via safety->authlib/joserfc.
     # Pin the security floor here (dev-only, not in the runtime path) to force the patched build.
     "cryptography>=48.0.1",
+    # GHSA-wphv-vfrh-23q5: joserfc <1.6.7 JWS payload-size-limit bypass. Same transitive
+    # chain (safety->authlib->joserfc); direct floor so the resolver keeps it patched.
+    "joserfc>=1.6.7",
     "bandit>=1.9.4",
     "radon>=6.0.1",
     "autoflake>=2.3.3",

--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -1025,9 +1025,9 @@ jinja2==3.1.6 ; python_version >= "3.10" and python_version < "4.0" \
 joblib==1.5.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713 \
     --hash=sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3
-joserfc==1.6.5 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48 \
-    --hash=sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e
+joserfc==1.7.2 ; python_version >= "3.10" and python_version < "4.0" \
+    --hash=sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947 \
+    --hash=sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5
 kiwisolver==1.5.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9 \
     --hash=sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679 \


### PR DESCRIPTION
## What
Add a direct dev-only security floor **`joserfc>=1.6.7`** to `pyproject.toml`. poetry now resolves **joserfc 1.7.2** (patched); `requirements-dev-lock.txt` follows. Only joserfc changes in `poetry.lock`.

## Why
joserfc is transitive (`safety → authlib → joserfc`), and authlib only requires `>=1.6.0` — so poetry's resolver kept the vulnerable **1.6.5** and reverted every Dependabot direct-bump (the "doomed transitive bumps" documented in `dependabot.yml`). PR #123 aligned the exports down to poetry.lock's 1.6.5, which correctly **surfaced 4 previously-masked alerts** (#62–#65, **GHSA-wphv-vfrh-23q5**: JWS payload-size-limit bypass, medium).

This mirrors the existing `cryptography>=48.0.1` floor for the *same* transitive chain — a direct pin is the only thing that survives future relocks.

## Impact
- Dev tooling only (safety scanner); runtime path unaffected.
- On merge: Dependabot re-scans → alerts #62–#65 clear → **0 open alerts**.

## Verification
- [ ] CI green (test 3.10–3.12, `lockfile sync`, `analyze`, quality-gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)