### PR TITLE
Trading Model v3 Phase 5: hard risk gate, conditioning dials, PM actions, wired report, forward-IC logger

### DIFF
--- a/scripts/v3_full_report.py
+++ b/scripts/v3_full_report.py
@@ -1,0 +1,398 @@
+# scripts/v3_full_report.py
+"""Trading Model v3 — FULLY-WIRED report driver (Phase 5D).
+
+Runs the full v3 pipeline (universe -> features -> scores -> deployment ->
+build_portfolio -> build_actions) and renders the complete HTML via
+``trade_modules.v3.report.render_report`` with the executive / risk panel and the
+decision-support Suggested Actions section wired ABOVE the existing factor cards.
+Writes ``~/Downloads/<UTCstamp>_v3_full_report.html`` (UTC ``%Y%m%d%H%M``).
+
+Live account (optional): a JSON at ``$V3_ACCOUNT_JSON`` or
+``~/Downloads/v3_live_account.json`` with schema::
+
+    {"nav": <float|null>, "weights": {"<ticker>": <fraction 0..1>, ...}}
+
+supplies REAL current weights + NAV for the action diff (delta$ shown when nav
+is present). When it is absent, current weights fall back to an equal split
+across held tickers and the report carries a clear "approximate" note.
+
+Also emits a network-free synthetic preview to
+``~/Downloads/v3_full_report_preview.html`` (structurally self-checked) so a
+reviewer can screenshot the layout without running the live pipeline.
+
+Run (VPS / network allowed):   .venv/bin/python scripts/v3_full_report.py
+Preview only (no network):     .venv/bin/python scripts/v3_full_report.py --preview
+
+Does NOT modify or import from the network path of v3_portfolio.py / v3_report.py
+beyond reusing the pure ``trend_regime`` helper.  No module-level
+``yahoofinance.core.config`` import.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.v3_portfolio import trend_regime  # noqa: E402  (pure, unit-tested)
+from trade_modules.v3.actions import build_actions  # noqa: E402
+from trade_modules.v3.combine import compute_scores  # noqa: E402
+from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
+from trade_modules.v3.construct import build_portfolio  # noqa: E402
+from trade_modules.v3.features import enrich_features  # noqa: E402
+from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
+from trade_modules.v3.report import compute_regime, render_report  # noqa: E402
+
+PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
+BUY_CSV = "yahoofinance/output/buy.csv"
+ETORO_CSV = "yahoofinance/output/etoro.csv"
+
+DEFAULT_ACCOUNT_JSON = "~/Downloads/v3_live_account.json"
+PREVIEW_OUT = "~/Downloads/v3_full_report_preview.html"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested with synthetic data / temp files)
+# ---------------------------------------------------------------------------
+
+
+def load_account_json(path: str | None = None) -> tuple[pd.Series, float | None, bool]:
+    """Load live-account current weights + NAV.
+
+    Resolution order: explicit ``path`` arg -> ``$V3_ACCOUNT_JSON`` ->
+    ``~/Downloads/v3_live_account.json``.  Schema::
+
+        {"nav": <float|null>, "weights": {"<ticker>": <fraction 0..1>, ...}}
+
+    Args:
+        path: Optional explicit path (takes precedence over the env var).
+
+    Returns:
+        ``(weights, nav, present)``:
+        - ``weights``: ``pd.Series`` of fractions indexed by ticker (empty when
+          the file is absent / unreadable / has no ``weights``).
+        - ``nav``: ``float`` NAV, or ``None`` when null / missing.
+        - ``present``: ``True`` only when a JSON file was found AND parsed.
+    """
+    # An explicit path is authoritative (no env/default fallback); only when no
+    # path is passed do we consult $V3_ACCOUNT_JSON then the default location.
+    if path is not None:
+        candidates = [path]
+    else:
+        candidates = [os.environ.get("V3_ACCOUNT_JSON"), DEFAULT_ACCOUNT_JSON]
+    chosen = next(
+        (os.path.expanduser(p) for p in candidates if p and os.path.exists(os.path.expanduser(p))),
+        None,
+    )
+    if not chosen:
+        return pd.Series(dtype=float), None, False
+
+    try:
+        with open(chosen, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:  # unreadable / malformed JSON
+        print(f"warn: could not read account JSON {chosen}: {exc}", file=sys.stderr)
+        return pd.Series(dtype=float), None, False
+
+    raw_w = data.get("weights") or {}
+    try:
+        weights = pd.Series({str(k): float(v) for k, v in raw_w.items()}, dtype=float)
+    except (TypeError, ValueError) as exc:
+        print(f"warn: bad weights in account JSON {chosen}: {exc}", file=sys.stderr)
+        weights = pd.Series(dtype=float)
+
+    nav_raw = data.get("nav")
+    nav = float(nav_raw) if nav_raw is not None else None
+    return weights, nav, True
+
+
+def resolve_current_weights(
+    port_tickers: list[str], account_weights: pd.Series, account_present: bool
+) -> tuple[pd.Series, bool]:
+    """Resolve the current-weights vector used for the action diff.
+
+    When a live account file supplied non-empty weights, those are used verbatim
+    (exact holdings).  Otherwise the current book is approximated as an EQUAL
+    SPLIT across the (deduped) portfolio tickers and the ``approx`` flag is set so
+    the report can warn that current weights are indicative.
+
+    Args:
+        port_tickers: Tickers held per portfolio.csv (order preserved).
+        account_weights: Weights parsed from the live account JSON.
+        account_present: Whether a live account JSON was found + parsed.
+
+    Returns:
+        ``(current_weights, approx)`` where ``approx`` is ``True`` when the
+        equal-split fallback was used.
+    """
+    if account_present and not account_weights.empty:
+        return account_weights, False
+    tickers = list(dict.fromkeys(str(t) for t in port_tickers))
+    if not tickers:
+        return pd.Series(dtype=float), True
+    eq = 1.0 / len(tickers)
+    return pd.Series(eq, index=tickers, dtype=float), True
+
+
+def _read_tickers(path: str) -> list[str]:
+    try:
+        df = pd.read_csv(path, na_values=["--"])
+        return df["TKR"].dropna().astype(str).tolist()
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: could not read {path}: {exc}", file=sys.stderr)
+        return []
+
+
+def _system_read(scores: pd.DataFrame, regime: str) -> str:
+    """One-sentence standfirst: portfolio ADD/TRIM + candidate buy-watch counts."""
+    port = scores[scores.get("is_portfolio", False) == True]  # noqa: E712
+    adds = int((port["conviction"] > 0.5).sum())
+    trims = int((port["conviction"] < -0.5).sum())
+    cand = scores[scores.get("is_portfolio", True) == False]  # noqa: E712
+    watch = int((cand["conviction"] > 0.5).sum())
+    return (
+        f"Regime {regime}: {adds} portfolio ADD / {trims} TRIM signals, "
+        f"{watch} candidate(s) clearing the buy-watch bar. Risk-gated book with "
+        f"decision-support actions; weigh full-cluster conviction, not single factors."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic preview (network-free) + structural self-check
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_scores() -> pd.DataFrame:
+    """A deterministic, mixed-currency synthetic scored frame (no network)."""
+    rng = np.random.default_rng(7)
+    n = 22
+    suffixes = ["", ".PA", ".L", ".DE", ".T", ""]  # mix so USD-bloc stays under cap
+    idx = [f"SYN{i:02d}{suffixes[i % len(suffixes)]}" for i in range(n)]
+    sectors = [
+        ["Technology", "Financials", "Energy", "Health Care", "Industrials"][i % 5]
+        for i in range(n)
+    ]
+    price = rng.uniform(20, 480, n).round(2)
+    df = pd.DataFrame(
+        {
+            "name": [f"Synthetic Co {i:02d}" for i in range(n)],
+            "sector": sectors,
+            "description": ["Illustrative synthetic issuer for preview and QA." for _ in range(n)],
+            "price": price,
+            "pe_trailing": rng.normal(22, 7, n),
+            "pe_forward": rng.normal(19, 6, n),
+            "pb": rng.normal(6, 3, n),
+            "ev_ebitda": rng.normal(15, 6, n),
+            "roe": rng.normal(20, 10, n),
+            "roa": rng.uniform(0.02, 0.30, n),
+            "gross_margin": rng.uniform(0.20, 0.70, n),
+            "op_margin": rng.uniform(0.05, 0.40, n),
+            "fcf": rng.uniform(0.5, 6.0, n),
+            "current_ratio": rng.uniform(0.8, 3.0, n),
+            "de": rng.normal(90, 40, n),
+            "mom_12_1": rng.normal(0.08, 0.25, n),
+            "price_perf": rng.normal(10, 15, n),
+            "pct_52w_high": rng.uniform(40, 100, n),
+            "beta": rng.uniform(0.6, 1.6, n),
+            "realized_vol": rng.uniform(0.15, 0.50, n),
+            "analyst_mom": rng.normal(2, 3, n),
+            "upside": rng.normal(12, 15, n),
+            "buy_pct": rng.uniform(20, 100, n),
+            "short_interest": rng.uniform(0.5, 6.0, n),
+            "target_dispersion": rng.uniform(0.1, 0.6, n),
+            "div_yield": rng.uniform(0, 4, n),
+            "cap": rng.uniform(5e9, 3e12, n),
+            "avg_volume": rng.uniform(3e5, 3e6, n),
+            "adv_usd": rng.uniform(5e7, 5e8, n),
+        },
+        index=idx,
+    )
+    df["entry"] = price
+    df["stop_loss"] = (price * 0.90).round(2)
+    df["take_profit"] = (price * 1.15).round(2)
+    df["rr"] = 1.5
+    scores = compute_scores(df, sector_neutral=True)
+    n_port = 6
+    scores["is_portfolio"] = [True] * n_port + [False] * (n - n_port)
+    return scores
+
+
+def build_synthetic_preview_html() -> str:
+    """Render the FULL report from synthetic data (no network) for screenshot/QA.
+
+    Current weights are crafted so that every action group (BUY / ADD / TRIM /
+    SELL / HOLD) is represented.
+    """
+    scores = _synthetic_scores()
+    result = build_portfolio(scores, pd.DataFrame(), top_n=12)
+    target = result["weights"]
+    invested = list(target[target > 1e-6].index)
+
+    cur: dict[str, float] = {}
+    if len(invested) >= 3:
+        cur[invested[0]] = max(float(target[invested[0]]) - 0.03, 0.001)  # ADD
+        cur[invested[1]] = float(target[invested[1]]) + 0.05  # TRIM
+        cur[invested[2]] = float(target[invested[2]])  # HOLD
+    # invested[3:] absent -> BUY; a held name outside the target -> SELL.
+    cur["SYNSELL"] = 0.05
+    current = pd.Series(cur, dtype=float)
+
+    actions = build_actions(target, current, scores, nav=250_000.0)
+    _, cond = resolve_deployment("neutral")
+
+    now = datetime.now(timezone.utc)
+    meta = {
+        "date": now.strftime("%Y-%m-%d"),
+        "n_portfolio": int(scores["is_portfolio"].sum()),
+        "n_candidates": int((~scores["is_portfolio"]).sum()),
+        "regime": "NEUTRAL",
+        "regime_detail": "synthetic offline preview (no live index fetch)",
+        "system_read": _system_read(scores, "NEUTRAL"),
+        "priced": int(scores["mom_12_1"].notna().sum()),
+        "enriched": int(scores["pb"].notna().sum()),
+        "generated_utc": now.strftime("%Y-%m-%d %H:%M UTC"),
+        "current_weights_approx": False,
+    }
+    return render_report(scores, meta, portfolio=result, actions=actions, conditioning=cond)
+
+
+def _self_check(html: str) -> None:
+    """Assert the rendered HTML has the exec panel, every action group, factor
+    cards, no literal 'None', and zero em-dashes (U+2014)."""
+    problems: list[str] = []
+    if '<div class="exec-panel">' not in html:
+        problems.append("exec/risk panel missing")
+    for cls in ("buy", "add", "trim", "sell", "hold"):
+        if f"act-grp act-grp--{cls}" not in html:
+            problems.append(f"action group {cls} missing")
+    if '<article class="card"' not in html:
+        problems.append("factor cards missing")
+    if "None" in html:
+        problems.append("literal 'None' present")
+    if "—" in html:
+        problems.append("em-dash (U+2014) present")
+    if problems:
+        raise AssertionError("preview self-check failed: " + "; ".join(problems))
+
+
+def write_preview(out: str = PREVIEW_OUT) -> str:
+    """Build + self-check the synthetic preview and write it to disk."""
+    html = build_synthetic_preview_html()
+    _self_check(html)
+    path = os.path.expanduser(out)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(html)
+    print(f"synthetic preview -> {path}  (self-check passed)")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Live pipeline (smoke-tested by the VPS run, not unit tests)
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    # --- Universe assembly (mirrors v3_portfolio.py) ---
+    port = _read_tickers(PORTFOLIO_CSV)
+    buy = _read_tickers(BUY_CSV)
+    port_set = set(port)
+    universe = list(dict.fromkeys(port + buy))
+    print(
+        f"universe: {len(universe)} tickers ({len(port_set)} portfolio + "
+        f"{len(set(buy) - port_set)} candidates)"
+    )
+
+    # --- Feature enrichment + scoring ---
+    feats = enrich_features(
+        universe, ETORO_CSV, price_period="2y", accruals_fetch=lambda _tickers: {}
+    )
+    priced = int(feats["mom_12_1"].notna().sum())
+    enriched = int(feats["pb"].notna().sum())
+    scores = compute_scores(feats, sector_neutral=True)
+    scores["is_portfolio"] = scores.index.isin(port_set)
+
+    elig = scores.get("eligible", pd.Series(True, index=scores.index)).fillna(False).astype(bool)
+    n_excluded = int((~elig).sum())
+    n_port = int((scores["is_portfolio"] & elig).sum())
+    n_cand = int((~scores["is_portfolio"] & elig).sum())
+
+    # --- Prices + market regime ---
+    prices: pd.DataFrame = pd.DataFrame()
+    spx_close: pd.Series = pd.Series(dtype=float)
+    try:
+        prices = robust_fetch_prices(universe, period="2y")
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: universe price fetch failed ({exc})", file=sys.stderr)
+    try:
+        spx_raw = robust_fetch_prices(["^GSPC"], period="2y")
+        if spx_raw is not None and not spx_raw.empty:
+            spx_close = spx_raw.iloc[:, 0]
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: ^GSPC fetch failed ({exc}); defaulting to neutral", file=sys.stderr)
+
+    regime, _mult = trend_regime(spx_close)  # lowercase key for deployment
+    regime_label, regime_detail = compute_regime(spx_close)  # display label + detail
+    gross_target, cond = resolve_deployment(regime, polymarket_signal=None)
+    print(f"regime: {regime}  deployment: {gross_target:.0%}")
+
+    # --- Risk-first construction ---
+    result = build_portfolio(
+        scores,
+        prices,
+        top_n=20,
+        target_vol=0.12,
+        name_cap=0.08,
+        sector_cap=0.25,
+        usd_bloc_cap=0.60,
+        gross_target=gross_target,
+    )
+
+    # --- Current weights (live account or equal-split fallback) + actions ---
+    account_weights, nav, present = load_account_json()
+    current_weights, approx = resolve_current_weights(port, account_weights, present)
+    if present:
+        print(f"current weights: live account ({len(current_weights)} names, nav={nav})")
+    else:
+        print(f"current weights: equal-split fallback ({len(current_weights)} names)")
+    actions = build_actions(result["weights"], current_weights, scores, nav=nav)
+
+    # --- Render the FULL report ---
+    now = datetime.now(timezone.utc)
+    meta = {
+        "date": now.strftime("%Y-%m-%d"),
+        "n_portfolio": n_port,
+        "n_candidates": n_cand,
+        "regime": regime_label,
+        "regime_detail": regime_detail,
+        "system_read": _system_read(scores, regime_label),
+        "priced": priced,
+        "enriched": enriched,
+        "generated_utc": now.strftime("%Y-%m-%d %H:%M UTC"),
+        "current_weights_approx": approx,
+    }
+    html = render_report(scores, meta, portfolio=result, actions=actions, conditioning=cond)
+
+    stamp = now.strftime("%Y%m%d%H%M")
+    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_full_report.html")
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(html)
+
+    print(f"excluded (ineligible): {n_excluded}")
+    print(f"full report -> {out}")
+
+    # Always emit the offline synthetic preview alongside the live report.
+    write_preview()
+
+
+if __name__ == "__main__":
+    if "--preview" in sys.argv:
+        write_preview()
+    else:
+        main()

--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -96,7 +96,9 @@ def append_snapshot(
         return 0
 
     new_df = pd.DataFrame(rows, columns=LOG_COLUMNS)
-    combined = pd.concat([existing, new_df], ignore_index=True)
+    # Skip concat when existing is empty to avoid a pandas FutureWarning about
+    # concatenating DataFrames with all-NA (or no) entries on first write.
+    combined = new_df if existing.empty else pd.concat([existing, new_df], ignore_index=True)
     combined.to_csv(log_path, index=False)
     return len(rows)
 

--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -1,0 +1,297 @@
+"""Trading Model v3 — Forward IC logger (Phase 5E).
+
+Runs the v3 pipeline (same universe assembly as v3_full_report) then APPENDS
+one row per eligible name to a persistent log:
+
+    $V3_IC_LOG  or  ~/.weirdapps-trading/v3_ic_log.csv
+
+Log schema (CSV): date, ticker, conviction, sector, close
+
+Idempotent per day: if rows for today's date already exist, skip entirely.
+
+Run (VPS / network allowed):   .venv/bin/python scripts/v3_ic_logger.py
+
+No module-level yahoofinance.core.config import.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from trade_modules.validation.xsection_ic import cross_sectional_ic  # noqa: E402
+
+PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
+BUY_CSV = "yahoofinance/output/buy.csv"
+ETORO_CSV = "yahoofinance/output/etoro.csv"
+
+DEFAULT_LOG = "~/.weirdapps-trading/v3_ic_log.csv"
+LOG_COLUMNS = ["date", "ticker", "conviction", "sector", "close"]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested, no network)
+# ---------------------------------------------------------------------------
+
+
+def append_snapshot(
+    log_path: str | Path,
+    date: str,
+    scored: pd.DataFrame,
+) -> int:
+    """Append one row per name to the log, idempotent per day.
+
+    Args:
+        log_path: Path to the persistent CSV log (created on first run).
+        date: UTC date string in ``%Y-%m-%d`` format.
+        scored: DataFrame indexed by ticker with at least columns
+            ``conviction``, ``sector``, and ``price`` (or ``close``).
+
+    Returns:
+        Number of rows appended.  0 when rows for ``date`` already exist
+        (idempotent: the log is never modified a second time for the same day).
+    """
+    log_path = Path(log_path).expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Load or initialise the existing log.
+    if log_path.exists() and log_path.stat().st_size > 0:
+        try:
+            existing = pd.read_csv(log_path, dtype={"date": str})
+        except Exception:  # noqa: BLE001
+            existing = pd.DataFrame(columns=LOG_COLUMNS)
+    else:
+        existing = pd.DataFrame(columns=LOG_COLUMNS)
+
+    # Idempotency guard: skip if any row for this date already exists.
+    if len(existing) > 0 and date in existing["date"].values:
+        return 0
+
+    # Build new rows from the scored frame.
+    rows: list[dict] = []
+    for ticker, row in scored.iterrows():
+        # Support both 'price' (from enrich_features) and 'close' (direct).
+        close_val = row.get("price") if "price" in row.index else row.get("close", np.nan)
+        conv_val = row.get("conviction", np.nan)
+        sect_val = row.get("sector", "")
+
+        rows.append(
+            {
+                "date": date,
+                "ticker": str(ticker),
+                "conviction": float(conv_val) if pd.notna(conv_val) else np.nan,
+                "sector": str(sect_val) if pd.notna(sect_val) else "",
+                "close": float(close_val) if pd.notna(close_val) else np.nan,
+            }
+        )
+
+    if not rows:
+        return 0
+
+    new_df = pd.DataFrame(rows, columns=LOG_COLUMNS)
+    combined = pd.concat([existing, new_df], ignore_index=True)
+    combined.to_csv(log_path, index=False)
+    return len(rows)
+
+
+def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
+    """Build (signal_date, ticker, conviction, forward_return) panel.
+
+    For each unique date at sorted position ``i`` in the log, the forward date
+    is the date at position ``i + horizon`` (log-row steps, not calendar days).
+    Forward return is defined as::
+
+        fwd = close[date_{i+h}] / close[date_i] - 1
+
+    matched per ticker across the two dates.
+
+    Args:
+        log_df: DataFrame with columns date, ticker, conviction, close.
+        horizon: Number of log-date steps to look forward.
+
+    Returns:
+        Long-format panel DataFrame with columns
+        ``[signal_date, ticker, conviction, forward_return]``.
+        Empty when there are fewer than ``horizon + 1`` distinct dates.
+    """
+    empty = pd.DataFrame(columns=["signal_date", "ticker", "conviction", "forward_return"])
+    if log_df is None or log_df.empty:
+        return empty
+
+    log = log_df.copy()
+    log["date"] = log["date"].astype(str)
+
+    dates = sorted(log["date"].unique())
+    if len(dates) <= horizon:
+        return empty
+
+    # Build a (date, ticker) -> close pivot for fast lookups.
+    pivot = log.pivot_table(index="date", columns="ticker", values="close", aggfunc="first")
+
+    # Build (date, ticker) -> conviction lookup.
+    conv_pivot = log.pivot_table(
+        index="date", columns="ticker", values="conviction", aggfunc="first"
+    )
+
+    records = []
+    for i, signal_date in enumerate(dates):
+        future_idx = i + horizon
+        if future_idx >= len(dates):
+            break
+        future_date = dates[future_idx]
+
+        for ticker in pivot.columns:
+            if signal_date not in pivot.index or future_date not in pivot.index:
+                continue
+            close_sig = pivot.at[signal_date, ticker] if ticker in pivot.columns else np.nan
+            close_fut = pivot.at[future_date, ticker] if ticker in pivot.columns else np.nan
+            if not np.isfinite(close_sig) or not np.isfinite(close_fut) or close_sig <= 0:
+                continue
+            conviction = (
+                conv_pivot.at[signal_date, ticker]
+                if (signal_date in conv_pivot.index and ticker in conv_pivot.columns)
+                else np.nan
+            )
+            records.append(
+                {
+                    "signal_date": signal_date,
+                    "ticker": ticker,
+                    "conviction": conviction,
+                    "forward_return": close_fut / close_sig - 1.0,
+                }
+            )
+
+    if not records:
+        return empty
+    return pd.DataFrame(records)
+
+
+def ic_from_log(
+    log_df: pd.DataFrame,
+    horizons: tuple[int, ...] = (5, 10, 21, 63),
+) -> dict:
+    """Compute cross-sectional IC for each horizon from the IC log.
+
+    Args:
+        log_df: DataFrame with columns date, ticker, conviction, sector, close.
+        horizons: Forward-return horizons to evaluate (in log-date steps).
+
+    Returns:
+        ``{horizon: result}`` where ``result`` is either:
+
+        - The dict returned by :func:`cross_sectional_ic` (keys: mean_ic,
+          ic_std, t_stat, hit_rate, n_dates, ic_by_date), or
+        - ``{"insufficient_history": True, "horizon": h,
+             "n_dates_available": N, "n_dates_needed": h+1}``
+          when fewer than ``h + 1`` distinct dates are in the log.
+    """
+    results: dict = {}
+
+    if log_df is None or log_df.empty:
+        for h in horizons:
+            results[h] = {
+                "insufficient_history": True,
+                "horizon": h,
+                "n_dates_available": 0,
+                "n_dates_needed": h + 1,
+            }
+        return results
+
+    dates = sorted(log_df["date"].astype(str).unique())
+    n_dates = len(dates)
+
+    for h in horizons:
+        if n_dates <= h:
+            results[h] = {
+                "insufficient_history": True,
+                "horizon": h,
+                "n_dates_available": n_dates,
+                "n_dates_needed": h + 1,
+            }
+            continue
+
+        panel = forward_return_panel(log_df, h)
+        if panel.empty or len(panel) == 0:
+            results[h] = {
+                "insufficient_history": True,
+                "horizon": h,
+                "n_dates_available": n_dates,
+                "n_dates_needed": h + 1,
+            }
+            continue
+
+        ic = cross_sectional_ic(
+            panel,
+            signal_col="conviction",
+            forward_col="forward_return",
+            date_col="signal_date",
+        )
+        results[h] = ic
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Live pipeline (network required — runs on VPS)
+# ---------------------------------------------------------------------------
+
+
+def _read_tickers(path: str) -> list[str]:
+    try:
+        df = pd.read_csv(path, na_values=["--"])
+        return df["TKR"].dropna().astype(str).tolist()
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: could not read {path}: {exc}", file=sys.stderr)
+        return []
+
+
+def main() -> None:
+    # Lazy imports: avoid module-level yahoofinance.core.config import.
+    from trade_modules.v3.combine import compute_scores  # noqa: PLC0415
+    from trade_modules.v3.features import enrich_features  # noqa: PLC0415
+
+    # --- Universe assembly (mirrors v3_full_report.py exactly) ---
+    port = _read_tickers(PORTFOLIO_CSV)
+    buy = _read_tickers(BUY_CSV)
+    port_set = set(port)
+    universe = list(dict.fromkeys(port + buy))
+    print(
+        f"universe: {len(universe)} tickers ({len(port_set)} portfolio + "
+        f"{len(set(buy) - port_set)} candidates)"
+    )
+
+    # --- Feature enrichment + scoring ---
+    feats = enrich_features(
+        universe, ETORO_CSV, price_period="2y", accruals_fetch=lambda _tickers: {}
+    )
+    scores = compute_scores(feats, sector_neutral=True)
+
+    # --- Filter to eligible names only ---
+    elig = scores.get("eligible", pd.Series(True, index=scores.index)).fillna(False).astype(bool)
+    eligible_scores = scores[elig]
+    print(f"eligible: {len(eligible_scores)} / {len(scores)} names")
+
+    # --- Log path (env override or default) ---
+    log_path = os.environ.get("V3_IC_LOG", DEFAULT_LOG)
+
+    # --- Today's UTC date ---
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # --- Append snapshot (idempotent) ---
+    n_appended = append_snapshot(log_path, today, eligible_scores)
+    expanded = os.path.expanduser(log_path)
+    if n_appended == 0:
+        print(f"skipped: rows for {today} already in log  ({expanded})")
+    else:
+        print(f"appended: {n_appended} rows for {today}  ->  {expanded}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_ic_report.py
+++ b/scripts/v3_ic_report.py
@@ -1,0 +1,159 @@
+"""Trading Model v3 — IC-join report (Phase 5E).
+
+Reads the forward-IC log at $V3_IC_LOG (or ~/.weirdapps-trading/v3_ic_log.csv),
+computes cross-sectional Spearman IC for each horizon in (5, 10, 21, 63) log-date
+steps, prints a summary, and saves a markdown report to:
+
+    ~/Downloads/<UTCstamp>_v3_ic_report.md
+
+Gracefully handles insufficient history for any horizon.
+
+Run:   .venv/bin/python scripts/v3_ic_report.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.v3_ic_logger import DEFAULT_LOG, ic_from_log  # noqa: E402
+
+HORIZONS = (5, 10, 21, 63)
+
+_HORIZON_LABELS = {
+    5: " ~1w",
+    10: " ~2w",
+    21: " ~1m",
+    63: " ~3m",
+}
+
+
+def _format_val(v: float | None, fmt: str = ".4f") -> str:
+    return f"{v:{fmt}}" if v is not None else "n/a"
+
+
+def _build_markdown(results: dict, log_path: str, n_rows: int, n_dates: int) -> str:
+    now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        "# v3 Forward IC Report",
+        "",
+        f"Generated: {now_str}",
+        f"Log: `{log_path}`  ({n_rows:,} rows, {n_dates} distinct dates)",
+        "",
+        "## Cross-Sectional IC by Horizon",
+        "",
+        "| Horizon | Label | mean IC | IC std | t-stat | Hit rate | n dates |",
+        "|--------:|:------|--------:|-------:|-------:|---------:|--------:|",
+    ]
+
+    for h in HORIZONS:
+        r = results.get(h, {})
+        label = _HORIZON_LABELS.get(h, "")
+        if r.get("insufficient_history"):
+            avail = r.get("n_dates_available", "?")
+            need = r.get("n_dates_needed", h + 1)
+            lines.append(f"| {h:>7} | {label} | *insufficient ({avail}/{need} dates)* | | | | |")
+        else:
+            mean_ic = _format_val(r.get("mean_ic"))
+            ic_std = _format_val(r.get("ic_std"))
+            t_stat = _format_val(r.get("t_stat"))
+            hit = _format_val(r.get("hit_rate"))
+            n_d = r.get("n_dates", 0)
+            lines.append(
+                f"| {h:>7} | {label} | {mean_ic} | {ic_std} | {t_stat} | {hit} | {n_d:>7} |"
+            )
+
+    lines += [
+        "",
+        "## Notes",
+        "",
+        "- **Horizon** is measured in log-date steps (one step = one daily logger run).",
+        "- IC is the mean Spearman rank correlation of conviction vs forward return across dates.",
+        "- A date contributes to IC only when >= 3 clean name-pairs are present.",
+        "- IC weighting in `compute_scores` activates once >63 dates are logged.",
+        "",
+        "## Raw JSON",
+        "",
+        "```json",
+    ]
+
+    # Serialise results (drop ic_by_date to keep the report concise).
+    slim = {}
+    for h, r in results.items():
+        r2 = {k: v for k, v in r.items() if k != "ic_by_date"}
+        slim[str(h)] = r2
+    lines.append(json.dumps(slim, indent=2, default=str))
+    lines.append("```")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    log_path = os.environ.get("V3_IC_LOG", DEFAULT_LOG)
+    expanded = os.path.expanduser(log_path)
+
+    if not os.path.exists(expanded):
+        print(f"log not found: {expanded}")
+        print("Run v3_ic_logger.py at least once first.")
+        sys.exit(0)
+
+    try:
+        log_df = pd.read_csv(expanded, dtype={"date": str})
+    except Exception as exc:  # noqa: BLE001
+        print(f"error reading log {expanded}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    n_rows = len(log_df)
+    dates = sorted(log_df["date"].astype(str).unique())
+    n_dates = len(dates)
+    print(f"log: {n_rows:,} rows, {n_dates} distinct dates  ({expanded})")
+    print(f"date range: {dates[0] if dates else 'n/a'} .. {dates[-1] if dates else 'n/a'}")
+    print()
+
+    results = ic_from_log(log_df, horizons=HORIZONS)
+
+    # Print summary table.
+    header = f"{'H':>5}  {'Label':5}  {'mean IC':>8}  {'IC std':>8}  {'t-stat':>7}  {'Hit%':>6}  {'n':>4}"
+    print(header)
+    print("-" * len(header))
+    for h in HORIZONS:
+        r = results[h]
+        label = _HORIZON_LABELS.get(h, "")
+        if r.get("insufficient_history"):
+            avail = r.get("n_dates_available", "?")
+            need = r.get("n_dates_needed", h + 1)
+            print(f"{h:>5}  {label:5}  insufficient history ({avail}/{need} dates)")
+        else:
+            mean_ic = r.get("mean_ic")
+            ic_std = r.get("ic_std")
+            t_stat = r.get("t_stat")
+            hit = r.get("hit_rate")
+            n_d = r.get("n_dates", 0)
+            print(
+                f"{h:>5}  {label:5}"
+                f"  {_format_val(mean_ic):>8}"
+                f"  {_format_val(ic_std):>8}"
+                f"  {_format_val(t_stat):>7}"
+                f"  {_format_val(hit, '.2%') if hit is not None else 'n/a':>6}"
+                f"  {n_d:>4}"
+            )
+
+    # Write markdown report.
+    md = _build_markdown(results, expanded, n_rows, n_dates)
+    now = datetime.now(timezone.utc)
+    stamp = now.strftime("%Y%m%d%H%M")
+    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_ic_report.md")
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    print(f"\nreport -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_portfolio.py
+++ b/scripts/v3_portfolio.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from trade_modules.riskfirst.regime_overlay import REGIME_EXPOSURE  # noqa: E402
 from trade_modules.v3.combine import compute_scores  # noqa: E402
+from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
 from trade_modules.v3.construct import build_portfolio  # noqa: E402
 from trade_modules.v3.features import enrich_features  # noqa: E402
 from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
@@ -35,9 +36,8 @@ PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
 BUY_CSV = "yahoofinance/output/buy.csv"
 ETORO_CSV = "yahoofinance/output/etoro.csv"
 
-# Regime -> fraction of capital deployed (Change 2). Averages ~90%, band 85-95%.
-# The regime now sets gross_target directly (replaces the old Kelly / gross dial).
-DEPLOYMENT_BY_REGIME = {"risk_off": 0.85, "neutral": 0.90, "risk_on": 0.95}
+# DEPLOYMENT_BY_REGIME is now the single source of truth in
+# trade_modules.v3.conditioning — imported above.
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +192,10 @@ def main() -> None:
         print(f"warn: ^GSPC fetch failed ({exc}); defaulting to neutral", file=sys.stderr)
 
     regime, mult = trend_regime(spx_close)
-    gross_target = DEPLOYMENT_BY_REGIME[regime]
+    # Polymarket is a shadow/zero-conviction cross-repo signal (lives in trading-hub).
+    # The seam is inert until wired and validated; max_pm_tilt=0 (default) guarantees
+    # zero effect on deployment regardless of what polymarket_signal contains.
+    gross_target, dial_diag = resolve_deployment(regime, polymarket_signal=None)
     print(f"regime: {regime}  multiplier: {mult:.2f}  deployment: {gross_target:.0%}")
 
     # --- Portfolio construction ---
@@ -278,6 +281,7 @@ def main() -> None:
         "regime": regime,
         "multiplier": mult,
         "gross_target": gross_target,
+        "conditioning": dial_diag,
         "diagnostics": {k: (_serial(v) if not isinstance(v, dict) else v) for k, v in diag.items()},
         "gross": gross,
         "cash": cash,

--- a/scripts/v3_portfolio.py
+++ b/scripts/v3_portfolio.py
@@ -26,6 +26,8 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from trade_modules.riskfirst.regime_overlay import REGIME_EXPOSURE  # noqa: E402
+from trade_modules.riskfirst.shadow_run import load_current_weights  # noqa: E402
+from trade_modules.v3.actions import build_actions  # noqa: E402
 from trade_modules.v3.combine import compute_scores  # noqa: E402
 from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
 from trade_modules.v3.construct import build_portfolio  # noqa: E402
@@ -152,6 +154,34 @@ def _read_tickers(path: str) -> list[str]:
         return []
 
 
+def _load_portfolio_weights(path: str) -> tuple[pd.Series, float | None]:
+    """Load current portfolio weights and NAV from portfolio.csv.
+
+    Strategy:
+    1. Try load_current_weights (shadow_run) — handles weight/totalInvestmentPct/etc.
+    2. If it returns empty (portfolio.csv has no weight column, as is the case for
+       the standard etorotrade schema), fall back to equal weights across listed
+       tickers — a best-effort approximation for action classification.
+    3. NAV: portfolio.csv carries no per-position USD value column → always None
+       (delta_usd is omitted; actions are decision-support in % only).
+
+    Returns:
+        (current_weights, nav) where nav is always None for this schema.
+    """
+    weights = load_current_weights(path)
+    if weights.empty:
+        # Fallback: assign equal weights across all listed portfolio tickers.
+        try:
+            df = pd.read_csv(path, na_values=["--"])
+            tickers = df["TKR"].dropna().astype(str).tolist()
+            if tickers:
+                eq = 1.0 / len(tickers)
+                weights = pd.Series(eq, index=tickers)
+        except Exception as exc:  # noqa: BLE001
+            print(f"warn: portfolio weight fallback failed ({exc})", file=sys.stderr)
+    return weights, None  # NAV always None: no USD value column in schema
+
+
 def main() -> None:
     # --- Universe assembly (mirrors v3_report.py exactly) ---
     port = _read_tickers(PORTFOLIO_CSV)
@@ -236,6 +266,20 @@ def main() -> None:
     for sec, w in sorted(sector_exp.items(), key=lambda x: -x[1]):
         print(f"    {sec:<22} {w:.1%}")
 
+    # --- Current portfolio weights + NAV (for action diff) ---
+    current_weights, nav = _load_portfolio_weights(PORTFOLIO_CSV)
+    print(
+        f"current portfolio: {len(current_weights)} names"
+        + (
+            " (equal-weight fallback)"
+            if current_weights.empty or current_weights.nunique() <= 1
+            else ""
+        )
+    )
+
+    # --- PM construction: target vs current → action list ---
+    actions = build_actions(result["weights"], current_weights, scores, nav=nav)
+
     holdings = build_target_rows(scores, result)
     print()
     print(f"{'─' * 60}")
@@ -255,6 +299,35 @@ def main() -> None:
         print(
             f"{h['ticker']:<10} {h['target_pct']:>6.1%}  {conv:>6}  {rank:>5}  {sector:<18}  {sl:>8}  {tp:>8}"
         )
+
+    # --- Actions summary console print ---
+    from collections import Counter
+
+    action_counts = Counter(a["action"] for a in actions)
+    buys = [a for a in actions if a["action"] in ("BUY", "ADD")]
+    sells = [a for a in actions if a["action"] in ("SELL", "TRIM")]
+    print()
+    print(f"{'─' * 60}")
+    print("SUGGESTED ACTIONS  (decision-support — review before executing)")
+    print(f"{'─' * 60}")
+    for act in ("BUY", "ADD", "TRIM", "SELL", "HOLD"):
+        n = action_counts.get(act, 0)
+        if n:
+            print(f"  {act:<5}  {n}")
+    if buys:
+        print()
+        print(f"  Top {min(5, len(buys))} BUY/ADD:")
+        for a in buys[:5]:
+            pct = f"{a['target_pct']:.1%}"
+            delta = f"{a['delta_pct']:+.1%}"
+            print(f"    {a['ticker']:<10} target {pct}  delta {delta}  ({a['action']})")
+    if sells:
+        print()
+        print(f"  Top {min(5, len(sells))} SELL/TRIM:")
+        for a in sells[:5]:
+            pct = f"{a['current_pct']:.1%}"
+            delta = f"{a['delta_pct']:+.1%}"
+            print(f"    {a['ticker']:<10} current {pct}  delta {delta}  ({a['action']})")
 
     # --- JSON output ---
     now = datetime.now(timezone.utc)
@@ -286,6 +359,7 @@ def main() -> None:
         "gross": gross,
         "cash": cash,
         "holdings": [{k: _serial(v) for k, v in h.items()} for h in holdings],
+        "actions": [{k: _serial(v) for k, v in a.items()} for a in actions],
     }
 
     out = os.path.expanduser(f"~/Downloads/{stamp}_v3_portfolio.json")

--- a/scripts/vps/v3-ic-logger.service
+++ b/scripts/vps/v3-ic-logger.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=v3 forward-IC logger — daily eligible-name snapshot to ~/.weirdapps-trading/v3_ic_log.csv
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/SourceCode/etorotrade
+ExecStart=%h/SourceCode/etorotrade/.venv/bin/python scripts/v3_ic_logger.py
+StandardOutput=append:%h/logs/v3-ic-logger/service.log
+StandardError=append:%h/logs/v3-ic-logger/service.err
+TimeoutStartSec=600

--- a/scripts/vps/v3-ic-logger.timer
+++ b/scripts/vps/v3-ic-logger.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily v3 forward-IC logger timer
+
+[Timer]
+# 23:47 UTC — off-peak, after signals pipeline (~22:00 UTC) and VPS brief runs.
+# Persistent=true catches up on missed runs after a reboot.
+# Install: cp scripts/vps/v3-ic-logger.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload && systemctl --user enable --now v3-ic-logger.timer
+OnCalendar=*-*-* 23:47:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/tests/unit/trade_modules/test_v3_actions.py
+++ b/tests/unit/trade_modules/test_v3_actions.py
@@ -1,0 +1,374 @@
+"""TDD tests for trade_modules.v3.actions.build_actions.
+
+Phase 5C: PM construction — suggested actions (BUY/ADD/TRIM/SELL/HOLD) vs live
+portfolio.
+
+Tests:
+- BUY:  ticker in target only (current_pct ≈ 0)
+- SELL: ticker in current only (target_pct ≈ 0)
+- ADD:  both, delta_pct > +threshold
+- TRIM: both, delta_pct < -threshold
+- HOLD: both, |delta_pct| <= threshold
+- delta_usd = delta_pct * nav when nav provided; None when nav absent
+- SL/TP pulled from scored for BUY and ADD rows
+- SELL rows absent from scored emit None for name/sector/conviction/price/SL/TP
+- Sort/grouping: BUY+ADD (target_pct desc) → TRIM+SELL (current_pct desc) → HOLD
+- epsilon boundary: current_pct < 1e-6 treated as not-held (→ BUY not ADD)
+"""
+
+import pandas as pd
+import pytest
+
+from trade_modules.v3.actions import build_actions
+
+# ---------------------------------------------------------------------------
+# Shared scored frame helper
+# ---------------------------------------------------------------------------
+
+
+def _scored(tickers, *, conviction=1.0, price=100.0, sl=90.0, tp=120.0, sector="Tech"):
+    """Build a minimal scored DataFrame for the given tickers."""
+    rows = []
+    for t in tickers:
+        rows.append(
+            {
+                "name": f"Company {t}",
+                "sector": sector,
+                "conviction": conviction,
+                "price": price,
+                "stop_loss": sl,
+                "take_profit": tp,
+            }
+        )
+    return pd.DataFrame(rows, index=pd.Index(tickers, name="ticker"))
+
+
+# ---------------------------------------------------------------------------
+# Action classification
+# ---------------------------------------------------------------------------
+
+
+class TestBuy:
+    """Ticker in target only → BUY."""
+
+    def test_action_label(self):
+        target = pd.Series({"A": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["A"])
+        acts = build_actions(target, current, scored)
+        assert len(acts) == 1
+        assert acts[0]["action"] == "BUY"
+
+    def test_correct_ticker(self):
+        target = pd.Series({"A": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["A"])
+        acts = build_actions(target, current, scored)
+        assert acts[0]["ticker"] == "A"
+
+    def test_target_pct_set(self):
+        target = pd.Series({"A": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["A"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["target_pct"]) == 0.05
+
+    def test_current_pct_zero(self):
+        target = pd.Series({"A": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["A"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["current_pct"]) == 0.0
+
+    def test_delta_pct(self):
+        target = pd.Series({"A": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["A"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["delta_pct"]) == 0.05
+
+
+class TestSell:
+    """Ticker in current only → SELL."""
+
+    def test_action_label(self):
+        target = pd.Series(dtype=float)
+        current = pd.Series({"B": 0.04})
+        scored = _scored(["B"])
+        acts = build_actions(target, current, scored)
+        assert len(acts) == 1
+        assert acts[0]["action"] == "SELL"
+
+    def test_current_pct_set(self):
+        target = pd.Series(dtype=float)
+        current = pd.Series({"B": 0.04})
+        scored = _scored(["B"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["current_pct"]) == 0.04
+
+    def test_target_pct_zero(self):
+        target = pd.Series(dtype=float)
+        current = pd.Series({"B": 0.04})
+        scored = _scored(["B"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["target_pct"]) == 0.0
+
+    def test_delta_pct_negative(self):
+        target = pd.Series(dtype=float)
+        current = pd.Series({"B": 0.04})
+        scored = _scored(["B"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["delta_pct"]) == -0.04
+
+    def test_sell_not_in_scored_emits_none_fields(self):
+        """SELL ticker absent from scored → name/sector/conviction/price/SL/TP are None."""
+        target = pd.Series(dtype=float)
+        current = pd.Series({"GHOST": 0.03})
+        scored = _scored([])  # empty
+        acts = build_actions(target, current, scored)
+        row = acts[0]
+        assert row["name"] is None
+        assert row["sector"] is None
+        assert row["conviction"] is None
+        assert row["price"] is None
+        assert row["stop_loss"] is None
+        assert row["take_profit"] is None
+
+
+class TestAdd:
+    """Both in target and current, delta > +threshold → ADD."""
+
+    def test_action_label(self):
+        target = pd.Series({"C": 0.07})
+        current = pd.Series({"C": 0.02})
+        scored = _scored(["C"])
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        assert acts[0]["action"] == "ADD"
+
+    def test_delta_pct(self):
+        target = pd.Series({"C": 0.07})
+        current = pd.Series({"C": 0.02})
+        scored = _scored(["C"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["delta_pct"]) == 0.05
+
+
+class TestTrim:
+    """Both in target and current, delta < -threshold → TRIM."""
+
+    def test_action_label(self):
+        target = pd.Series({"D": 0.02})
+        current = pd.Series({"D": 0.08})
+        scored = _scored(["D"])
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        assert acts[0]["action"] == "TRIM"
+
+    def test_delta_pct_negative(self):
+        target = pd.Series({"D": 0.02})
+        current = pd.Series({"D": 0.08})
+        scored = _scored(["D"])
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["delta_pct"]) == -0.06
+
+
+class TestHold:
+    """Both in target and current, |delta| <= threshold → HOLD."""
+
+    def test_action_label_exact_threshold(self):
+        target = pd.Series({"E": 0.055})
+        current = pd.Series({"E": 0.05})
+        scored = _scored(["E"])
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        # delta = 0.005 == threshold → HOLD (not ADD)
+        assert acts[0]["action"] == "HOLD"
+
+    def test_action_label_within_threshold(self):
+        target = pd.Series({"E": 0.052})
+        current = pd.Series({"E": 0.05})
+        scored = _scored(["E"])
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        assert acts[0]["action"] == "HOLD"
+
+    def test_action_label_negative_within_threshold(self):
+        target = pd.Series({"E": 0.048})
+        current = pd.Series({"E": 0.05})
+        scored = _scored(["E"])
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        assert acts[0]["action"] == "HOLD"
+
+
+# ---------------------------------------------------------------------------
+# Epsilon boundary: sub-epsilon current treated as not-held (→ BUY)
+# ---------------------------------------------------------------------------
+
+
+class TestEpsilon:
+    def test_sub_epsilon_current_gives_buy(self):
+        target = pd.Series({"F": 0.06})
+        current = pd.Series({"F": 5e-7})  # below epsilon 1e-6
+        scored = _scored(["F"])
+        acts = build_actions(target, current, scored)
+        assert acts[0]["action"] == "BUY"
+
+    def test_sub_epsilon_target_gives_sell(self):
+        target = pd.Series({"G": 5e-7})  # below epsilon
+        current = pd.Series({"G": 0.04})
+        scored = _scored(["G"])
+        acts = build_actions(target, current, scored)
+        assert acts[0]["action"] == "SELL"
+
+
+# ---------------------------------------------------------------------------
+# delta_usd: nav * delta_pct when nav given, else None
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaUsd:
+    def test_delta_usd_with_nav(self):
+        target = pd.Series({"H": 0.10})
+        current = pd.Series({"H": 0.04})
+        scored = _scored(["H"])
+        acts = build_actions(target, current, scored, nav=100_000.0)
+        assert pytest.approx(acts[0]["delta_usd"]) == pytest.approx(0.06 * 100_000.0)
+
+    def test_delta_usd_none_without_nav(self):
+        target = pd.Series({"I": 0.10})
+        current = pd.Series({"I": 0.04})
+        scored = _scored(["I"])
+        acts = build_actions(target, current, scored, nav=None)
+        assert acts[0]["delta_usd"] is None
+
+    def test_delta_usd_sell_with_nav(self):
+        target = pd.Series(dtype=float)
+        current = pd.Series({"J": 0.05})
+        scored = _scored(["J"])
+        acts = build_actions(target, current, scored, nav=200_000.0)
+        assert pytest.approx(acts[0]["delta_usd"]) == pytest.approx(-0.05 * 200_000.0)
+
+
+# ---------------------------------------------------------------------------
+# SL/TP present for BUY and ADD, and pulled from scored
+# ---------------------------------------------------------------------------
+
+
+class TestStopLossTakeProfit:
+    def test_buy_has_sl_tp(self):
+        target = pd.Series({"K": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["K"], sl=88.0, tp=125.0)
+        acts = build_actions(target, current, scored)
+        row = acts[0]
+        assert row["action"] == "BUY"
+        assert pytest.approx(row["stop_loss"]) == 88.0
+        assert pytest.approx(row["take_profit"]) == 125.0
+
+    def test_add_has_sl_tp(self):
+        target = pd.Series({"L": 0.08})
+        current = pd.Series({"L": 0.02})
+        scored = _scored(["L"], sl=75.0, tp=150.0)
+        acts = build_actions(target, current, scored)
+        row = acts[0]
+        assert row["action"] == "ADD"
+        assert pytest.approx(row["stop_loss"]) == 75.0
+        assert pytest.approx(row["take_profit"]) == 150.0
+
+    def test_conviction_pulled_from_scored(self):
+        target = pd.Series({"M": 0.05})
+        current = pd.Series(dtype=float)
+        scored = _scored(["M"], conviction=3.75)
+        acts = build_actions(target, current, scored)
+        assert pytest.approx(acts[0]["conviction"]) == 3.75
+
+
+# ---------------------------------------------------------------------------
+# Sort / grouping order
+# ---------------------------------------------------------------------------
+
+
+class TestSortOrder:
+    """BUY+ADD (target_pct desc) → TRIM+SELL (current_pct desc) → HOLD last."""
+
+    def _make_multi(self):
+        """Universe: 2 BUY, 1 ADD, 1 TRIM, 1 SELL, 1 HOLD."""
+        target = pd.Series(
+            {
+                "BUY1": 0.08,  # BUY (larger)
+                "BUY2": 0.05,  # BUY (smaller)
+                "ADD1": 0.07,  # ADD
+                "TRIM1": 0.01,  # TRIM
+                "HOLD1": 0.04,  # HOLD
+            }
+        )
+        current = pd.Series(
+            {
+                "ADD1": 0.02,  # ADD: delta = +0.05 > 0.005
+                "TRIM1": 0.06,  # TRIM: delta = -0.05 < -0.005
+                "SELL1": 0.09,  # SELL (not in target)
+                "HOLD1": 0.042,  # HOLD: delta = -0.002 ≤ 0.005
+            }
+        )
+        all_tickers = set(target.index) | set(current.index)
+        scored = _scored(list(all_tickers))
+        return target, current, scored
+
+    def test_buy_add_before_trim_sell_before_hold(self):
+        target, current, scored = self._make_multi()
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        actions = [a["action"] for a in acts]
+        # Find positions of group boundaries
+        hold_idx = next(i for i, a in enumerate(actions) if a == "HOLD")
+        # All HOLD rows must be at the end
+        assert all(a == "HOLD" for a in actions[hold_idx:])
+        # All BUY/ADD before first SELL/TRIM
+        buy_add = [i for i, a in enumerate(actions) if a in ("BUY", "ADD")]
+        trim_sell = [i for i, a in enumerate(actions) if a in ("TRIM", "SELL")]
+        if buy_add and trim_sell:
+            assert max(buy_add) < min(trim_sell)
+
+    def test_buy_add_sorted_by_target_pct_desc(self):
+        target, current, scored = self._make_multi()
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        buy_add = [a for a in acts if a["action"] in ("BUY", "ADD")]
+        pcts = [a["target_pct"] for a in buy_add]
+        assert pcts == sorted(pcts, reverse=True)
+
+    def test_trim_sell_sorted_by_current_pct_desc(self):
+        target, current, scored = self._make_multi()
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        trim_sell = [a for a in acts if a["action"] in ("TRIM", "SELL")]
+        pcts = [a["current_pct"] for a in trim_sell]
+        assert pcts == sorted(pcts, reverse=True)
+
+    def test_hold_is_last(self):
+        target, current, scored = self._make_multi()
+        acts = build_actions(target, current, scored, add_trim_threshold=0.005)
+        actions = [a["action"] for a in acts]
+        assert actions[-1] == "HOLD"
+
+
+# ---------------------------------------------------------------------------
+# Misc / edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_inputs_returns_empty_list(self):
+        acts = build_actions(pd.Series(dtype=float), pd.Series(dtype=float), _scored([]))
+        assert acts == []
+
+    def test_buy_and_sell_mix(self):
+        target = pd.Series({"NEW": 0.06})
+        current = pd.Series({"OLD": 0.03})
+        scored = _scored(["NEW", "OLD"])
+        acts = build_actions(target, current, scored)
+        labels = {a["ticker"]: a["action"] for a in acts}
+        assert labels["NEW"] == "BUY"
+        assert labels["OLD"] == "SELL"
+
+    def test_threshold_zero_makes_hold_very_narrow(self):
+        """With threshold=0, any nonzero delta becomes ADD or TRIM."""
+        target = pd.Series({"X": 0.051})
+        current = pd.Series({"X": 0.050})
+        scored = _scored(["X"])
+        acts = build_actions(target, current, scored, add_trim_threshold=0.0)
+        assert acts[0]["action"] == "ADD"

--- a/tests/unit/trade_modules/test_v3_conditioning.py
+++ b/tests/unit/trade_modules/test_v3_conditioning.py
@@ -1,0 +1,171 @@
+"""Unit tests for trade_modules.v3.conditioning."""
+
+from __future__ import annotations
+
+import pytest
+
+from trade_modules.v3.conditioning import (
+    DEPLOYMENT_BY_REGIME,
+    polymarket_adjustment,
+    regime_deployment,
+    resolve_deployment,
+)
+
+# ---------------------------------------------------------------------------
+# DEPLOYMENT_BY_REGIME constant
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_by_regime_values() -> None:
+    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.85
+    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.90
+    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.95
+
+
+# ---------------------------------------------------------------------------
+# regime_deployment
+# ---------------------------------------------------------------------------
+
+
+class TestRegimeDeployment:
+    def test_risk_off(self) -> None:
+        assert regime_deployment("risk_off") == pytest.approx(0.85)
+
+    def test_neutral(self) -> None:
+        assert regime_deployment("neutral") == pytest.approx(0.90)
+
+    def test_risk_on(self) -> None:
+        assert regime_deployment("risk_on") == pytest.approx(0.95)
+
+    def test_unknown_returns_neutral(self) -> None:
+        assert regime_deployment("unknown") == pytest.approx(0.90)
+
+    def test_empty_string_returns_neutral(self) -> None:
+        assert regime_deployment("") == pytest.approx(0.90)
+
+    def test_none_as_string_returns_neutral(self) -> None:
+        # None is not in the dict; falls back to neutral.
+        assert regime_deployment("None") == pytest.approx(0.90)
+
+
+# ---------------------------------------------------------------------------
+# polymarket_adjustment
+# ---------------------------------------------------------------------------
+
+
+class TestPolymarketAdjustment:
+    # Inert cases — must return exactly 0.0
+    def test_signal_none_returns_zero(self) -> None:
+        assert polymarket_adjustment(None) == 0.0
+
+    def test_max_tilt_zero_returns_zero(self) -> None:
+        assert polymarket_adjustment(0.8) == 0.0
+
+    def test_both_none_and_zero_tilt(self) -> None:
+        assert polymarket_adjustment(None, max_tilt=0.0) == 0.0
+
+    def test_positive_signal_zero_tilt(self) -> None:
+        assert polymarket_adjustment(1.0, max_tilt=0.0) == 0.0
+
+    # Enabled cases — nonzero max_tilt
+    def test_full_positive_signal(self) -> None:
+        adj = polymarket_adjustment(1.0, max_tilt=0.05)
+        assert adj == pytest.approx(0.05)
+
+    def test_full_negative_signal(self) -> None:
+        adj = polymarket_adjustment(-1.0, max_tilt=0.05)
+        assert adj == pytest.approx(-0.05)
+
+    def test_partial_signal(self) -> None:
+        adj = polymarket_adjustment(0.5, max_tilt=0.04)
+        assert adj == pytest.approx(0.02)
+
+    def test_signal_clipped_above(self) -> None:
+        adj = polymarket_adjustment(2.0, max_tilt=0.05)
+        assert abs(adj) <= 0.05
+
+    def test_signal_clipped_below(self) -> None:
+        adj = polymarket_adjustment(-3.0, max_tilt=0.05)
+        assert abs(adj) <= 0.05
+
+    def test_magnitude_bounded_by_max_tilt(self) -> None:
+        for sig in (-1.5, -1.0, 0.0, 0.75, 2.0):
+            adj = polymarket_adjustment(sig, max_tilt=0.03)
+            assert abs(adj) <= 0.03 + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# resolve_deployment
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDeployment:
+    def test_known_regime_no_pm(self) -> None:
+        dep, diag = resolve_deployment("risk_on")
+        assert dep == pytest.approx(0.95)
+        assert diag["final_deployment"] == pytest.approx(0.95)
+
+    def test_neutral_regime(self) -> None:
+        dep, diag = resolve_deployment("neutral")
+        assert dep == pytest.approx(0.90)
+
+    def test_risk_off_regime(self) -> None:
+        dep, diag = resolve_deployment("risk_off")
+        assert dep == pytest.approx(0.85)
+
+    def test_unknown_regime_neutral_fallback(self) -> None:
+        dep, _ = resolve_deployment("garbage")
+        assert dep == pytest.approx(0.90)
+
+    # Polymarket inert by default
+    def test_polymarket_inactive_by_default(self) -> None:
+        _, diag = resolve_deployment("neutral", polymarket_signal=0.9)
+        assert diag["polymarket_active"] is False
+        assert diag["polymarket_tilt"] == pytest.approx(0.0)
+        assert diag["final_deployment"] == pytest.approx(0.90)
+
+    def test_polymarket_active_flag(self) -> None:
+        _, diag = resolve_deployment("neutral", polymarket_signal=1.0, max_pm_tilt=0.03)
+        assert diag["polymarket_active"] is True
+
+    # Band clamping
+    def test_clamped_to_upper_band(self) -> None:
+        # risk_on (0.95) + large positive tilt should not exceed 0.95 (hi of default band)
+        dep, diag = resolve_deployment("risk_on", polymarket_signal=1.0, max_pm_tilt=0.10)
+        assert dep <= 0.95 + 1e-9
+
+    def test_clamped_to_lower_band(self) -> None:
+        # risk_off (0.85) + large negative tilt should not go below 0.85 (lo of default band)
+        dep, diag = resolve_deployment("risk_off", polymarket_signal=-1.0, max_pm_tilt=0.10)
+        assert dep >= 0.85 - 1e-9
+
+    def test_custom_band(self) -> None:
+        dep, _ = resolve_deployment("risk_on", band=(0.70, 0.80))
+        assert dep == pytest.approx(0.80)
+
+    # dial_diag keys
+    def test_dial_diag_keys_present(self) -> None:
+        _, diag = resolve_deployment("neutral", polymarket_signal=0.5, max_pm_tilt=0.02)
+        required = {
+            "regime",
+            "base_deployment",
+            "polymarket_signal",
+            "polymarket_tilt",
+            "polymarket_active",
+            "final_deployment",
+        }
+        assert required <= set(diag.keys())
+
+    def test_dial_diag_signal_preserved(self) -> None:
+        _, diag = resolve_deployment("neutral", polymarket_signal=0.5)
+        assert diag["polymarket_signal"] == 0.5
+
+    def test_dial_diag_regime_preserved(self) -> None:
+        _, diag = resolve_deployment("risk_off")
+        assert diag["regime"] == "risk_off"
+
+    # Consistency: base_deployment matches regime_deployment
+    def test_base_deployment_matches_regime_fn(self) -> None:
+        for regime in ("risk_off", "neutral", "risk_on"):
+            _, diag = resolve_deployment(regime)
+            assert diag["base_deployment"] == pytest.approx(regime_deployment(regime))

--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -125,6 +125,7 @@ def test_conviction_tilt_higher_conviction_gets_more_weight_equal_vol():
         usd_bloc_cap=1.0,
         gross_target=1.0,
         cvar_budget=10.0,
+        vol_ceiling=10.0,  # neutralize the Phase 5A vol lever; this test is about the tilt
     )
     w = res["weights"]
     assert w["A"] > w["B"]  # higher conviction -> larger weight
@@ -142,6 +143,7 @@ def test_high_conviction_high_vol_name_is_not_the_smallest():
         "usd_bloc_cap": 1.0,
         "gross_target": 1.0,
         "cvar_budget": 10.0,
+        "vol_ceiling": 10.0,  # neutralize the Phase 5A vol lever; this test is about the tilt
     }
     erc_only = build_portfolio(scored, pd.DataFrame(), conviction_weight=0.0, **kw)
     tilted = build_portfolio(scored, pd.DataFrame(), conviction_weight=0.5, **kw)
@@ -154,10 +156,16 @@ def test_high_conviction_high_vol_name_is_not_the_smallest():
 
 
 def test_conviction_weight_zero_reproduces_pure_erc():
-    """conviction_weight=0 must reproduce the pure ERC -> caps -> deploy path."""
+    """conviction_weight=0 must reproduce the pure ERC -> caps -> deploy -> GATE path.
+
+    Phase 5A: build_portfolio now returns the risk-GATED book, so the manual
+    reconstruction feeds its ERC->caps->deploy result through the same
+    apply_risk_gate to match. This keeps the binding caps AND the λ=0 ERC intent.
+    """
     from trade_modules.riskfirst.construct import apply_name_cap, cap_groups, erc_weights
     from trade_modules.riskfirst.fx import USD_BLOC, cap_bloc, currency_of
     from trade_modules.v3.construct import _make_cov_fn
+    from trade_modules.v3.risk_gate import apply_risk_gate
 
     scored = _make_scored()
     prices = _make_prices(_ALL, seed=21)
@@ -194,7 +202,23 @@ def test_conviction_weight_zero_reproduces_pure_erc():
     scale = min(gt / gross_risk, 1.0) if gross_risk > 0 else 0.0
     w = w * scale
 
-    np.testing.assert_allclose(res["weights"].loc[selected].to_numpy(), w, rtol=1e-9, atol=1e-12)
+    # Phase 5A: build_portfolio returns the GATED book — apply the same gate here.
+    betas_sel = pd.to_numeric(sub["beta"], errors="coerce").fillna(1.0).to_numpy()
+    gated, _ = apply_risk_gate(
+        pd.Series(w, index=selected),
+        np.asarray(cov, dtype=float),
+        sectors=sub["SECTOR"].astype(str).to_numpy(),
+        currencies=[currency_of(t) for t in selected],
+        betas=betas_sel,
+        vol_ceiling=0.18,
+        name_cap=name_cap,
+        sector_cap=sector_cap,
+        usd_bloc_cap=usd_cap,
+    )
+
+    np.testing.assert_allclose(
+        res["weights"].loc[selected].to_numpy(), gated.to_numpy(), rtol=1e-9, atol=1e-12
+    )
 
 
 def test_all_nonpositive_conviction_falls_back_to_uniform():

--- a/tests/unit/trade_modules/test_v3_full_report.py
+++ b/tests/unit/trade_modules/test_v3_full_report.py
@@ -1,0 +1,109 @@
+"""TDD tests for scripts.v3_full_report pure helpers + synthetic preview.
+
+Covers:
+  - load_account_json: parses the {"nav", "weights"} schema; nav null → None;
+    missing file → (empty, None, present=False); env-var resolution.
+  - resolve_current_weights: live account passthrough; equal-split fallback
+    when the account file is absent (approx flag set).
+  - build_synthetic_preview_html: network-free full render containing the exec
+    panel, every action group, factor cards, no literal None, zero em-dashes.
+"""
+
+import json
+
+import pandas as pd
+
+from scripts.v3_full_report import (
+    build_synthetic_preview_html,
+    load_account_json,
+    resolve_current_weights,
+)
+
+# ---------------------------------------------------------------------------
+# load_account_json
+# ---------------------------------------------------------------------------
+
+
+def test_load_account_json_parses_schema(tmp_path):
+    p = tmp_path / "acct.json"
+    p.write_text(json.dumps({"nav": 123456.7, "weights": {"AAPL": 0.25, "MSFT": 0.1}}))
+    weights, nav, present = load_account_json(str(p))
+    assert present is True
+    assert nav == 123456.7
+    assert set(weights.index) == {"AAPL", "MSFT"}
+    assert weights["AAPL"] == 0.25
+    assert weights["MSFT"] == 0.1
+
+
+def test_load_account_json_null_nav(tmp_path):
+    p = tmp_path / "acct.json"
+    p.write_text(json.dumps({"nav": None, "weights": {"AAPL": 1.0}}))
+    weights, nav, present = load_account_json(str(p))
+    assert present is True
+    assert nav is None
+    assert weights["AAPL"] == 1.0
+
+
+def test_load_account_json_missing_file():
+    weights, nav, present = load_account_json("/nonexistent/path/does-not-exist.json")
+    assert present is False
+    assert nav is None
+    assert weights.empty
+
+
+def test_load_account_json_env_var(tmp_path, monkeypatch):
+    p = tmp_path / "env_acct.json"
+    p.write_text(json.dumps({"nav": 5000.0, "weights": {"NVDA": 0.5}}))
+    monkeypatch.setenv("V3_ACCOUNT_JSON", str(p))
+    weights, nav, present = load_account_json()  # no explicit path → env resolution
+    assert present is True
+    assert nav == 5000.0
+    assert weights["NVDA"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# resolve_current_weights
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_current_weights_live_passthrough():
+    acct = pd.Series({"AAPL": 0.3, "MSFT": 0.2})
+    weights, approx = resolve_current_weights(["AAPL", "MSFT"], acct, account_present=True)
+    assert approx is False
+    assert weights.equals(acct)
+
+
+def test_resolve_current_weights_equal_split_fallback():
+    weights, approx = resolve_current_weights(
+        ["AAA", "BBB", "CCC", "AAA"], pd.Series(dtype=float), account_present=False
+    )
+    assert approx is True
+    # dedup → 3 names, equal split
+    assert set(weights.index) == {"AAA", "BBB", "CCC"}
+    assert abs(weights.sum() - 1.0) < 1e-9
+    assert abs(weights["AAA"] - 1.0 / 3.0) < 1e-9
+
+
+def test_resolve_current_weights_empty_account_falls_back():
+    """account_present=True but empty weights → still equal-split fallback."""
+    weights, approx = resolve_current_weights(
+        ["X", "Y"], pd.Series(dtype=float), account_present=True
+    )
+    assert approx is True
+    assert set(weights.index) == {"X", "Y"}
+
+
+# ---------------------------------------------------------------------------
+# synthetic preview
+# ---------------------------------------------------------------------------
+
+
+def test_build_synthetic_preview_is_complete():
+    html = build_synthetic_preview_html()
+    assert html.startswith("<!DOCTYPE") and "</html>" in html
+    assert '<div class="exec-panel">' in html
+    for cls in ("buy", "add", "trim", "sell", "hold"):
+        assert f"act-grp act-grp--{cls}" in html, f"missing action group: {cls}"
+    assert '<article class="card"' in html
+    assert "None" not in html
+    assert "—" not in html

--- a/tests/unit/trade_modules/test_v3_ic_logger.py
+++ b/tests/unit/trade_modules/test_v3_ic_logger.py
@@ -1,0 +1,318 @@
+"""TDD tests for scripts.v3_ic_logger pure helpers (Phase 5E).
+
+Covers:
+  - append_snapshot : idempotency (same date twice → 0 second time, no dup rows)
+  - forward_return_panel : correct fwd = close[date+h]/close[date] - 1 per ticker
+  - ic_from_log : positive mean_ic when conviction predicts forward return
+  - ic_from_log : near-zero mean_ic on noise (independent signal)
+  - ic_from_log : graceful insufficient-history marker when fewer dates than horizon
+
+No network calls — all synthetic in-memory / tmp-file data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.v3_ic_logger import append_snapshot, forward_return_panel, ic_from_log
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic log builders
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_log() -> pd.DataFrame:
+    """Three dates, two tickers, deterministic closes for exact arithmetic tests."""
+    return pd.DataFrame(
+        [
+            {
+                "date": "2026-01-01",
+                "ticker": "T00",
+                "conviction": 0.5,
+                "sector": "Tech",
+                "close": 100.0,
+            },
+            {
+                "date": "2026-01-01",
+                "ticker": "T01",
+                "conviction": -0.2,
+                "sector": "Tech",
+                "close": 200.0,
+            },
+            {
+                "date": "2026-01-02",
+                "ticker": "T00",
+                "conviction": 0.3,
+                "sector": "Tech",
+                "close": 102.0,
+            },
+            {
+                "date": "2026-01-02",
+                "ticker": "T01",
+                "conviction": 0.1,
+                "sector": "Tech",
+                "close": 196.0,
+            },
+            {
+                "date": "2026-01-03",
+                "ticker": "T00",
+                "conviction": -0.1,
+                "sector": "Tech",
+                "close": 105.0,
+            },
+            {
+                "date": "2026-01-03",
+                "ticker": "T01",
+                "conviction": 0.4,
+                "sector": "Tech",
+                "close": 198.0,
+            },
+        ]
+    )
+
+
+def _make_predictive_log(
+    n_dates: int, n_tickers: int, noise_scale: float, seed: int
+) -> pd.DataFrame:
+    """Time-series log where conviction[d][t] predicts next-day log-return.
+
+    Daily return for ticker t on day d:
+        r[d][t] = conviction[d][t] * 0.05 + N(0, noise_scale)
+
+    Prices are cumulative products of (1 + r).  A low noise_scale → high IC.
+    """
+    rng = np.random.default_rng(seed)
+    n_total = n_dates + 10  # extra future dates for higher horizons
+    tickers = [f"T{t:02d}" for t in range(n_tickers)]
+    dates = [f"2026-01-{d + 1:02d}" for d in range(n_total)]
+
+    convictions = rng.standard_normal((n_total, n_tickers))
+    prices = np.ones((n_total, n_tickers)) * 100.0
+    for d in range(1, n_total):
+        ret = convictions[d - 1] * 0.05 + rng.standard_normal(n_tickers) * noise_scale
+        prices[d] = prices[d - 1] * (1 + ret)
+
+    rows = []
+    for d_idx in range(n_total):
+        for t_idx, ticker in enumerate(tickers):
+            rows.append(
+                {
+                    "date": dates[d_idx],
+                    "ticker": ticker,
+                    "conviction": convictions[d_idx, t_idx],
+                    "sector": "Technology",
+                    "close": float(prices[d_idx, t_idx]),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _make_noise_log(n_dates: int, n_tickers: int, seed: int) -> pd.DataFrame:
+    """Log where conviction and forward return are independent (pure noise)."""
+    rng = np.random.default_rng(seed)
+    n_total = n_dates + 10
+    tickers = [f"T{t:02d}" for t in range(n_tickers)]
+    dates = [f"2026-01-{d + 1:02d}" for d in range(n_total)]
+
+    rows = []
+    prices = np.ones((n_total, n_tickers)) * 100.0
+    for d in range(1, n_total):
+        # returns independent of convictions
+        prices[d] = prices[d - 1] * (1 + rng.standard_normal(n_tickers) * 0.02)
+
+    for d_idx in range(n_total):
+        for t_idx, ticker in enumerate(tickers):
+            rows.append(
+                {
+                    "date": dates[d_idx],
+                    "ticker": ticker,
+                    "conviction": rng.standard_normal(),  # independent signal
+                    "sector": "Technology",
+                    "close": float(prices[d_idx, t_idx]),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _scored_frame(n: int = 4) -> pd.DataFrame:
+    """Minimal scored DataFrame matching what compute_scores returns for eligible names."""
+    return pd.DataFrame(
+        {
+            "conviction": [0.8, -0.3, 1.1, 0.0],
+            "sector": ["Tech", "Finance", "Energy", "Health"],
+            "price": [100.0, 200.0, 50.0, 75.0],
+        },
+        index=[f"TKR{i}" for i in range(n)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# append_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestAppendSnapshot:
+    def test_first_append_returns_row_count(self, tmp_path):
+        log_path = tmp_path / "log.csv"
+        scored = _scored_frame()
+        n = append_snapshot(str(log_path), "2026-07-01", scored)
+        assert n == len(scored)
+
+    def test_idempotent_same_date_returns_zero(self, tmp_path):
+        log_path = tmp_path / "log.csv"
+        scored = _scored_frame()
+        append_snapshot(str(log_path), "2026-07-01", scored)
+        n2 = append_snapshot(str(log_path), "2026-07-01", scored)
+        assert n2 == 0
+
+    def test_no_duplicate_rows_after_two_calls(self, tmp_path):
+        log_path = tmp_path / "log.csv"
+        scored = _scored_frame()
+        append_snapshot(str(log_path), "2026-07-01", scored)
+        append_snapshot(str(log_path), "2026-07-01", scored)
+        df = pd.read_csv(log_path)
+        assert len(df) == len(scored)
+        assert list(df["date"].unique()) == ["2026-07-01"]
+
+    def test_different_dates_both_appended(self, tmp_path):
+        log_path = tmp_path / "log.csv"
+        scored = _scored_frame()
+        n1 = append_snapshot(str(log_path), "2026-07-01", scored)
+        n2 = append_snapshot(str(log_path), "2026-07-02", scored)
+        assert n1 == len(scored)
+        assert n2 == len(scored)
+        df = pd.read_csv(log_path)
+        assert len(df) == 2 * len(scored)
+
+    def test_log_schema_correct(self, tmp_path):
+        """CSV must have exactly the five schema columns."""
+        log_path = tmp_path / "log.csv"
+        append_snapshot(str(log_path), "2026-07-01", _scored_frame())
+        df = pd.read_csv(log_path)
+        assert set(df.columns) == {"date", "ticker", "conviction", "sector", "close"}
+
+    def test_close_sourced_from_price_column(self, tmp_path):
+        log_path = tmp_path / "log.csv"
+        scored = pd.DataFrame(
+            {"conviction": [0.5], "sector": ["Tech"], "price": [123.45]},
+            index=["XYZ"],
+        )
+        append_snapshot(str(log_path), "2026-07-01", scored)
+        df = pd.read_csv(log_path)
+        assert pytest.approx(df.loc[0, "close"], rel=1e-6) == 123.45
+
+    def test_creates_parent_dir_if_missing(self, tmp_path):
+        log_path = tmp_path / "deep" / "nested" / "log.csv"
+        n = append_snapshot(str(log_path), "2026-07-01", _scored_frame())
+        assert n > 0
+        assert log_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# forward_return_panel
+# ---------------------------------------------------------------------------
+
+
+class TestForwardReturnPanel:
+    def test_correct_forward_returns_h1(self):
+        log = _make_simple_log()
+        panel = forward_return_panel(log, horizon=1)
+
+        # T00: 2026-01-01 close=100, next=102 → fwd = 0.02
+        row_t00_d1 = panel[(panel["signal_date"] == "2026-01-01") & (panel["ticker"] == "T00")]
+        assert len(row_t00_d1) == 1
+        assert pytest.approx(row_t00_d1.iloc[0]["forward_return"], rel=1e-6) == 0.02
+
+        # T01: 2026-01-01 close=200, next=196 → fwd = -0.02
+        row_t01_d1 = panel[(panel["signal_date"] == "2026-01-01") & (panel["ticker"] == "T01")]
+        assert len(row_t01_d1) == 1
+        assert pytest.approx(row_t01_d1.iloc[0]["forward_return"], rel=1e-6) == -0.02
+
+    def test_correct_forward_returns_h2(self):
+        log = _make_simple_log()
+        panel = forward_return_panel(log, horizon=2)
+
+        # T00: 2026-01-01 close=100, date+2 close=105 → fwd = 0.05
+        row = panel[(panel["signal_date"] == "2026-01-01") & (panel["ticker"] == "T00")]
+        assert len(row) == 1
+        assert pytest.approx(row.iloc[0]["forward_return"], rel=1e-6) == 0.05
+
+    def test_empty_when_horizon_exceeds_dates(self):
+        log = _make_simple_log()
+        panel = forward_return_panel(log, horizon=5)
+        assert panel.empty
+
+    def test_columns_present(self):
+        log = _make_simple_log()
+        panel = forward_return_panel(log, horizon=1)
+        assert set(panel.columns) >= {"signal_date", "ticker", "conviction", "forward_return"}
+
+    def test_conviction_carried_from_signal_date(self):
+        log = _make_simple_log()
+        panel = forward_return_panel(log, horizon=1)
+        # conviction at 2026-01-01 for T00 is 0.5
+        row = panel[(panel["signal_date"] == "2026-01-01") & (panel["ticker"] == "T00")]
+        assert pytest.approx(row.iloc[0]["conviction"], rel=1e-6) == 0.5
+
+    def test_no_nan_in_forward_return(self):
+        log = _make_simple_log()
+        panel = forward_return_panel(log, horizon=1)
+        assert panel["forward_return"].notna().all()
+
+
+# ---------------------------------------------------------------------------
+# ic_from_log
+# ---------------------------------------------------------------------------
+
+
+class TestIcFromLog:
+    def test_positive_mean_ic_on_predictive_log(self):
+        """When conviction predicts forward return, mean IC should be positive."""
+        log = _make_predictive_log(n_dates=30, n_tickers=40, noise_scale=0.002, seed=99)
+        results = ic_from_log(log, horizons=(1,))
+        r = results[1]
+        assert "insufficient_history" not in r, f"Got insufficient_history: {r}"
+        assert r["mean_ic"] is not None
+        assert r["mean_ic"] > 0.1, f"Expected positive IC, got {r['mean_ic']:.4f}"
+
+    def test_near_zero_mean_ic_on_noise_log(self):
+        """Independent conviction and returns → IC centred on zero."""
+        log = _make_noise_log(n_dates=40, n_tickers=40, seed=7)
+        results = ic_from_log(log, horizons=(1,))
+        r = results[1]
+        # Can be None if no dates qualified — both None and ~0 are acceptable
+        if r.get("mean_ic") is not None:
+            assert abs(r["mean_ic"]) < 0.25, f"Noise IC unexpectedly large: {r['mean_ic']:.4f}"
+
+    def test_insufficient_history_marker(self):
+        """Horizons needing more dates than available get the graceful marker."""
+        # Only 3 distinct dates → horizon=5 is insufficient (need at least 6)
+        log = _make_simple_log()  # 3 dates
+        results = ic_from_log(log, horizons=(5, 10))
+        for h in (5, 10):
+            assert results[h].get("insufficient_history") is True, (
+                f"Expected insufficient_history for horizon={h}, got {results[h]}"
+            )
+
+    def test_returns_dict_keyed_by_horizon(self):
+        log = _make_predictive_log(n_dates=15, n_tickers=20, noise_scale=0.005, seed=1)
+        results = ic_from_log(log, horizons=(1, 2, 5))
+        assert set(results.keys()) == {1, 2, 5}
+
+    def test_sufficient_history_gives_ic_result(self):
+        """With enough dates, the result dict has the standard IC keys."""
+        log = _make_predictive_log(n_dates=20, n_tickers=20, noise_scale=0.005, seed=42)
+        results = ic_from_log(log, horizons=(1,))
+        r = results[1]
+        if "insufficient_history" not in r:
+            assert "mean_ic" in r
+            assert "n_dates" in r
+
+    def test_horizon_with_zero_dates_logged(self):
+        """Empty log → all horizons get insufficient_history."""
+        empty = pd.DataFrame(columns=["date", "ticker", "conviction", "sector", "close"])
+        results = ic_from_log(empty, horizons=(1, 5))
+        for h in (1, 5):
+            assert results[h].get("insufficient_history") is True

--- a/tests/unit/trade_modules/test_v3_portfolio.py
+++ b/tests/unit/trade_modules/test_v3_portfolio.py
@@ -11,7 +11,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.v3_portfolio import DEPLOYMENT_BY_REGIME, build_target_rows, trend_regime
+from scripts.v3_portfolio import build_target_rows, trend_regime
+from trade_modules.v3.conditioning import DEPLOYMENT_BY_REGIME
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/trade_modules/test_v3_report.py
+++ b/tests/unit/trade_modules/test_v3_report.py
@@ -406,3 +406,56 @@ def test_render_actions_only_partial_provision():
     assert "act-grp act-grp--buy" in html
     assert '<div class="exec-panel">' not in html
     assert html.startswith("<!DOCTYPE")
+
+
+def test_exec_panel_deployed_cvar_uses_post_gate_value():
+    """CVaR-95 deployed tile shows post-gate cvar_after, not pre-gate cvar_95_deployed.
+
+    When a vol lever fires, gate["cvar_after"] reflects the gated portfolio vol and
+    is the only internally consistent companion to the "Portfolio vol" tile (which also
+    uses gate["vol_after"]).  The pre-gate diag["cvar_95_deployed"] overstates the
+    actually-gated book and must be suppressed.
+    """
+    from trade_modules.v3.report import _exec_panel
+
+    # Pre-gate: 15 % → would display "15.0%".  Post-gate: 10 % → should display "10.0%".
+    # Risk-book CVaR (gross = 1.0): 20 % → must remain unchanged at "20.0%".
+    portfolio = {
+        "gross": 0.85,
+        "cash": 0.15,
+        "usd_bloc": 0.85,
+        "sector_exposures": {"Technology": 0.85},
+        "diagnostics": {
+            "cvar_95_risk_book": 0.20,
+            "cvar_95_deployed": 0.15,  # pre-gate — must NOT appear in the deployed tile
+            "net_beta": 0.70,
+            "net_beta_band": (0.3, 1.1),
+            "binding": {},
+            "gate": {
+                "vol_after": 0.08,
+                "vol_ceiling": 0.18,
+                "net_beta": 0.70,
+                "net_beta_band": (0.3, 1.1),
+                "net_beta_out": False,
+                "effective_bets": 8.0,
+                "min_effective_bets": 3.0,
+                "caps_ok": True,
+                "max_name": 0.15,
+                "max_sector": 0.25,
+                "usd_bloc": 0.50,
+                "cvar_after": 0.10,  # post-gate — must appear in the deployed tile
+                "levers_fired": ["tail_deweight"],
+                "gross_cut": False,
+            },
+        },
+    }
+
+    html = _exec_panel(portfolio, None, {"regime": "NEUTRAL"})
+
+    # Post-gate value must appear (displayed via _pct1: 0.10 → "10.0%").
+    assert "10.0%" in html, "post-gate cvar_after not rendered in deployed-CVaR tile"
+    # Pre-gate value must NOT appear in the deployed tile (risk-book uses 20.0%,
+    # so 15.0% uniquely identifies the pre-gate deployed figure — it must be gone).
+    assert "15.0%" not in html, "pre-gate cvar_95_deployed leaked into deployed-CVaR tile"
+    # Risk-book tile must be unchanged (20.0% still present).
+    assert "20.0%" in html, "risk-book CVaR tile was incorrectly modified"

--- a/tests/unit/trade_modules/test_v3_report.py
+++ b/tests/unit/trade_modules/test_v3_report.py
@@ -287,3 +287,122 @@ def test_render_card_shows_description():
     assert "Microsoft develops software" in html
     # ZZZ has empty description → no empty desc div should pollute the card
     assert 'class="desc">' not in html.split("ZED CORP")[1].split("Energy")[0]
+
+
+# ---------------------------------------------------------------------------
+# Phase 5D — fully-wired report (exec/risk panel + suggested actions)
+# ---------------------------------------------------------------------------
+
+
+def _pac():
+    """A real portfolio + actions + conditioning triple, network-free.
+
+    Uses the actual construct/actions/conditioning pipeline (empty prices →
+    single-factor beta covariance) so the report renders the genuine payload
+    schema.  Current weights are crafted to force ALL FIVE action groups.
+    """
+    from trade_modules.v3.actions import build_actions
+    from trade_modules.v3.conditioning import resolve_deployment
+    from trade_modules.v3.construct import build_portfolio
+
+    scores = _many_scores(n=24, n_port=6)
+    price = scores["price"].to_numpy()
+    scores["entry"] = price
+    scores["stop_loss"] = price * 0.90
+    scores["take_profit"] = price * 1.15
+    scores["rr"] = 1.5
+
+    result = build_portfolio(scores, pd.DataFrame(), top_n=12)
+    target = result["weights"]
+    invested = list(target[target > 1e-6].index)
+    assert len(invested) >= 4, "need enough invested names to exercise all groups"
+
+    cur: dict[str, float] = {}
+    cur[invested[0]] = max(float(target[invested[0]]) - 0.03, 0.001)  # ADD (target >> current)
+    cur[invested[1]] = float(target[invested[1]]) + 0.05  # TRIM (current > target)
+    cur[invested[2]] = float(target[invested[2]])  # HOLD (equal)
+    # invested[3:] absent from current → BUY
+    cur["GHOSTX"] = 0.04  # SELL (held, not in target, not in scores → enriched None)
+    current = pd.Series(cur, dtype=float)
+
+    actions = build_actions(target, current, scores, nav=250_000.0)
+    _, cond = resolve_deployment("neutral")
+    return scores, result, actions, cond
+
+
+def test_render_with_portfolio_actions_is_well_formed():
+    scores, result, actions, cond = _pac()
+    html = render_report(scores, _meta(), portfolio=result, actions=actions, conditioning=cond)
+    assert html.startswith("<!DOCTYPE") and "</html>" in html
+    assert html.count("<html") == 1
+
+
+def test_render_shows_exec_panel_and_summary():
+    scores, result, actions, cond = _pac()
+    html = render_report(scores, _meta(), portfolio=result, actions=actions, conditioning=cond)
+    assert 'class="exec-panel"' in html  # (a) executive / risk panel
+    assert 'class="exec-summary"' in html  # top one-line executive summary
+    assert "Positioning and Risk" in html  # panel section title
+    # risk stat labels present
+    assert "Deployment" in html
+    assert "CVaR" in html
+
+
+def test_render_shows_all_action_groups_and_note():
+    scores, result, actions, cond = _pac()
+    html = render_report(scores, _meta(), portfolio=result, actions=actions, conditioning=cond)
+    for cls in ("buy", "add", "trim", "sell", "hold"):
+        assert f"act-grp act-grp--{cls}" in html, f"missing action group: {cls}"
+    assert "Suggested Actions" in html
+    # decision-support disclaimer (no em-dash)
+    assert "Decision-support" in html
+    assert "not auto-executed" in html
+
+
+def test_render_factor_cards_still_present_below():
+    scores, result, actions, cond = _pac()
+    html = render_report(scores, _meta(), portfolio=result, actions=actions, conditioning=cond)
+    # existing factor cards + overview still rendered
+    assert '<article class="card"' in html
+    assert "Overview" in html
+    # exec/actions come ABOVE the overview heatmap
+    assert html.index("Suggested Actions") < html.index(">Overview<")
+
+
+def test_render_with_data_has_no_literal_none_or_emdash():
+    scores, result, actions, cond = _pac()
+    html = render_report(scores, _meta(), portfolio=result, actions=actions, conditioning=cond)
+    assert "None" not in html  # None-valued fields (e.g. SELL ghost name) never leak
+    assert "—" not in html  # zero em-dashes
+
+
+def test_render_backward_compatible_when_new_params_none():
+    """Passing the new params as None must reproduce the current output byte-for-byte."""
+    scores = _scores()
+    base = render_report(scores, _meta())
+    with_none = render_report(scores, _meta(), portfolio=None, actions=None, conditioning=None)
+    assert base == with_none
+    # and none of the new SECTIONS render in the legacy output (CSS class names
+    # always live in the stylesheet, so assert on rendered elements/titles)
+    assert '<div class="exec-panel">' not in base
+    assert "act-grp act-grp--buy" not in base
+    assert '<div class="exec-summary">' not in base
+    assert "Positioning and Risk" not in base
+    assert "Suggested Actions" not in base
+
+
+def test_render_approx_current_weights_note():
+    scores, result, actions, cond = _pac()
+    meta = dict(_meta())
+    meta["current_weights_approx"] = True
+    html = render_report(scores, meta, portfolio=result, actions=actions, conditioning=cond)
+    assert "approximate" in html.lower()
+
+
+def test_render_actions_only_partial_provision():
+    """Actions provided but portfolio None: actions section renders, exec panel does not."""
+    scores, _result, actions, _cond = _pac()
+    html = render_report(scores, _meta(), actions=actions)
+    assert "act-grp act-grp--buy" in html
+    assert '<div class="exec-panel">' not in html
+    assert html.startswith("<!DOCTYPE")

--- a/tests/unit/trade_modules/test_v3_risk_gate.py
+++ b/tests/unit/trade_modules/test_v3_risk_gate.py
@@ -239,7 +239,7 @@ def test_respects_max_iter_no_hang():
 def test_net_beta_reported_and_flagged():
     cov = _cov(np.full(6, 0.12), corr=0.1)
     w = _series(np.full(6, 0.90 / 6))
-    betas = [1.8] * 6  # high-beta book (net beta ~ 0.9*1.8 = 1.62 > band hi)
+    betas = [1.8] * 6  # high-beta book (net beta on proportions = 1.8 > band hi)
     gated, diag = apply_risk_gate(
         w,
         cov,

--- a/tests/unit/trade_modules/test_v3_risk_gate.py
+++ b/tests/unit/trade_modules/test_v3_risk_gate.py
@@ -1,0 +1,298 @@
+"""TDD tests for trade_modules.v3.risk_gate.apply_risk_gate (Phase 5A).
+
+The HARD risk gate enforces (blocking) a portfolio vol ceiling and the
+concentration caps on an already-constructed book, using the owner's HYBRID
+rule:
+
+  1. caps-to-convergence — iterate name / USD-bloc / sector caps until no cap is
+     left breached;
+  2. vol ceiling via tail de-weighting (lever 1) — de-weight the worst
+     tail-risk names first, keeping deployment constant;
+  3. gross cut (lever 2, fallback) — only if de-weighting is exhausted, scale the
+     whole book down so vol == ceiling (deployment drops below target).
+
+These tests pin the enforcement contract, the lever order, cap convergence, the
+identity behaviour on a compliant book, and loop termination.
+"""
+
+import numpy as np
+import pandas as pd
+
+from trade_modules.riskfirst.construct import portfolio_vol
+from trade_modules.v3.risk_gate import apply_risk_gate
+
+_TOL = 1e-6
+
+
+def _cov(vols, corr=0.0):
+    """Annualised covariance from per-name vols and a common pairwise corr."""
+    vols = np.asarray(vols, dtype=float)
+    n = len(vols)
+    C = np.full((n, n), float(corr))
+    np.fill_diagonal(C, 1.0)
+    return np.outer(vols, vols) * C
+
+
+def _series(vals, prefix="T"):
+    vals = np.asarray(vals, dtype=float)
+    return pd.Series(vals, index=[f"{prefix}{i}" for i in range(len(vals))])
+
+
+def _sector_props(sectors, p):
+    tot: dict = {}
+    for lab, wt in zip(sectors, p, strict=True):
+        tot[lab] = tot.get(lab, 0.0) + float(wt)
+    return tot
+
+
+# --------------------------------------------------------------------------- #
+# (a) vol ceiling enforced (tail de-weighting)
+# --------------------------------------------------------------------------- #
+
+
+def test_vol_ceiling_enforced_after_gate():
+    """A book with a few very-high-vol names is pulled to/under the ceiling.
+
+    Weight is concentrated in the hot names (the 0.90 gross means absolute book
+    vol = 0.90 x proportional vol, so an equal-weight book would be too calm).
+    """
+    vols = np.array([0.70, 0.70, 0.70] + [0.12] * 9)
+    cov = _cov(vols, corr=0.1)
+    w = pd.Series([0.18, 0.18, 0.18] + [0.04] * 9, index=[f"T{i}" for i in range(12)])
+    assert abs(w.sum() - 0.90) < 1e-12
+    sectors = ["A"] * 4 + ["B"] * 4 + ["C"] * 4
+    currencies = ["EUR"] * 12
+
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=sectors,
+        currencies=currencies,
+        vol_ceiling=0.18,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+    )
+    assert diag["vol_before"] > 0.18
+    assert portfolio_vol(gated.to_numpy(), cov) <= 0.18 + _TOL
+    assert diag["vol_after"] <= 0.18 + _TOL
+    assert "tail_deweight" in diag["levers_fired"]
+    # gated book keeps the same index/order.
+    assert list(gated.index) == list(w.index)
+
+
+# --------------------------------------------------------------------------- #
+# (b) caps-to-convergence — no cap left breached
+# --------------------------------------------------------------------------- #
+
+
+def test_caps_to_convergence_all_within_tol():
+    """A book breaching the USD-bloc + sector caps ends fully cap-compliant.
+
+    15 names (11 USD + 4 EUR); TECH holds 5 names. At equal weight the USD bloc
+    (0.73) and the TECH sector (0.33) both breach; the caps are feasible (enough
+    names/sectors for redistribution) so convergence removes every breach and
+    keeps deployment at 0.90.
+    """
+    usd = [f"U{i}" for i in range(11)]
+    eur = [f"E{i}.DE" for i in range(4)]
+    tickers = usd + eur
+    currencies = ["USD"] * 11 + ["EUR"] * 4
+    sectors = ["TECH"] * 5 + ["FIN"] * 3 + ["ENE"] * 3 + ["UTL"] * 2 + ["MAT"] * 2
+    w = pd.Series(np.full(15, 0.90 / 15), index=tickers)
+    cov = _cov(np.full(15, 0.15), corr=0.2)  # calm -> vol lever inert
+
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=sectors,
+        currencies=currencies,
+        vol_ceiling=0.50,
+        name_cap=0.15,
+        sector_cap=0.25,
+        usd_bloc_cap=0.60,
+    )
+    p = gated / gated.sum()
+    assert p.max() <= 0.15 + _TOL
+    assert max(_sector_props(sectors, p).values()) <= 0.25 + _TOL
+    bloc = float(sum(wt for c, wt in zip(currencies, p, strict=True) if c in ("USD", "HKD")))
+    assert bloc <= 0.60 + _TOL
+    assert diag["caps_ok"] is True
+    assert "caps" in diag["levers_fired"]
+    assert diag["gross_cut"] is False  # calm book: no vol cut
+    assert abs(gated.sum() - 0.90) < _TOL  # feasible caps -> deployment preserved
+
+
+# --------------------------------------------------------------------------- #
+# (c) lever order — de-weight before gross cut
+# --------------------------------------------------------------------------- #
+
+
+def test_lever1_deweight_alone_preserves_deployment():
+    """Reducible by de-weighting -> gross_cut False, deployment (gross) unchanged."""
+    vols = [0.70, 0.65, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12]
+    cov = _cov(vols, corr=0.2)
+    w = pd.Series(
+        [0.35, 0.30, 0.05, 0.05, 0.05, 0.04, 0.03, 0.03], index=[f"T{i}" for i in range(8)]
+    )
+    assert abs(w.sum() - 0.90) < 1e-12
+
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=["S"] * 8,
+        currencies=["EUR"] * 8,
+        vol_ceiling=0.18,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+    )
+    assert diag["gross_cut"] is False
+    assert "tail_deweight" in diag["levers_fired"]
+    assert abs(gated.sum() - 0.90) < _TOL  # deployment preserved
+    assert portfolio_vol(gated.to_numpy(), cov) <= 0.18 + _TOL
+
+
+def test_lever2_gross_cut_when_deweight_exhausted():
+    """All-high-vol, high-corr book can't be de-weighted below the ceiling ->
+    gross cut fires, deployment drops, vol pinned to the ceiling."""
+    cov = _cov(np.full(8, 0.40), corr=0.6)
+    w = _series(np.full(8, 0.90 / 8), prefix="H")
+
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=["S"] * 8,
+        currencies=["EUR"] * 8,
+        vol_ceiling=0.18,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+    )
+    assert diag["gross_cut"] is True
+    assert "gross_cut" in diag["levers_fired"]
+    assert portfolio_vol(gated.to_numpy(), cov) <= 0.18 + _TOL
+    assert gated.sum() < 0.90 - _TOL  # deployment reduced below target
+    assert diag["gross_after"] < diag["gross_before"]
+
+
+# --------------------------------------------------------------------------- #
+# (d) already-compliant book -> gate is (near) identity
+# --------------------------------------------------------------------------- #
+
+
+def test_identity_when_within_all_limits():
+    cov = _cov(np.full(10, 0.12), corr=0.1)  # calm -> vol < ceiling
+    w = _series(np.full(10, 0.90 / 10))
+    sectors = [f"S{i % 5}" for i in range(10)]  # 5 sectors x 2 -> 18% each
+    currencies = ["EUR"] * 10
+
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=sectors,
+        currencies=currencies,
+        vol_ceiling=0.18,
+        name_cap=0.15,
+        sector_cap=0.25,
+        usd_bloc_cap=0.60,
+    )
+    np.testing.assert_allclose(gated.to_numpy(), w.to_numpy(), rtol=1e-9, atol=1e-12)
+    assert diag["levers_fired"] == []
+    assert diag["gross_cut"] is False
+    assert diag["caps_ok"] is True
+    assert abs(diag["gross_after"] - diag["gross_before"]) < 1e-12
+
+
+# --------------------------------------------------------------------------- #
+# (e) termination — loops respect max_iter (no hang) and lever 2 still binds
+# --------------------------------------------------------------------------- #
+
+
+def test_respects_max_iter_no_hang():
+    vols = np.array([0.60, 0.55, 0.50, 0.45, 0.40] + [0.20] * 5)
+    cov = _cov(vols, corr=0.3)
+    w = _series(np.full(10, 0.90 / 10))
+
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=["S"] * 10,
+        currencies=["EUR"] * 10,
+        vol_ceiling=0.15,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+        max_iter=5,
+    )
+    # The tail-deweight loop never exceeds max_iter ...
+    assert diag["iterations"] <= 5
+    # ... and the lever-2 fallback still guarantees the ceiling.
+    assert portfolio_vol(gated.to_numpy(), cov) <= 0.15 + _TOL
+
+
+# --------------------------------------------------------------------------- #
+# net-beta reporting + effective bets + degenerate input
+# --------------------------------------------------------------------------- #
+
+
+def test_net_beta_reported_and_flagged():
+    cov = _cov(np.full(6, 0.12), corr=0.1)
+    w = _series(np.full(6, 0.90 / 6))
+    betas = [1.8] * 6  # high-beta book (net beta ~ 0.9*1.8 = 1.62 > band hi)
+    gated, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=["S"] * 6,
+        currencies=["EUR"] * 6,
+        betas=betas,
+        vol_ceiling=1.0,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+    )
+    assert diag["net_beta"] > 1.1
+    assert diag["net_beta_out"] is True
+    # NaN beta -> coerced to 1.0 (no NaN leaks into net beta).
+    _, diag2 = apply_risk_gate(
+        w,
+        cov,
+        sectors=["S"] * 6,
+        currencies=["EUR"] * 6,
+        betas=[1.0, np.nan, 1.0, 1.0, 1.0, 1.0],
+        vol_ceiling=1.0,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+    )
+    assert not np.isnan(diag2["net_beta"])
+
+
+def test_effective_bets_on_gated_proportions():
+    cov = _cov(np.full(10, 0.12), corr=0.1)
+    w = _series(np.full(10, 0.90 / 10))
+    _, diag = apply_risk_gate(
+        w,
+        cov,
+        sectors=["S"] * 10,
+        currencies=["EUR"] * 10,
+        vol_ceiling=1.0,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+    )
+    # 10 equal names -> ~10 effective bets.
+    assert abs(diag["effective_bets"] - 10.0) < 1e-6
+
+
+def test_empty_book_is_safe():
+    gated, diag = apply_risk_gate(
+        pd.Series(dtype=float),
+        np.zeros((0, 0)),
+        sectors=[],
+        currencies=[],
+        vol_ceiling=0.18,
+    )
+    assert len(gated) == 0
+    assert diag["levers_fired"] == []
+    assert diag["gross_cut"] is False

--- a/trade_modules/v3/actions.py
+++ b/trade_modules/v3/actions.py
@@ -1,0 +1,140 @@
+"""v3 Phase 5C — PM construction: suggested actions vs live portfolio.
+
+Turns the risk-gated target book (from build_portfolio) plus the live portfolio
+weights into a per-ticker action list for DECISION-SUPPORT.  The user reviews
+the list and decides whether to execute.  This module does NOT trade.
+
+Pure function: no I/O, no network, no yahoofinance.core.config import.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# A ticker with weight below this threshold is considered "not held / not targeted".
+_EPSILON: float = 1e-6
+
+_BUY_ADD_ACTIONS: frozenset[str] = frozenset({"BUY", "ADD"})
+_TRIM_SELL_ACTIONS: frozenset[str] = frozenset({"TRIM", "SELL"})
+
+
+def _safe_get(row, col: str):
+    """Extract a column value from a scored row, returning None on NaN / missing."""
+    if row is None:
+        return None
+    val = row.get(col) if hasattr(row, "get") else getattr(row, col, None)
+    if val is None:
+        return None
+    try:
+        if pd.isna(val):
+            return None
+    except (TypeError, ValueError):
+        pass
+    return val
+
+
+def build_actions(
+    target_weights: pd.Series,
+    current_weights: pd.Series,
+    scored: pd.DataFrame,
+    *,
+    nav: float | None = None,
+    add_trim_threshold: float = 0.005,
+) -> list[dict]:
+    """Build per-ticker action list: BUY / ADD / TRIM / SELL / HOLD.
+
+    For every ticker in the UNION of ``target_weights`` and ``current_weights``,
+    emit one action dict.  Names where both target and current are zero (below
+    ``_EPSILON``) are silently skipped.
+
+    Action rules (epsilon = 1e-6):
+    - **BUY**:  target > epsilon AND current < epsilon.
+    - **SELL**: current > epsilon AND target < epsilon.
+    - **ADD**:  both > epsilon AND delta_pct > +add_trim_threshold.
+    - **TRIM**: both > epsilon AND delta_pct < -add_trim_threshold.
+    - **HOLD**: both > epsilon AND |delta_pct| <= add_trim_threshold.
+
+    Args:
+        target_weights: Risk-gated target allocation (fractions summing <= 1).
+            Indexed by ticker.  Zero-weight names may be absent.
+        current_weights: Current live allocation (fractions summing <= 1).
+            Indexed by ticker.  May be empty (e.g. portfolio.csv has no weight
+            column; the caller should pass equal weights over listed holdings as a
+            best-effort approximation in that case).
+        scored: Output of compute_scores — carries ``name``, ``sector``,
+            ``conviction``, ``price``, ``stop_loss``, ``take_profit`` columns
+            (indexed by ticker).  SELL names absent from scored get None for those
+            enriched fields.
+        nav: Total portfolio NAV in USD.  When provided,
+            ``delta_usd = delta_pct * nav``.  When ``None`` (portfolio.csv has no
+            per-position USD value column), ``delta_usd`` is ``None``.
+        add_trim_threshold: Minimum |delta_pct| required to escalate from HOLD to
+            ADD / TRIM.  Default 0.005 (0.5 pp).
+
+    Returns:
+        List of action dicts sorted:
+        **BUY + ADD** (by target_pct desc) → **TRIM + SELL** (by current_pct desc)
+        → **HOLD** (by target_pct desc).
+
+        Each dict has keys::
+
+            {ticker, name, sector, conviction, action, current_pct, target_pct,
+             delta_pct, delta_usd, price, stop_loss, take_profit}
+    """
+    all_tickers: set[str] = set(target_weights.index) | set(current_weights.index)
+
+    actions: list[dict] = []
+    for ticker in all_tickers:
+        target_pct = float(target_weights.get(ticker, 0.0))
+        current_pct = float(current_weights.get(ticker, 0.0))
+        delta_pct = target_pct - current_pct
+        delta_usd = float(delta_pct) * nav if nav is not None else None
+
+        in_target = target_pct > _EPSILON
+        in_current = current_pct > _EPSILON
+
+        if in_target and not in_current:
+            action = "BUY"
+        elif in_current and not in_target:
+            action = "SELL"
+        elif in_target and in_current:
+            if delta_pct > add_trim_threshold:
+                action = "ADD"
+            elif delta_pct < -add_trim_threshold:
+                action = "TRIM"
+            else:
+                action = "HOLD"
+        else:
+            # Both zero / sub-epsilon — ghost ticker, skip.
+            continue
+
+        row = scored.loc[ticker] if (scored is not None and ticker in scored.index) else None
+
+        actions.append(
+            {
+                "ticker": ticker,
+                "name": _safe_get(row, "name"),
+                "sector": _safe_get(row, "sector"),
+                "conviction": _safe_get(row, "conviction"),
+                "action": action,
+                "current_pct": current_pct,
+                "target_pct": target_pct,
+                "delta_pct": delta_pct,
+                "delta_usd": delta_usd,
+                "price": _safe_get(row, "price"),
+                "stop_loss": _safe_get(row, "stop_loss"),
+                "take_profit": _safe_get(row, "take_profit"),
+            }
+        )
+
+    # Sort: BUY+ADD (target_pct desc) → TRIM+SELL (current_pct desc) → HOLD
+    def _sort_key(item: dict) -> tuple:
+        act = item["action"]
+        if act in _BUY_ADD_ACTIONS:
+            return (0, -item["target_pct"])
+        if act in _TRIM_SELL_ACTIONS:
+            return (1, -item["current_pct"])
+        return (2, -item["target_pct"])  # HOLD
+
+    actions.sort(key=_sort_key)
+    return actions

--- a/trade_modules/v3/conditioning.py
+++ b/trade_modules/v3/conditioning.py
@@ -1,0 +1,115 @@
+"""v3 regime + Polymarket conditioning dials.
+
+Single source of truth for deployment fractions and the two conditioning
+adjustments (regime overlay + Polymarket tilt).  Imported by the v3_portfolio
+runner; Polymarket seam is inert by default (``max_tilt=0``).
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Regime → base deployment fraction
+# ---------------------------------------------------------------------------
+
+# Fraction of capital deployed by market regime (band 85-95%).
+# This is the SINGLE SOURCE OF TRUTH — imported back into v3_portfolio.py.
+DEPLOYMENT_BY_REGIME: dict[str, float] = {
+    "risk_off": 0.85,
+    "neutral": 0.90,
+    "risk_on": 0.95,
+}
+
+_UNKNOWN_DEPLOYMENT = DEPLOYMENT_BY_REGIME["neutral"]
+
+
+def regime_deployment(regime: str) -> float:
+    """Return the base deployment fraction for a regime string.
+
+    Unknown / missing regime labels fall back to neutral (0.90).
+
+    Args:
+        regime: One of ``"risk_off"``, ``"neutral"``, ``"risk_on"``.
+
+    Returns:
+        Deployment fraction in [0, 1].
+    """
+    return DEPLOYMENT_BY_REGIME.get(regime, _UNKNOWN_DEPLOYMENT)
+
+
+# ---------------------------------------------------------------------------
+# Polymarket tilt (shadow / zero-conviction seam)
+# ---------------------------------------------------------------------------
+
+
+def polymarket_adjustment(signal: float | None, *, max_tilt: float = 0.0) -> float:
+    """Return a bounded deployment tilt from a Polymarket signal.
+
+    Polymarket is a shadow / zero-conviction cross-repo signal.  The seam is
+    INERT by default: when ``max_tilt == 0`` (the default) this function
+    ALWAYS returns 0.0.  A nonzero ``max_tilt`` may only be passed after the
+    signal has been validated and explicitly enabled.
+
+    Args:
+        signal: Normalised Polymarket signal in [-1, 1] (or ``None`` when
+            unavailable).  Values outside [-1, 1] are clipped.
+        max_tilt: Maximum absolute deployment adjustment the signal may produce.
+            MUST be 0.0 (the default) while the signal is in shadow phase.
+
+    Returns:
+        Deployment tilt in ``[-max_tilt, +max_tilt]``; 0.0 when signal is
+        ``None`` or ``max_tilt == 0``.
+    """
+    if signal is None or max_tilt == 0.0:
+        return 0.0
+    clipped = max(-1.0, min(1.0, float(signal)))
+    return clipped * max_tilt
+
+
+# ---------------------------------------------------------------------------
+# Composite resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_deployment(
+    regime: str,
+    polymarket_signal: float | None = None,
+    *,
+    max_pm_tilt: float = 0.0,
+    band: tuple[float, float] = (0.85, 0.95),
+) -> tuple[float, dict]:
+    """Resolve the final deployment fraction and emit a diagnostic dict.
+
+    Combines the regime base with the (inert-by-default) Polymarket tilt and
+    clamps the result to ``band``.
+
+    Args:
+        regime: Market regime string (``"risk_off"`` / ``"neutral"`` /
+            ``"risk_on"``; unknown → neutral).
+        polymarket_signal: Normalised Polymarket signal in [-1, 1], or ``None``.
+            Ignored (zero effect) while ``max_pm_tilt == 0``.
+        max_pm_tilt: Maximum absolute Polymarket tilt.  MUST remain 0.0 (the
+            default) while the Polymarket signal is in shadow phase.
+        band: ``(lo, hi)`` clamping band for the final deployment fraction.
+
+    Returns:
+        ``(deployment, dial_diag)`` where:
+
+        - ``deployment`` is the clamped final fraction in ``band``.
+        - ``dial_diag`` is a diagnostic dict with keys
+          ``{regime, base_deployment, polymarket_signal, polymarket_tilt,
+          polymarket_active, final_deployment}``.
+    """
+    lo, hi = band
+    base = regime_deployment(regime)
+    tilt = polymarket_adjustment(polymarket_signal, max_tilt=max_pm_tilt)
+    deployment = max(lo, min(hi, base + tilt))
+
+    dial_diag: dict = {
+        "regime": regime,
+        "base_deployment": base,
+        "polymarket_signal": polymarket_signal,
+        "polymarket_tilt": tilt,
+        "polymarket_active": max_pm_tilt > 0.0,
+        "final_deployment": deployment,
+    }
+    return deployment, dial_diag

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -39,7 +39,7 @@ from trade_modules.riskfirst.construct import apply_name_cap, cap_groups, erc_we
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import USD_BLOC, cap_bloc, currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
-from trade_modules.v3.risk_gate import apply_risk_gate
+from trade_modules.v3.risk_gate import _Z_ES_95, apply_risk_gate
 
 # Exchange-suffix -> company domicile country, for dual-listing (mother-market)
 # dedup. A bare ticker (no suffix) or an unmapped suffix is treated as US.
@@ -61,8 +61,7 @@ _SUFFIX_COUNTRY = {
 }
 _HOME_COUNTRY = "United States"  # bare / unmapped suffix
 
-# Parametric-normal 95% Expected Shortfall multiplier: E[Z | Z > z_.95] = φ(1.645)/0.05.
-_Z_ES_95 = 2.063
+# _Z_ES_95 imported from risk_gate (single definition shared across both modules).
 # Report-only risk-gate thresholds.
 _BETA_BAND = (0.3, 1.1)
 _MIN_EFFECTIVE_BETS = 12

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -17,10 +17,14 @@ PRIMITIVES directly, so that conviction participates in sizing:
     (Change 2);
   * an empirical shrunk-covariance estimate from the supplied price history,
     falling back to a single-factor beta covariance whenever a selected name
-    lacks usable price history; and
-  * a report-only risk gate — parametric-normal CVaR(95%), net beta, and the
-    effective number of bets. It only sets flags; it never shrinks the book
-    (hard vol/CVaR enforcement is deferred to Phase 5).
+    lacks usable price history;
+  * a pre-gate report-only assessment — parametric-normal CVaR(95%), net beta,
+    and the effective number of bets — kept for oversight (it only sets flags);
+    and
+  * a Phase 5A HARD risk gate (:mod:`trade_modules.v3.risk_gate`) that ENFORCES
+    the vol ceiling and concentration caps on the deployed book (caps to
+    convergence -> tail de-weight to the ceiling -> gross-cut fallback). The
+    returned book is the gated book; ``diagnostics["gate"]`` holds its report.
 
 Pure orchestration: no network access and no ``yahoofinance.core.config``
 import (module-level or otherwise).
@@ -35,6 +39,7 @@ from trade_modules.riskfirst.construct import apply_name_cap, cap_groups, erc_we
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import USD_BLOC, cap_bloc, currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
+from trade_modules.v3.risk_gate import apply_risk_gate
 
 # Exchange-suffix -> company domicile country, for dual-listing (mother-market)
 # dedup. A bare ticker (no suffix) or an unmapped suffix is treated as US.
@@ -302,6 +307,7 @@ def build_portfolio(
     usd_bloc_cap: float = 0.60,
     gross_target: float = 0.90,
     cvar_budget: float = 0.25,
+    vol_ceiling: float = 0.18,
 ) -> dict:
     """Construct a risk-first book from a v3 scored frame + price history.
 
@@ -333,7 +339,17 @@ def build_portfolio(
             (85% risk_off / 90% neutral / 95% risk_on).
         cvar_budget: Annual parametric-normal CVaR(95%) ceiling for the risk
             book. A breach only sets ``binding["cvar"]`` — it NEVER shrinks the
-            book (hard vol/CVaR enforcement is deferred to Phase 5).
+            book (the CVaR flag stays report-only; hard VOL enforcement is done by
+            the Phase 5A gate below).
+        vol_ceiling: HARD annualised vol ceiling enforced by the Phase 5A risk
+            gate (:func:`trade_modules.v3.risk_gate.apply_risk_gate`). After the
+            conviction-tilt + caps + ``gross_target`` deployment, the book is run
+            through the gate, which (1) drives all caps to convergence, (2)
+            de-weights the worst tail-risk names until vol ≤ ceiling, and (3) as a
+            fallback cuts gross below ``gross_target`` if de-weighting is
+            exhausted. The RETURNED book is the GATED book; ``diagnostics["gate"]``
+            carries the gate report and ``diagnostics`` still keeps the pre-gate
+            assessment (``binding`` / ``port_vol`` / ``cvar_95_*``).
 
     Returns:
         ``{weights, gross, cash, usd_bloc, sector_exposures, selected,
@@ -485,8 +501,25 @@ def build_portfolio(
         },
     }
 
+    # --- Phase 5A: HARD risk gate (blocking enforcement) on the deployed book ---
+    # The diagnostics above are the PRE-gate assessment (report-only). The gate
+    # now ENFORCES the vol ceiling + caps: caps-to-convergence -> tail de-weight
+    # to the vol ceiling -> gross-cut fallback. The RETURNED book is the gated one.
+    gated_series, gate_diag = apply_risk_gate(
+        pd.Series(w_final, index=selected),
+        cov,
+        sectors=sub.reindex(selected)["SECTOR"].astype(str).to_numpy(),
+        currencies=[currency_of(t) for t in selected],
+        betas=betas_sel,
+        vol_ceiling=vol_ceiling,
+        name_cap=name_cap,
+        sector_cap=sector_cap,
+        usd_bloc_cap=usd_bloc_cap,
+    )
+    diagnostics["gate"] = gate_diag
+
     full = pd.Series(0.0, index=sub.index)
-    full.loc[selected] = w_final
+    full.loc[selected] = gated_series.to_numpy()
     gross = float(full.sum())
 
     usd_bloc = float(sum(v for t, v in full.items() if currency_of(t) in USD_BLOC))

--- a/trade_modules/v3/fetch.py
+++ b/trade_modules/v3/fetch.py
@@ -96,7 +96,6 @@ def robust_fetch_prices(
 
     chunks = [tickers[i : i + batch_size] for i in range(0, len(tickers), batch_size)]
     frames: list[pd.DataFrame] = []
-    skipped = 0
 
     for chunk_idx, batch in enumerate(chunks):
         success = False
@@ -114,15 +113,9 @@ def robust_fetch_prices(
                     time.sleep(backoff)
                 # On final attempt: fall through; success stays False
 
-        if not success:
-            skipped += len(batch)
-
         # Throttle between batches; skip sleep after the last chunk.
         if chunk_idx < len(chunks) - 1:
             time.sleep(pause)
-
-    if skipped:
-        pass  # caller can count via the absence of tickers in the result
 
     if not frames:
         return pd.DataFrame()

--- a/trade_modules/v3/fetch.py
+++ b/trade_modules/v3/fetch.py
@@ -98,20 +98,17 @@ def robust_fetch_prices(
     frames: list[pd.DataFrame] = []
 
     for chunk_idx, batch in enumerate(chunks):
-        success = False
         for attempt in range(retries + 1):  # initial try + up to `retries` retries
             try:
                 df = downloader(batch, period)
                 if isinstance(df, pd.Series):
                     df = df.to_frame(name=batch[0])
                 frames.append(df)
-                success = True
                 break
             except Exception:  # noqa: BLE001
                 if attempt < retries:
                     backoff = pause * (2**attempt)
                     time.sleep(backoff)
-                # On final attempt: fall through; success stays False
 
         # Throttle between batches; skip sleep after the last chunk.
         if chunk_idx < len(chunks) - 1:

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -615,7 +615,15 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
     min_eff = gate.get("min_effective_bets")
     caps_ok = gate.get("caps_ok")
     cvar_rb = diag.get("cvar_95_risk_book")
-    cvar_dep = diag.get("cvar_95_deployed")
+    # Prefer the post-gate value when a lever fired (gate["cvar_after"] reflects the
+    # gated vol, keeping this tile consistent with the "Portfolio vol" tile which also
+    # reads the post-gate gate["vol_after"]). Falls back to the pre-gate
+    # diag["cvar_95_deployed"] when no gate dict is present.
+    cvar_dep = (
+        gate.get("cvar_after")
+        if gate.get("cvar_after") is not None
+        else diag.get("cvar_95_deployed")
+    )
 
     lo, hi = float(band[0]), float(band[1])
     vol_tone = (

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -17,18 +17,14 @@ import html as _html
 import numpy as np
 import pandas as pd
 
-# --- editorial palette (light; the user's) ---------------------------------
-INK = "#16181d"  # primary ink
-INK2 = "#4a4e57"  # secondary ink
+# --- editorial palette (Python-side colors used in helper functions) --------
+# INK, INK2, LINE, WARM, ACCENT, BULL_BAR, BEAR_BAR, TRACK appear only as
+# CSS custom-property literals inside _stylesheet(); they are not referenced
+# from Python code and are not defined here.  MUTED / BULL / BEAR are used
+# in the Python helpers below (_z_color, _heat_bg, _heat_cell).
 MUTED = "#9aa0a8"  # muted labels
-LINE = "#e7e6e2"  # hairline
-WARM = "#faf9f7"  # whisper-warm section tone
-ACCENT = "#123b3a"  # deep ink-teal structural accent
 BULL = "#2d6a4f"
-BULL_BAR = "#bfe3cd"
 BEAR = "#b3402f"
-BEAR_BAR = "#f2c4bb"
-TRACK = "#efeeea"  # neutral z-bar track
 
 # Bar scaling: metric z clamps at ±2.5; conviction meter uses a robust
 # per-frame scale (90th pct of |conviction|) so typical names read strongly

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -231,6 +231,78 @@ def _bar(z, zmax: float, cls: str) -> str:
     return f'<span class="{cls}"><span class="{cls}-fill {cls}-{side}" style="width:{w:.1f}%;"></span></span>'
 
 
+# --- Phase 5D formatters (never emit the literal "None") --------------------
+_AMBER = "#96601a"  # warm ochre for TRIM / soft-warn (stays within the light palette)
+
+
+def _pct1(v) -> str:
+    """A fraction as a 1-decimal percent (0.182 -> "18.2%"); NaN/None -> "n/a"."""
+    return "n/a" if _isnan(v) else f"{float(v) * 100:.1f}%"
+
+
+def _pct0(v) -> str:
+    """A fraction as a whole percent (0.9 -> "90%"); NaN/None -> "n/a"."""
+    return "n/a" if _isnan(v) else f"{float(v) * 100:.0f}%"
+
+
+def _pp(v) -> str:
+    """A fractional delta as signed percentage points (0.023 -> "+2.3 pp")."""
+    return "n/a" if _isnan(v) else f"{float(v) * 100:+.1f} pp"
+
+
+def _num1(v) -> str:
+    return "n/a" if _isnan(v) else f"{float(v):.1f}"
+
+
+def _num2(v) -> str:
+    return "n/a" if _isnan(v) else f"{float(v):.2f}"
+
+
+def _money(v) -> str:
+    return "n/a" if _isnan(v) else f"${float(v):,.2f}"
+
+
+def _usd_signed(v) -> str:
+    """Signed whole-dollar delta ("+$1,234" / "-$980"); NaN/None -> "" (omitted)."""
+    if _isnan(v):
+        return ""
+    v = float(v)
+    return f"{'+' if v >= 0 else '-'}${abs(v):,.0f}"
+
+
+# Suggested-action groups: (ACTION, css-suffix, one-line hint). Rendered in this
+# order; BUY/ADD carry entry/SL/TP tiles.
+_ACTION_GROUPS = [
+    ("BUY", "buy", "Open new position"),
+    ("ADD", "add", "Increase weight"),
+    ("TRIM", "trim", "Reduce weight"),
+    ("SELL", "sell", "Close position"),
+    ("HOLD", "hold", "No change"),
+]
+_LEVEL_ACTIONS = {"BUY", "ADD"}
+
+# Binding-flag / gate-lever -> short human chip label.
+_FLAG_LABELS = {
+    "cvar": "CVaR over budget",
+    "net_beta": "net-beta out of band",
+    "effective_bets": "low breadth",
+    "deployment_capped": "deployment cap-limited",
+    "name_cap": "name cap",
+    "sector_cap": "sector cap",
+    "usd_bloc_cap": "USD-bloc cap",
+    "vol_over_target": "vol over target",
+}
+_LEVER_LABELS = {
+    "caps": "gate: caps",
+    "tail_deweight": "gate: tail de-weight",
+    "gross_cut": "gate: gross cut",
+}
+
+# Section numerals; render_report assigns them left-to-right so the legacy
+# Overview / Portfolio / Candidates stay I / II / III when no new sections lead.
+_ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII"]
+
+
 # --- regime (pure; script supplies the fetched index series) ----------------
 def compute_regime(index_close: pd.Series) -> tuple[str, str]:
     """Classify the market regime from an index close series.
@@ -470,6 +542,232 @@ def _section_head(numeral: str, label: str, sub: str) -> str:
     )
 
 
+# --- Phase 5D: executive summary line + exec/risk panel + suggested actions --
+def _exec_summary_line(meta: dict, portfolio, actions, conditioning) -> str:
+    """A single scannable line at the very top: regime, deployment, BUY/SELL, vol.
+
+    Renders whatever is available; omits any item whose source (portfolio /
+    actions / conditioning) was not supplied.
+    """
+    cond = conditioning or {}
+    items: list[str] = []
+    regime = str(meta.get("regime") or cond.get("regime") or "").strip()
+    if regime:
+        items.append(f"{_esc(regime.upper())} regime")
+    if portfolio is not None:
+        items.append(
+            f"{_pct0(portfolio.get('gross'))} deployed / {_pct0(portfolio.get('cash'))} cash"
+        )
+    elif cond.get("final_deployment") is not None:
+        items.append(f"{_pct0(cond.get('final_deployment'))} deployment")
+    if actions is not None:
+        n_buy = sum(1 for a in actions if a.get("action") == "BUY")
+        n_sell = sum(1 for a in actions if a.get("action") == "SELL")
+        items.append(f"{n_buy} BUY / {n_sell} SELL")
+    if portfolio is not None:
+        gate = (portfolio.get("diagnostics") or {}).get("gate") or {}
+        vol, ceil = gate.get("vol_after"), gate.get("vol_ceiling")
+        if not _isnan(vol):
+            tail = f" (ceiling {_pct0(ceil)})" if not _isnan(ceil) else ""
+            items.append(f"vol {_pct1(vol)}{tail}")
+    if not items:
+        return ""
+    inner = '<span class="es-sep">·</span>'.join(f'<span class="es-item">{i}</span>' for i in items)
+    return f'<div class="exec-summary">{inner}</div>'
+
+
+def _stat(label: str, value: str, sub: str = "", tone: str = "") -> str:
+    """One executive stat tile: label over a big value with an optional sub-note.
+
+    ``tone`` in {"", "bull", "bear", "warn"} colors the value within the palette.
+    """
+    tone_cls = f" stat--{tone}" if tone else ""
+    sub_html = f'<div class="stat-sub">{_esc(sub)}</div>' if sub else ""
+    return (
+        f'<div class="stat{tone_cls}">'
+        f'<div class="stat-l">{_esc(label)}</div>'
+        f'<div class="stat-v">{_esc(value)}</div>{sub_html}</div>'
+    )
+
+
+def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
+    """The executive / risk panel: deployment + risk stat tiles, sector exposures
+    and any binding cap / gate flags. Reads the build_portfolio result dict
+    (``diagnostics`` incl. ``diagnostics['gate']``) and the resolve_deployment
+    dial diagnostics. Degenerate inputs (missing gate) render "n/a" gracefully.
+    """
+    cond = conditioning or {}
+    diag = portfolio.get("diagnostics") or {}
+    gate = diag.get("gate") or {}
+    binding = diag.get("binding") or {}
+
+    gross = portfolio.get("gross")
+    cash = portfolio.get("cash")
+    usd_bloc = portfolio.get("usd_bloc")
+    sector_exp = portfolio.get("sector_exposures") or {}
+
+    regime = str(meta.get("regime") or cond.get("regime") or "").strip().upper() or "n/a"
+    final_dep = cond.get("final_deployment")
+    base_dep = cond.get("base_deployment")
+
+    vol_after = gate.get("vol_after")
+    vol_ceiling = gate.get("vol_ceiling")
+    net_beta = gate.get("net_beta", diag.get("net_beta"))
+    band = gate.get("net_beta_band") or diag.get("net_beta_band") or (0.3, 1.1)
+    net_beta_out = gate.get("net_beta_out")
+    eff = gate.get("effective_bets", diag.get("effective_bets"))
+    min_eff = gate.get("min_effective_bets")
+    caps_ok = gate.get("caps_ok")
+    cvar_rb = diag.get("cvar_95_risk_book")
+    cvar_dep = diag.get("cvar_95_deployed")
+
+    lo, hi = float(band[0]), float(band[1])
+    vol_tone = (
+        ""
+        if (_isnan(vol_after) or _isnan(vol_ceiling))
+        else ("bull" if float(vol_after) <= float(vol_ceiling) + 1e-9 else "bear")
+    )
+    if _isnan(net_beta):
+        beta_tone = ""
+    elif net_beta_out is True or not (lo <= float(net_beta) <= hi):
+        beta_tone = "warn"
+    else:
+        beta_tone = "bull"
+    eff_tone = (
+        ""
+        if _isnan(eff)
+        else ("warn" if (not _isnan(min_eff) and float(eff) < float(min_eff)) else "bull")
+    )
+    caps_tone = "" if caps_ok is None else ("bull" if caps_ok else "bear")
+    caps_val = "n/a" if caps_ok is None else ("OK" if caps_ok else "BREACH")
+
+    regime_sub = ""
+    if not _isnan(final_dep):
+        regime_sub = f"target {_pct0(final_dep)}"
+        if not _isnan(base_dep) and abs(float(base_dep) - float(final_dep)) > 1e-9:
+            regime_sub = f"base {_pct0(base_dep)} to {_pct0(final_dep)}"
+
+    tiles = [
+        _stat("Regime", regime, regime_sub),
+        _stat("Deployment", _pct0(gross), f"{_pct0(cash)} cash"),
+        _stat("Portfolio vol", _pct1(vol_after), f"ceiling {_pct0(vol_ceiling)}", vol_tone),
+        _stat("Net beta", _num2(net_beta), f"band {lo:.1f} to {hi:.1f}", beta_tone),
+        _stat("CVaR-95 risk book", _pct1(cvar_rb), "fully invested"),
+        _stat("CVaR-95 deployed", _pct1(cvar_dep), "at deployment"),
+        _stat(
+            "Effective bets",
+            _num1(eff),
+            ("min " + _num1(min_eff)) if not _isnan(min_eff) else "diversification",
+            eff_tone,
+        ),
+        _stat("Concentration caps", caps_val, f"USD-bloc {_pct0(usd_bloc)}", caps_tone),
+    ]
+    grid = f'<div class="stat-grid">{"".join(tiles)}</div>'
+
+    sec_items = sorted(
+        ((str(k), float(v)) for k, v in sector_exp.items() if float(v) > 1e-6),
+        key=lambda kv: -kv[1],
+    )[:5]
+    sec_html = ""
+    if sec_items:
+        chips = "".join(
+            f'<span class="sec-chip"><b>{_esc(k.title())}</b> {_pct1(v)}</span>'
+            for k, v in sec_items
+        )
+        sec_html = f'<div class="exec-sub"><span class="exec-sub-l">Top sectors</span>{chips}</div>'
+
+    flags = [_FLAG_LABELS[k] for k, on in binding.items() if on and k in _FLAG_LABELS]
+    for lev in gate.get("levers_fired") or []:
+        if lev in _LEVER_LABELS:
+            flags.append(_LEVER_LABELS[lev])
+    if gate.get("gross_cut") and _LEVER_LABELS["gross_cut"] not in flags:
+        flags.append(_LEVER_LABELS["gross_cut"])
+    seen: set = set()
+    flags = [f for f in flags if not (f in seen or seen.add(f))]
+    if flags:
+        chips = "".join(
+            f'<span class="flag-chip{" lever" if str(f).startswith("gate:") else ""}">'
+            f"{_esc(f)}</span>"
+            for f in flags
+        )
+        flag_html = f'<div class="exec-flags"><span class="exec-sub-l">Flags</span>{chips}</div>'
+    else:
+        flag_html = (
+            '<div class="exec-flags"><span class="exec-sub-l">Flags</span>'
+            '<span class="flag-none">none binding</span></div>'
+        )
+
+    return f'<div class="exec-panel">{grid}{sec_html}{flag_html}</div>'
+
+
+def _action_row(a: dict) -> str:
+    """One suggested-action row: id + conviction + current→target(+delta,$) + levels."""
+    tkr = _esc(a.get("ticker") or "")
+    name = _esc(a.get("name") or "")
+    conv = a.get("conviction")
+    conv_s = "·" if _isnan(conv) else f"{conv:+.2f}"
+    cur, tgt, delta = a.get("current_pct"), a.get("target_pct"), a.get("delta_pct")
+    usd = _usd_signed(a.get("delta_usd"))
+    usd_html = f'<span class="act-usd">{usd}</span>' if usd else ""
+    name_html = f'<div class="act-name">{name}</div>' if name else ""
+    move = (
+        f'<span class="from">{_pct1(cur)}</span> '
+        f'<span class="to">→ {_pct1(tgt)}</span> '
+        f'<span class="act-dpp">({_pp(delta)})</span>{usd_html}'
+    )
+    levels_html = ""
+    if a.get("action") in _LEVEL_ACTIONS:
+        levels_html = (
+            f'<span class="act-lvl">E {_money(a.get("price"))}</span>'
+            f'<span class="act-lvl sl">SL {_money(a.get("stop_loss"))}</span>'
+            f'<span class="act-lvl tp">TP {_money(a.get("take_profit"))}</span>'
+        )
+    return (
+        f'<div class="act-row">'
+        f'<div class="act-id"><div class="act-tkr">{tkr}</div>{name_html}</div>'
+        f'<div class="act-conv" style="color:{_z_color(conv)};">{conv_s}</div>'
+        f'<div class="act-move">{move}</div>'
+        f'<div class="act-levels">{levels_html}</div>'
+        f"</div>"
+    )
+
+
+def _action_group(action: str, cls: str, hint: str, rows: list) -> str:
+    if not rows:
+        return ""
+    body = "".join(_action_row(a) for a in rows)
+    n = len(rows)
+    count = f"{n} name" + ("" if n == 1 else "s")
+    return (
+        f'<div class="act-grp act-grp--{cls}">'
+        f'<div class="act-grp-head"><span class="act-tag">{action}</span>'
+        f'<span class="act-hint">{_esc(hint)}</span>'
+        f'<span class="act-count">{count}</span></div>'
+        f'<div class="act-rows">{body}</div>'
+        f"</div>"
+    )
+
+
+def _actions_block(actions: list, approx_current: bool = False) -> str:
+    """Decision-support action groups (BUY / ADD / TRIM / SELL / HOLD).
+
+    Empty groups are omitted. When ``approx_current`` is set (no live account),
+    a clear note flags that current weights are an equal-split approximation.
+    """
+    note = '<div class="act-note">Decision-support: you decide, not auto-executed.'
+    if approx_current:
+        note += (
+            ' <span class="act-note-warn">Current weights are approximate '
+            "(equal-split; no live account file supplied).</span>"
+        )
+    note += "</div>"
+    groups = "".join(
+        _action_group(act, cls, hint, [a for a in actions if a.get("action") == act])
+        for act, cls, hint in _ACTION_GROUPS
+    )
+    return f'<div class="actions-block">{note}{groups}</div>'
+
+
 def _card_grid(frame: pd.DataFrame, cols, conv_scale: float) -> str:
     cards = [
         _card(t, r, cols, conv_scale, min(i * 0.04, 0.36))
@@ -478,19 +776,19 @@ def _card_grid(frame: pd.DataFrame, cols, conv_scale: float) -> str:
     return f'<div class="cards">{"".join(cards)}</div>'
 
 
-def _portfolio_section(scores: pd.DataFrame, conv_scale: float) -> str:
+def _portfolio_section(scores: pd.DataFrame, conv_scale: float, numeral: str = "II") -> str:
     cols = scores.columns
     mask = scores.get("is_portfolio", pd.Series(False, index=scores.index)) == True  # noqa: E712
     port = scores[mask].sort_values("conviction", ascending=False, na_position="last")
     sub = f"Current holdings · {len(port)} name(s) · tilt = ADD / HOLD / TRIM"
-    head = _section_head("II", "Portfolio", sub)
+    head = _section_head(numeral, "Portfolio", sub)
     if port.empty:
         return head + '<div class="empty">No portfolio holdings in this run.</div>'
     return head + _card_grid(port, cols, conv_scale)
 
 
 def _candidates_section(
-    scores: pd.DataFrame, conv_scale: float, max_long: int, max_avoid: int
+    scores: pd.DataFrame, conv_scale: float, max_long: int, max_avoid: int, numeral: str = "III"
 ) -> str:
     cols = scores.columns
     mask = scores.get("is_portfolio", pd.Series(False, index=scores.index)) == False  # noqa: E712
@@ -498,7 +796,7 @@ def _candidates_section(
     total = len(cand)
     if cand.empty:
         return (
-            _section_head("III", "Candidates", "Buy-signal watchlist")
+            _section_head(numeral, "Candidates", "Buy-signal watchlist")
             + '<div class="empty">No candidates in this run.</div>'
         )
 
@@ -513,7 +811,7 @@ def _candidates_section(
         + (f" and bottom {len(avoids)}" if len(avoids) else "")
         + " · tilt = BUY-WATCH / WATCH / PASS"
     )
-    head = _section_head("III", "Candidates", sub)
+    head = _section_head(numeral, "Candidates", sub)
     body = _card_grid(longs, cols, conv_scale)
     if len(avoids):
         body += '<div class="cards-divider"><span>Lowest conviction · potential avoids</span></div>'
@@ -702,6 +1000,82 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 
 .empty{color:var(--muted);font-size:13px;padding:14px 0;}
 
+/* Phase 5D: executive summary strip */
+.exec-summary{display:flex;flex-wrap:wrap;align-items:center;gap:8px 10px;margin:30px 0 4px;
+  padding:14px 20px;border:1px solid var(--line);border-radius:11px;background:var(--warm);
+  font-family:var(--mono);font-size:12.5px;color:var(--ink2);font-variant-numeric:tabular-nums;}
+.es-item{font-weight:500;color:var(--ink);}
+.es-sep{color:var(--muted);margin:0 2px;}
+
+/* Phase 5D: exec / risk panel */
+.exec-panel{margin-top:4px;}
+.stat-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;}
+.stat{border:1px solid var(--line);border-radius:12px;padding:15px 16px;background:var(--canvas);
+  box-shadow:0 1px 2px rgba(22,24,29,.04);}
+.stat-l{font-size:9px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--muted);}
+.stat-v{font-family:var(--mono);font-size:23px;font-weight:500;color:var(--ink);margin-top:9px;
+  line-height:1;font-variant-numeric:tabular-nums;letter-spacing:-.5px;}
+.stat-sub{font-size:10.5px;color:var(--muted);margin-top:7px;}
+.stat--bull .stat-v{color:var(--bull);}
+.stat--bear .stat-v{color:var(--bear);}
+.stat--warn .stat-v{color:#96601a;}
+.exec-sub{margin-top:18px;display:flex;flex-wrap:wrap;align-items:center;gap:8px;}
+.exec-flags{margin-top:12px;display:flex;flex-wrap:wrap;align-items:center;gap:8px;}
+.exec-sub-l{font-size:9px;font-weight:600;letter-spacing:1px;text-transform:uppercase;
+  color:var(--muted);margin-right:4px;}
+.sec-chip{font-family:var(--mono);font-size:11px;color:var(--ink2);background:var(--warm);
+  border:1px solid var(--line);border-radius:100px;padding:4px 11px;font-variant-numeric:tabular-nums;}
+.sec-chip b{color:var(--ink);font-weight:600;}
+.flag-chip{font-size:10px;font-weight:600;letter-spacing:.3px;padding:4px 10px;border-radius:100px;
+  border:1px solid var(--bear-bar);background:var(--bear-fill);color:var(--bear);}
+.flag-chip.lever{border-color:var(--line);background:var(--warm);color:var(--ink2);}
+.flag-none{font-size:11px;color:var(--muted);}
+
+/* Phase 5D: suggested actions */
+.act-note{font-size:11.5px;font-style:italic;color:var(--muted);margin:0 0 20px;letter-spacing:.2px;}
+.act-note-warn{color:var(--bear);font-style:normal;font-weight:500;}
+.act-grp{border:1px solid var(--line);border-left:3px solid var(--muted);border-radius:11px;
+  padding:15px 18px 7px;margin-bottom:16px;background:var(--canvas);
+  box-shadow:0 1px 2px rgba(22,24,29,.04);}
+.act-grp-head{display:flex;align-items:baseline;gap:12px;margin-bottom:6px;}
+.act-tag{font-size:11px;font-weight:700;letter-spacing:1.2px;}
+.act-hint{font-size:11px;color:var(--muted);}
+.act-count{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--muted);
+  font-variant-numeric:tabular-nums;}
+.act-grp--buy{border-left-color:var(--bull);}
+.act-grp--buy .act-tag{color:var(--bull);}
+.act-grp--add{border-left-color:var(--bull-bar);}
+.act-grp--add .act-tag{color:var(--bull);}
+.act-grp--trim{border-left-color:#e6c88f;}
+.act-grp--trim .act-tag{color:#96601a;}
+.act-grp--sell{border-left-color:var(--bear);}
+.act-grp--sell .act-tag{color:var(--bear);}
+.act-grp--hold{border-left-color:var(--line);}
+.act-grp--hold .act-tag{color:var(--ink2);}
+.act-rows{display:flex;flex-direction:column;}
+.act-row{display:grid;grid-template-columns:minmax(150px,1.5fr) 56px minmax(150px,1.4fr) auto;
+  align-items:center;gap:8px 16px;padding:10px 0;border-top:1px dotted var(--line);}
+.act-row:first-child{border-top:none;}
+.act-id{min-width:0;}
+.act-tkr{font-family:var(--serif);font-weight:600;font-size:16px;color:var(--ink);letter-spacing:-.2px;}
+.act-name{font-size:11px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.act-conv{font-family:var(--mono);font-size:12.5px;font-variant-numeric:tabular-nums;text-align:right;}
+.act-move{font-family:var(--mono);font-size:12.5px;color:var(--ink2);font-variant-numeric:tabular-nums;}
+.act-move .to{color:var(--ink);font-weight:600;}
+.act-move .act-dpp{color:var(--muted);}
+.act-usd{color:var(--muted);margin-left:8px;}
+.act-levels{display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;}
+.act-lvl{font-family:var(--mono);font-size:10.5px;color:var(--ink2);background:var(--warm);
+  border:1px solid var(--line);border-radius:7px;padding:3px 8px;font-variant-numeric:tabular-nums;}
+.act-lvl.sl{color:var(--bear);}
+.act-lvl.tp{color:var(--bull);}
+@media (max-width:900px){.stat-grid{grid-template-columns:repeat(2,1fr);}}
+@media (max-width:560px){
+  .act-row{grid-template-columns:1fr auto;}
+  .act-move,.act-levels{grid-column:1 / -1;justify-content:flex-start;}
+}
+@media (max-width:420px){.stat-grid{grid-template-columns:1fr 1fr;}}
+
 /* footer */
 .footer{margin-top:72px;padding-top:26px;border-top:2px solid var(--ink);}
 .footer .eyebrow{margin-bottom:12px;}
@@ -754,15 +1128,32 @@ def render_report(
     *,
     max_long_cards: int = _MAX_LONG_CARDS,
     max_avoid_cards: int = _MAX_AVOID_CARDS,
+    portfolio: dict | None = None,
+    actions: list | None = None,
+    conditioning: dict | None = None,
 ) -> str:
     """Render the full standalone HTML factor report.
 
     Args:
         scores: Scored frame (from ``compute_scores``) indexed by ticker,
             with cluster z's, ``conviction``, ``rank`` and ``is_portfolio``.
-        meta: Header metadata (date, regime, counts, system_read, ...).
+        meta: Header metadata (date, regime, counts, system_read, ...). When
+            ``actions`` is supplied, ``meta["current_weights_approx"]`` (bool)
+            drives a note that current weights are an equal-split approximation.
         max_long_cards: Max highest-conviction candidate cards to detail.
         max_avoid_cards: Max lowest-conviction candidate cards to detail.
+        portfolio: Optional ``build_portfolio`` result dict. When given, an
+            executive / risk panel (deployment, vol vs ceiling, CVaR, net beta,
+            effective bets, caps, sector + USD-bloc exposure, binding/gate flags)
+            renders ABOVE the factor cards.
+        actions: Optional ``build_actions`` list. When given, a decision-support
+            Suggested Actions section (grouped BUY / ADD / TRIM / SELL / HOLD)
+            renders ABOVE the factor cards.
+        conditioning: Optional ``resolve_deployment`` dial-diagnostics dict, used
+            by the exec panel + summary line for regime / deployment context.
+
+    ``portfolio`` / ``actions`` / ``conditioning`` are fully optional: when all
+    three are ``None`` the output is byte-for-byte identical to the legacy report.
 
     Returns:
         A complete HTML document string.
@@ -808,8 +1199,28 @@ def render_report(
         f"</div></header>"
     )
 
+    # Phase 5D: exec / risk panel + suggested actions render ABOVE the factor
+    # cards. Section numerals are assigned left-to-right so that when no new
+    # section leads, Overview / Portfolio / Candidates keep I / II / III.
+    sec_idx = 0
+    new_top = ""
+    if portfolio is not None:
+        new_top += _section_head(
+            _ROMAN[sec_idx],
+            "Positioning and Risk",
+            "Deployment, portfolio risk and exposure limits after the risk gate",
+        ) + _exec_panel(portfolio, conditioning, meta)
+        sec_idx += 1
+    if actions is not None:
+        new_top += _section_head(
+            _ROMAN[sec_idx],
+            "Suggested Actions",
+            "Risk-gated target book vs current holdings · grouped by action",
+        ) + _actions_block(actions, bool(meta.get("current_weights_approx")))
+        sec_idx += 1
+
     overview = _section_head(
-        "I",
+        _ROMAN[sec_idx],
         "Overview",
         f"Conviction heatmap · all {n_universe} scored names ranked · "
         "cluster factor tilt by cell color",
@@ -820,8 +1231,18 @@ def render_report(
             f'<div class="excluded-note">{n_excluded} name{plural} excluded '
             f"(non-equity or insufficient data).</div>"
         )
-    port_sec = _portfolio_section(scored, conv_scale)
-    cand_sec = _candidates_section(scored, conv_scale, max_long_cards, max_avoid_cards)
+    sec_idx += 1
+    port_sec = _portfolio_section(scored, conv_scale, _ROMAN[sec_idx])
+    sec_idx += 1
+    cand_sec = _candidates_section(
+        scored, conv_scale, max_long_cards, max_avoid_cards, _ROMAN[sec_idx]
+    )
+
+    summary_line = (
+        _exec_summary_line(meta, portfolio, actions, conditioning)
+        if (portfolio is not None or actions is not None)
+        else ""
+    )
 
     footer = (
         f'<footer class="footer">'
@@ -851,7 +1272,10 @@ def render_report(
         f"</footer>"
     )
 
-    body = f'<div class="wrap">{masthead}{overview}{port_sec}{cand_sec}{footer}</div>'
+    body = (
+        f'<div class="wrap">{masthead}{summary_line}{new_top}'
+        f"{overview}{port_sec}{cand_sec}{footer}</div>"
+    )
 
     return (
         "<!DOCTYPE html>\n"

--- a/trade_modules/v3/risk_gate.py
+++ b/trade_modules/v3/risk_gate.py
@@ -1,0 +1,346 @@
+"""Phase 5A HARD risk gate (blocking enforcement) for the v3 book.
+
+:func:`build_portfolio` produces a conviction-tilted, capped book scaled to a
+``gross_target`` fraction of capital, with a REPORT-ONLY risk assessment. This
+module turns that assessment into ENFORCEMENT, using the owner's HYBRID rule —
+keep deployment high (~85-95%), raise the vol ceiling to ~18%, de-weight the
+worst tail-risk names FIRST, and only cut gross below the deployment target if
+the book is still over budget after de-weighting:
+
+  1. **Caps to convergence.** Iterate {name-cap -> USD-bloc-cap -> sector-cap}
+     until no cap is left breached (each cap redistributes its excess to under-cap
+     names, so the invested sum is preserved whenever a receiver exists). A single
+     interleaved pass can leave a residual breach (e.g. the sector cap re-breaches
+     the name cap); iterating to a fixed point removes it.
+
+  2. **Vol ceiling via tail de-weighting (lever 1).** While the portfolio vol
+     exceeds the ceiling, shrink the highest risk-contribution name
+     (``RC_i = w_i * (cov @ w)_i``) by a fixed factor and redistribute the freed
+     weight to the lowest-risk in-book names (inverse-vol), then re-run the caps.
+     This keeps the invested sum constant (deployment is preserved) and only
+     accepts a step that strictly reduces vol, so it terminates.
+
+  3. **Gross cut (lever 2, fallback).** If de-weighting is exhausted and vol is
+     still over the ceiling, uniformly scale the whole book so ``vol == ceiling``.
+     Uniform scaling preserves every cap fraction; only deployment drops.
+
+Net beta is reported (a breach only sets a flag). Final diagnostics are computed
+on the GATED book. Pure numpy/pandas + the riskfirst primitives; no
+``yahoofinance.core.config`` import (module-level or otherwise).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from trade_modules.riskfirst.construct import apply_name_cap, cap_groups, portfolio_vol
+from trade_modules.riskfirst.fx import USD_BLOC, cap_bloc
+
+# Parametric-normal 95% Expected Shortfall multiplier: E[Z | Z > z_.95].
+_Z_ES_95 = 2.063
+# Tail-name shrink factor per de-weight step (×0.85 => frees 15% of the name).
+_SHRINK = 0.85
+# Tolerances.
+_CAP_TOL = 1e-6  # cap-compliance check
+_STABLE_TOL = 1e-9  # caps fixed-point / weight-stability
+_VOL_TOL = 1e-12  # vol-improvement / ceiling slack
+
+
+def _clamp_caps(
+    w: np.ndarray,
+    sec_arr: np.ndarray,
+    is_bloc: np.ndarray,
+    *,
+    name_thr: float,
+    bloc_thr: float,
+    sector_thr: float,
+) -> np.ndarray:
+    """Force compliance by clamping DOWN (excess -> cash, no redistribution).
+
+    Applied once after the redistributing loop as a terminator: for a feasible
+    book the loop has already converged so this is a no-op, but when the caps are
+    mutually infeasible at the current gross (e.g. an over-cap sector with too few
+    non-zero receivers) the loop can oscillate — this pass guarantees a compliant
+    book by dropping the irreducible excess to cash. Order name -> sector -> bloc,
+    all downward, so every later clamp preserves the earlier ones.
+    """
+    w = np.minimum(np.asarray(w, dtype=float).copy(), name_thr)  # per-name -> cash
+    for lab in dict.fromkeys(sec_arr.tolist()):
+        mask = sec_arr == lab
+        s = float(w[mask].sum())
+        if s > sector_thr + _STABLE_TOL:
+            w[mask] *= sector_thr / s
+    s = float(w[is_bloc].sum())
+    if s > bloc_thr + _STABLE_TOL:
+        w[is_bloc] *= bloc_thr / s
+    return w
+
+
+def _caps_to_convergence(
+    w: np.ndarray,
+    sec_arr: np.ndarray,
+    is_bloc: np.ndarray,
+    *,
+    name_thr: float,
+    bloc_thr: float,
+    sector_thr: float,
+    max_iter: int,
+) -> tuple[np.ndarray, int]:
+    """Iterate {name -> USD-bloc -> sector} caps until the weights stop moving.
+
+    Thresholds are ABSOLUTE (``cap * gross``), which for a book whose gross equals
+    the caller's deployment target is exactly the proportional cap, and — unlike
+    renormalising each pass — gives a stable fixed point (no re-inflation spiral)
+    when a cap cannot be satisfied without dropping gross to cash. The
+    redistributing loop preserves the invested sum whenever a receiver exists; a
+    final :func:`_clamp_caps` guarantees compliance (dropping to cash) if the caps
+    are infeasible and the loop would otherwise oscillate.
+    """
+    w = np.asarray(w, dtype=float).copy()
+    iters = 0
+    for _ in range(max_iter):
+        iters += 1
+        prev = w.copy()
+        w = apply_name_cap(w, name_thr)
+        w = cap_bloc(w, is_bloc, bloc_thr)
+        w = cap_groups(w, sec_arr, sector_thr)
+        if np.max(np.abs(w - prev)) < _STABLE_TOL:
+            break
+    w = _clamp_caps(
+        w, sec_arr, is_bloc, name_thr=name_thr, bloc_thr=bloc_thr, sector_thr=sector_thr
+    )
+    return w, iters
+
+
+def apply_risk_gate(
+    weights: pd.Series,
+    cov: np.ndarray,
+    *,
+    sectors,
+    currencies,
+    betas=None,
+    vol_ceiling: float = 0.18,
+    name_cap: float = 0.08,
+    sector_cap: float = 0.25,
+    usd_bloc_cap: float = 0.60,
+    net_beta_band: tuple[float, float] = (0.3, 1.1),
+    min_effective_bets: float = 10.0,
+    max_iter: int = 100,
+) -> tuple[pd.Series, dict]:
+    """Enforce the vol ceiling + concentration caps on a constructed book.
+
+    Args:
+        weights: Deployed book (long-only), indexed by ticker, summing to the
+            deployment target. ``cov`` / ``sectors`` / ``currencies`` / ``betas``
+            are aligned POSITIONALLY to ``weights``.
+        cov: Annualised covariance matrix aligned to ``weights`` order.
+        sectors: Per-name sector labels aligned to ``weights``.
+        currencies: Per-name listing currencies aligned to ``weights`` (a name is
+            USD-bloc when its currency is in :data:`USD_BLOC`).
+        betas: Per-name betas aligned to ``weights`` (NaN -> 1.0); ``None`` -> all
+            ones.
+        vol_ceiling: Hard annualised vol ceiling enforced by levers 1 and 2.
+        name_cap / sector_cap / usd_bloc_cap: Concentration caps (fraction of the
+            invested book).
+        net_beta_band: Report-only acceptable net-beta band.
+        min_effective_bets: Report-only diversification floor.
+        max_iter: Iteration cap for BOTH the caps fixed-point loop and the
+            tail-deweight loop (guarantees termination).
+
+    Returns:
+        ``(gated_weights, gate_diag)``. ``gate_diag`` keys: ``levers_fired``,
+        ``gross_before``, ``gross_after``, ``vol_before``, ``vol_after``,
+        ``vol_ceiling``, ``cvar_after``, ``net_beta``, ``net_beta_band``,
+        ``net_beta_out``, ``gross_cut``, ``effective_bets``,
+        ``min_effective_bets``, ``caps_ok``, ``max_name``, ``max_sector``,
+        ``usd_bloc``, ``iterations`` (tail-deweight steps), ``caps_iterations``.
+    """
+    index = weights.index
+    w = np.asarray(weights.to_numpy(), dtype=float).copy()
+    cov = np.asarray(cov, dtype=float)
+    sec_arr = np.asarray(list(sectors), dtype=object)
+    ccy = list(currencies)
+    is_bloc = np.array([c in USD_BLOC for c in ccy], dtype=bool)
+    n = int(w.shape[0])
+
+    if betas is None:
+        b = np.ones(n, dtype=float)
+    else:
+        b = pd.to_numeric(pd.Series(list(betas)), errors="coerce").fillna(1.0).to_numpy()
+
+    gross_before = float(w.sum())
+    vol_before = portfolio_vol(w, cov) if n else 0.0
+    lo_band, hi_band = float(net_beta_band[0]), float(net_beta_band[1])
+
+    def _diag(
+        levers,
+        gross_after,
+        port_vol,
+        net_beta,
+        net_beta_out,
+        gross_cut,
+        eff,
+        caps_ok,
+        max_name,
+        max_sector,
+        usd_bloc,
+        l1_iter,
+        caps_iter,
+    ) -> dict:
+        return {
+            "levers_fired": levers,
+            "gross_before": gross_before,
+            "gross_after": float(gross_after),
+            "vol_before": float(vol_before),
+            "vol_after": float(port_vol),
+            "vol_ceiling": float(vol_ceiling),
+            "cvar_after": _Z_ES_95 * float(port_vol),
+            "net_beta": float(net_beta),
+            "net_beta_band": (lo_band, hi_band),
+            "net_beta_out": bool(net_beta_out),
+            "gross_cut": bool(gross_cut),
+            "effective_bets": float(eff),
+            "min_effective_bets": float(min_effective_bets),
+            "caps_ok": bool(caps_ok),
+            "max_name": float(max_name),
+            "max_sector": float(max_sector),
+            "usd_bloc": float(usd_bloc),
+            "iterations": int(l1_iter),
+            "caps_iterations": int(caps_iter),
+        }
+
+    # Degenerate: empty / all-cash book — nothing to enforce.
+    if n == 0 or gross_before <= 0:
+        return pd.Series(w, index=index), _diag(
+            [],
+            gross_before,
+            vol_before,
+            0.0,
+            False,
+            False,
+            0.0,
+            True,
+            0.0,
+            0.0,
+            0.0,
+            0,
+            0,
+        )
+
+    g_target = gross_before
+    name_thr = name_cap * g_target
+    bloc_thr = usd_bloc_cap * g_target
+    sector_thr = sector_cap * g_target
+
+    levers_fired: list[str] = []
+    caps_iter_total = 0
+
+    # --- 1. caps to convergence -------------------------------------------- #
+    w_pre = w.copy()
+    w, ci = _caps_to_convergence(
+        w,
+        sec_arr,
+        is_bloc,
+        name_thr=name_thr,
+        bloc_thr=bloc_thr,
+        sector_thr=sector_thr,
+        max_iter=max_iter,
+    )
+    caps_iter_total += ci
+    if np.max(np.abs(w - w_pre)) > _STABLE_TOL:
+        levers_fired.append("caps")
+
+    # --- 2. vol ceiling via tail de-weighting (lever 1) -------------------- #
+    l1_iter = 0
+    if n > 1:
+        inv_vol = 1.0 / np.sqrt(np.clip(np.diag(cov), 1e-18, None))
+        cur_vol = portfolio_vol(w, cov)
+        while cur_vol > vol_ceiling + _VOL_TOL and l1_iter < max_iter:
+            in_book = w > 1e-12
+            if int(in_book.sum()) <= 1:
+                break
+            rc = w * (cov @ w)  # per-name risk contribution
+            hi = int(np.argmax(np.where(in_book, rc, -np.inf)))
+            recv = in_book.copy()
+            recv[hi] = False
+            if not recv.any():
+                break
+            iv_recv = np.where(recv, inv_vol, 0.0)
+            iv_sum = float(iv_recv.sum())
+            if iv_sum <= 0:
+                break
+            # Shrink the worst tail-risk name; redistribute freed weight to the
+            # lowest-risk in-book names (inverse-vol) so the invested sum holds.
+            trial = w.copy()
+            freed = trial[hi] * (1.0 - _SHRINK)
+            trial[hi] *= _SHRINK
+            trial += freed * (iv_recv / iv_sum)
+            trial, ci = _caps_to_convergence(
+                trial,
+                sec_arr,
+                is_bloc,
+                name_thr=name_thr,
+                bloc_thr=bloc_thr,
+                sector_thr=sector_thr,
+                max_iter=max_iter,
+            )
+            caps_iter_total += ci
+            new_vol = portfolio_vol(trial, cov)
+            if new_vol < cur_vol - _VOL_TOL:  # accept only a strict improvement
+                w, cur_vol = trial, new_vol
+                l1_iter += 1
+            else:  # de-weighting can no longer help — lever 1 exhausted
+                break
+        if l1_iter > 0:
+            levers_fired.append("tail_deweight")
+
+    # --- 3. gross cut (lever 2, fallback) ---------------------------------- #
+    gross_cut = False
+    pv = portfolio_vol(w, cov)
+    if pv > vol_ceiling + _VOL_TOL:
+        w = w * (vol_ceiling / pv)  # uniform -> vol == ceiling, caps preserved
+        gross_cut = True
+        levers_fired.append("gross_cut")
+
+    # --- 4. net beta (report; NaN beta -> 1.0) ----------------------------- #
+    net_beta = float(np.dot(w, b))
+    net_beta_out = not (lo_band <= net_beta <= hi_band)
+
+    # --- 5. final diagnostics on the GATED book ---------------------------- #
+    gross_after = float(w.sum())
+    port_vol = portfolio_vol(w, cov)
+    if gross_after > 0:
+        p = w / gross_after
+    else:
+        p = w
+    ss = float(np.sum(p**2))
+    effective_bets = float(1.0 / ss) if ss > 0 else 0.0
+    max_name = float(p.max()) if n else 0.0
+    sec_tot: dict = {}
+    for lab, wt in zip(sec_arr.tolist(), p.tolist(), strict=True):
+        sec_tot[lab] = sec_tot.get(lab, 0.0) + float(wt)
+    max_sector = max(sec_tot.values(), default=0.0)
+    usd_bloc = float(np.sum(p[is_bloc])) if is_bloc.any() else 0.0
+    caps_ok = (
+        max_name <= name_cap + _CAP_TOL
+        and max_sector <= sector_cap + _CAP_TOL
+        and usd_bloc <= usd_bloc_cap + _CAP_TOL
+    )
+
+    gate_diag = _diag(
+        levers_fired,
+        gross_after,
+        port_vol,
+        net_beta,
+        net_beta_out,
+        gross_cut,
+        effective_bets,
+        caps_ok,
+        max_name,
+        max_sector,
+        usd_bloc,
+        l1_iter,
+        caps_iter_total,
+    )
+    return pd.Series(w, index=index), gate_diag

--- a/trade_modules/v3/risk_gate.py
+++ b/trade_modules/v3/risk_gate.py
@@ -24,9 +24,11 @@ the book is still over budget after de-weighting:
      still over the ceiling, uniformly scale the whole book so ``vol == ceiling``.
      Uniform scaling preserves every cap fraction; only deployment drops.
 
-Net beta is reported (a breach only sets a flag). Final diagnostics are computed
-on the GATED book. Pure numpy/pandas + the riskfirst primitives; no
-``yahoofinance.core.config`` import (module-level or otherwise).
+Net beta is computed on INVESTED PROPORTIONS (scale-invariant; comparable to the
+pre-gate value in construct.py) and is report-only (a breach only sets a flag).
+Final diagnostics are computed on the GATED book. Pure numpy/pandas + the
+riskfirst primitives; no ``yahoofinance.core.config`` import (module-level or
+otherwise).
 """
 
 from __future__ import annotations
@@ -303,8 +305,10 @@ def apply_risk_gate(
         gross_cut = True
         levers_fired.append("gross_cut")
 
-    # --- 4. net beta (report; NaN beta -> 1.0) ----------------------------- #
-    net_beta = float(np.dot(w, b))
+    # --- 4. net beta on invested PROPORTIONS (scale-invariant; matches pre-gate) #
+    _gross_for_beta = float(w.sum())
+    _p_beta = w / _gross_for_beta if _gross_for_beta > 0 else w
+    net_beta = float(np.dot(_p_beta, b))
     net_beta_out = not (lo_band <= net_beta <= hi_band)
 
     # --- 5. final diagnostics on the GATED book ---------------------------- #

--- a/trade_modules/validation/xsection_ic.py
+++ b/trade_modules/validation/xsection_ic.py
@@ -17,9 +17,11 @@ producer:
                       the forward return is taken.  Answers "does this signal add
                       rank-ordering power the incumbents don't already have?".
 
-Both reuse ``_spearman_rho`` from the harness (NaN-safe, len<3 / constant-guarded)
-and pairwise-drop NaNs before calling it (``_spearman_rho`` returns None if ANY
-NaN is present, so cleaning first is what makes these NaN-safe).
+Both reuse ``_spearman_rho`` from the harness (len<3 / constant-guarded) and
+pairwise-drop NaNs before calling it.  ``_spearman_rho`` returns None when the
+cleaned input has fewer than 3 observations or when the signal/return is constant;
+the pairwise-drop here is what makes these functions NaN-safe (consistent pair
+counts across the two series, not a NaN-rejection guard inside _spearman_rho).
 
 No I/O.  Never raises on thin or degenerate data — returns explicit None fields.
 """


### PR DESCRIPTION
## Trading Model v3 — Phase 5

Builds on Phase 1+2 (PR #137). Turns the risk-managed target book into an enforced, actionable, monitored system.

- **5A Hard risk gate** (`risk_gate.py`): caps-to-convergence + tail de-weight to an ~18% vol ceiling + gross-cut fallback (owner's hybrid rule: keep ~85-95% deployment, de-weight worst tail-risk first, cut gross only if still breached). Wired into `build_portfolio` (returns the gated book).
- **5B Conditioning dials** (`conditioning.py`): regime → deployment (85/90/95%); Polymarket seam inert by default (shadow / zero-conviction).
- **5C PM construction** (`actions.py`): target vs live portfolio → BUY/ADD/TRIM/SELL/HOLD with delta pp, delta USD, entry/SL/TP.
- **5D Fully-wired report** (`report.py` + `scripts/v3_full_report.py`): exec/risk panel + suggested actions + factor cards; reads live eToro weights + NAV; backward-compatible render.
- **5E Forward-IC logger** (`scripts/v3_ic_logger.py` + `v3_ic_report.py` + `scripts/vps/v3-ic-logger.{service,timer}`): daily conviction snapshot → cross-sectional incremental-IC over time.

~480 tests; ruff / ruff-format / mypy / gitleaks green. Per-task reviews + opus whole-branch capstone = merge-ready.

Live run (2026-07-13, real weights, NAV $1.12M): RISK_ON, 95% deployed, the hard gate pulled portfolio vol 34% to 17.5% (under the 18% ceiling), net beta 0.52, 16 BUY / 14 ADD / 7 TRIM / 40 SELL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)