### PR TITLE
v3 Factor Snapshot: pipeline refinements (region cap, ADV, cap-USD, social, prune, coverage, Polymarket)

### DIFF
--- a/scripts/v3_account_snapshot.py
+++ b/scripts/v3_account_snapshot.py
@@ -1,0 +1,242 @@
+# scripts/v3_account_snapshot.py
+"""Write the live eToro account snapshot the v3 report anchors on.
+
+Hits the eToro public API (getPortfolio + real/pnl) and writes
+``~/Downloads/v3_live_account.json`` with per-position P/L, so the overlay
+report can show profit/loss + current value on the names you already hold.
+
+Schema written::
+
+    {
+      "nav": <total_equity USD>,
+      "as_of": "<YYYY-MM-DD>",
+      "source": "v3_account_snapshot (eToro API)",
+      "weights":   {"<ticker>": <fraction 0..1>, ...},
+      "positions": {"<ticker>": {current_value, base_value, cost, pnl,
+                                 pnl_pct, weight_pct}, ...},
+      "account":   {invested_cost, unrealized_pnl, profit_pct, total_equity,
+                    available}
+    }
+
+Credentials: macOS Keychain (services ``etoro-public-key`` / ``etoro-user-key``)
+or env ``ETORO_PUBLIC_KEY`` / ``ETORO_USER_KEY`` (used on the VPS). Self-contained
+(no cross-repo import); mirrors the proven order-execution header recipe.
+
+Run:  .venv/bin/python scripts/v3_account_snapshot.py [-o <path>]
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PORTFOLIO = "https://www.etoro.com/api/public/v1/trading/info/portfolio"
+_PNL = "https://www.etoro.com/api/public/v1/trading/info/real/pnl"
+_INPUT_CSV = Path(os.path.expanduser("~/SourceCode/etorotrade/yahoofinance/input/portfolio.csv"))
+_DEFAULT_OUT = "~/Downloads/v3_live_account.json"
+
+
+def _key(service: str) -> str:
+    """Read an eToro key from env first, then the macOS Keychain."""
+    env = "ETORO_PUBLIC_KEY" if "public" in service else "ETORO_USER_KEY"
+    if os.environ.get(env):
+        return os.environ[env]
+    if sys.platform == "darwin":
+        try:
+            r = subprocess.run(
+                ["security", "find-generic-password", "-a", "etoro-api", "-s", service, "-w"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=5,
+            )
+            return r.stdout.strip()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return ""
+    return ""
+
+
+def _api_get(url: str) -> dict:
+    """GET a JSON eToro endpoint with the Cloudflare-safe header set."""
+    pub, usr = _key("etoro-public-key"), _key("etoro-user-key")
+    if not pub or not usr:
+        raise RuntimeError(
+            "eToro API keys missing (set ETORO_PUBLIC_KEY / ETORO_USER_KEY or Keychain)"
+        )
+    r = subprocess.run(
+        [
+            "curl",
+            "-s",
+            url,
+            "-H",
+            f"x-api-key: {pub}",
+            "-H",
+            f"x-user-key: {usr}",
+            "-H",
+            f"x-request-id: {uuid.uuid4()}",
+            "-H",
+            "User-Agent: Mozilla/5.0",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        raise RuntimeError(f"eToro API call failed ({url}): exit {r.returncode}")
+    return json.loads(r.stdout)
+
+
+def _instrument_map() -> dict[int, str]:
+    """instrumentId -> ticker, from input/portfolio.csv."""
+    if not _INPUT_CSV.exists():
+        return {}
+    out: dict[int, str] = {}
+    with open(_INPUT_CSV) as f:
+        for row in csv.DictReader(f):
+            iid, sym = row.get("instrumentId"), (row.get("symbol") or "").strip()
+            if iid and sym:
+                try:
+                    out[int(iid)] = sym
+                except ValueError:
+                    pass
+    return out
+
+
+_SEARCH = "https://www.etoro.com/api/public/v1/market-data/search"
+_CRYPTO = {
+    "BTC": "BTC-USD",
+    "ETH": "ETH-USD",
+    "XRP": "XRP-USD",
+    "SOL": "SOL-USD",
+    "ADA": "ADA-USD",
+    "DOGE": "DOGE-USD",
+}
+
+
+def _normalize_ticker(sym: str) -> str:
+    """Match the signal-pipeline ticker conventions (crypto suffix, HK zero-pad)."""
+    if sym in _CRYPTO:
+        return _CRYPTO[sym]
+    if sym.endswith(".HK"):
+        pfx = sym.split(".")[0].lstrip("0") or "0"
+        return f"{pfx.zfill(4)}.HK"
+    return sym
+
+
+def _resolve_instrument(iid: int) -> str:
+    """Resolve an instrumentId not in portfolio.csv to a ticker via the search API."""
+    try:
+        data = _api_get(f"{_SEARCH}?instrumentId={iid}")
+    except Exception:  # noqa: BLE001 (best-effort fallback; skip on any failure)
+        return ""
+    for item in data.get("items", []):
+        sym = (item.get("internalSymbolFull") or "").strip()
+        if sym and not sym.endswith(".24-7"):
+            return _normalize_ticker(sym)
+    return ""
+
+
+def build_snapshot() -> dict:
+    """Fetch the account + per-position P/L and shape it into the v3 schema."""
+    cp = fetch_portfolio()
+    credit = float(cp.get("credit", 0))
+    orders = cp.get("orders", [])
+    pending = sum(float(o.get("amount", 0)) for o in orders)
+    available = credit - pending
+
+    imap = _instrument_map()
+    pnl_map = fetch_pnl()
+
+    pos: dict[str, dict] = {}
+    total_pnl = total_exposure = 0.0
+    for p in cp.get("positions", []):
+        iid = int(p.get("instrumentID", 0))
+        ticker = imap.get(iid) or _resolve_instrument(iid)
+        if not ticker:
+            continue  # unmapped + unresolvable instrument: skip
+        pid = int(p.get("positionID", 0))
+        cost = float(p.get("initialAmountInDollars", 0))
+        base = float(p.get("unitsBaseValueDollars", cost))
+        rp = pnl_map.get(pid, {})
+        pnl = float(rp.get("pnl", 0.0))
+        exposure = float(rp.get("exposure", base))
+        total_pnl += pnl
+        total_exposure += exposure
+        d = pos.setdefault(
+            ticker, {"cost": 0.0, "base_value": 0.0, "pnl": 0.0, "current_value": 0.0}
+        )
+        d["cost"] += cost
+        d["base_value"] += base
+        d["pnl"] += pnl
+        d["current_value"] += exposure
+
+    total_equity = available + total_exposure + pending
+    invested = sum(d["base_value"] for d in pos.values()) + pending
+    for d in pos.values():
+        d["pnl_pct"] = round(d["pnl"] / d["base_value"] * 100, 2) if d["base_value"] > 0 else 0.0
+        d["weight_pct"] = round(d["current_value"] / total_equity * 100, 2) if total_equity else 0.0
+        for k in ("cost", "base_value", "pnl", "current_value"):
+            d[k] = round(d[k], 2)
+
+    weights = {
+        t: round(d["current_value"] / total_equity, 6) for t, d in pos.items() if total_equity
+    }
+    return {
+        "nav": round(total_equity, 2),
+        "as_of": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "source": "v3_account_snapshot (eToro API)",
+        "weights": weights,
+        "positions": pos,
+        "account": {
+            "invested_cost": round(invested, 2),
+            "unrealized_pnl": round(total_pnl, 2),
+            "profit_pct": round(total_pnl / invested * 100, 2) if invested > 0 else 0.0,
+            "total_equity": round(total_equity, 2),
+            "available": round(available, 2),
+        },
+    }
+
+
+def fetch_portfolio() -> dict:
+    raw = _api_get(_PORTFOLIO)
+    return raw.get("clientPortfolio", raw)
+
+
+def fetch_pnl() -> dict[int, dict]:
+    data = _api_get(_PNL)
+    out: dict[int, dict] = {}
+    for p in data.get("clientPortfolio", {}).get("positions", []):
+        pid = int(p.get("positionID", 0))
+        upnl = p.get("unrealizedPnL", {})
+        if pid and upnl:
+            out[pid] = {
+                "pnl": float(upnl.get("pnL", 0)),
+                "exposure": float(upnl.get("exposureInAccountCurrency", 0)),
+            }
+    return out
+
+
+def main() -> int:
+    out = os.path.expanduser(
+        sys.argv[sys.argv.index("-o") + 1] if "-o" in sys.argv else _DEFAULT_OUT
+    )
+    snap = build_snapshot()
+    with open(out, "w", encoding="utf-8") as fh:
+        json.dump(snap, fh, indent=2)
+    acc = snap["account"]
+    print(
+        f"snapshot -> {out}  |  equity ${acc['total_equity']:,.0f}  "
+        f"P/L ${acc['unrealized_pnl']:+,.0f} ({acc['profit_pct']:+.2f}%)  "
+        f"{len(snap['positions'])} positions"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/v3_account_snapshot.py
+++ b/scripts/v3_account_snapshot.py
@@ -38,6 +38,8 @@ from pathlib import Path
 
 _PORTFOLIO = "https://www.etoro.com/api/public/v1/trading/info/portfolio"
 _PNL = "https://www.etoro.com/api/public/v1/trading/info/real/pnl"
+_TRADEINFO = "https://www.etoro.com/api/public/v1/user-info/people/{u}/tradeinfo?period={p}"
+_USERNAME = os.environ.get("ETORO_USERNAME", "plessas")
 _INPUT_CSV = Path(os.path.expanduser("~/SourceCode/etorotrade/yahoofinance/input/portfolio.csv"))
 _DEFAULT_OUT = "~/Downloads/v3_live_account.json"
 
@@ -187,6 +189,16 @@ def build_snapshot() -> dict:
     weights = {
         t: round(d["current_value"] / total_equity, 6) for t, d in pos.items() if total_equity
     }
+    raw_positions = cp.get("positions", [])
+    social = fetch_social()
+    social.update(
+        {
+            "unique_assets": len(pos),
+            "open_positions": len(raw_positions),  # incl. lots
+            "shorts": sum(1 for p in raw_positions if not p.get("isBuy", True)),
+            "cash_pct": round(available / total_equity * 100, 1) if total_equity else 0.0,
+        }
+    )
     return {
         "nav": round(total_equity, 2),
         "as_of": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
@@ -200,6 +212,7 @@ def build_snapshot() -> dict:
             "total_equity": round(total_equity, 2),
             "available": round(available, 2),
         },
+        "social": social,
     }
 
 
@@ -220,6 +233,36 @@ def fetch_pnl() -> dict[int, dict]:
                 "exposure": float(upnl.get("exposureInAccountCurrency", 0)),
             }
     return out
+
+
+def fetch_social() -> dict:
+    """PI performance + social metrics from the eToro tradeinfo endpoint.
+
+    Two period calls: CurrYear (YTD gain, today, this-week, risk score, copiers,
+    win ratio, trades) and CurrMonth (MTD gain). Gains and winRatio are already
+    percentages (3.4 = 3.4%). Best-effort: returns {} if the endpoint is
+    unavailable so the report degrades gracefully.
+    """
+    try:
+        yr = _api_get(_TRADEINFO.format(u=_USERNAME, p="CurrYear"))
+        mo = _api_get(_TRADEINFO.format(u=_USERNAME, p="CurrMonth"))
+    except Exception:  # noqa: BLE001 (best-effort; report renders without social block)
+        return {}
+    return {
+        "username": _USERNAME,
+        "copiers": yr.get("copiers"),
+        "baseline_copiers": yr.get("baseLineCopiers"),
+        "copiers_gain_pct": yr.get("copiersGain"),
+        "risk_score": yr.get("riskScore"),
+        "max_daily_risk": yr.get("maxDailyRiskScore"),
+        "win_ratio": yr.get("winRatio"),
+        "trades_ytd": yr.get("trades"),
+        "gain_ytd": yr.get("gain"),
+        "gain_mtd": mo.get("gain"),
+        "daily_gain": yr.get("dailyGain"),
+        "week_gain": yr.get("thisWeekGain"),
+        "aum_tier_desc": yr.get("aumTierDesc"),
+    }
 
 
 def main() -> int:

--- a/scripts/v3_full_report.py
+++ b/scripts/v3_full_report.py
@@ -113,6 +113,32 @@ def load_account_json(path: str | None = None) -> tuple[pd.Series, float | None,
     return weights, nav, True
 
 
+def load_account_positions(path: str | None = None) -> dict[str, dict]:
+    """Load per-ticker P/L from the live-account JSON ``positions`` block.
+
+    Mirrors :func:`load_account_json` path resolution. Returns
+    ``{ticker: {"pnl", "pnl_pct", "current_value", ...}}`` — empty when the file
+    is absent or carries no ``positions`` (older snapshots without P/L).
+    """
+    if path is not None:
+        candidates: list[str | None] = [path]
+    else:
+        candidates = [os.environ.get("V3_ACCOUNT_JSON"), DEFAULT_ACCOUNT_JSON]
+    chosen = next(
+        (os.path.expanduser(p) for p in candidates if p and os.path.exists(os.path.expanduser(p))),
+        None,
+    )
+    if not chosen:
+        return {}
+    try:
+        with open(chosen, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    pos = data.get("positions") or {}
+    return {str(k): v for k, v in pos.items() if isinstance(v, dict)}
+
+
 def resolve_current_weights(
     port_tickers: list[str], account_weights: pd.Series, account_present: bool
 ) -> tuple[pd.Series, bool]:

--- a/scripts/v3_full_report.py
+++ b/scripts/v3_full_report.py
@@ -139,6 +139,30 @@ def load_account_positions(path: str | None = None) -> dict[str, dict]:
     return {str(k): v for k, v in pos.items() if isinstance(v, dict)}
 
 
+def load_account_block(path: str | None = None) -> dict:
+    """Load the account-level summary block from the live-account JSON.
+
+    Returns the ``account`` dict (keys: total_equity, unrealized_pnl, profit_pct,
+    available, invested_cost) or {} when the file is absent or the key is missing.
+    """
+    if path is not None:
+        candidates: list[str | None] = [path]
+    else:
+        candidates = [os.environ.get("V3_ACCOUNT_JSON"), DEFAULT_ACCOUNT_JSON]
+    chosen = next(
+        (os.path.expanduser(p) for p in candidates if p and os.path.exists(os.path.expanduser(p))),
+        None,
+    )
+    if not chosen:
+        return {}
+    try:
+        with open(chosen, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return data.get("account") or {}
+
+
 def resolve_current_weights(
     port_tickers: list[str], account_weights: pd.Series, account_present: bool
 ) -> tuple[pd.Series, bool]:

--- a/scripts/v3_full_report.py
+++ b/scripts/v3_full_report.py
@@ -163,6 +163,30 @@ def load_account_block(path: str | None = None) -> dict:
     return data.get("account") or {}
 
 
+def load_account_social(path: str | None = None) -> dict:
+    """Load the PI performance + social block from the live-account JSON.
+
+    Returns the ``social`` dict (copiers, risk_score, win_ratio, gain_ytd/mtd,
+    daily_gain, unique_assets, open_positions, ...) or {} when absent.
+    """
+    if path is not None:
+        candidates: list[str | None] = [path]
+    else:
+        candidates = [os.environ.get("V3_ACCOUNT_JSON"), DEFAULT_ACCOUNT_JSON]
+    chosen = next(
+        (os.path.expanduser(p) for p in candidates if p and os.path.exists(os.path.expanduser(p))),
+        None,
+    )
+    if not chosen:
+        return {}
+    try:
+        with open(chosen, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return data.get("social") or {}
+
+
 def resolve_current_weights(
     port_tickers: list[str], account_weights: pd.Series, account_present: bool
 ) -> tuple[pd.Series, bool]:

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -42,6 +42,7 @@ from scripts.v3_full_report import (  # noqa: E402  (pure helpers, reused)
     _synthetic_scores,
     _system_read,
     load_account_json,
+    load_account_positions,
     resolve_current_weights,
 )
 from scripts.v3_portfolio import trend_regime  # noqa: E402  (pure, unit-tested)
@@ -378,6 +379,14 @@ def main() -> None:
     )
     view = overlay_portfolio_view(overlay, scores)
     actions = build_actions(overlay["weights"], current_weights, scores, nav=nav)
+    # Attach live P/L from the eToro account snapshot to held names (P/L $ / % / value).
+    _positions = load_account_positions()
+    for _a in actions:
+        _p = _positions.get(_a.get("ticker"))
+        if _p:
+            _a["pnl"] = _p.get("pnl")
+            _a["pnl_pct"] = _p.get("pnl_pct")
+            _a["current_value"] = _p.get("current_value")
 
     # --- Render the FULL report ---
     now = datetime.now(timezone.utc)

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -170,13 +170,13 @@ def _compute_allocations(positions: dict, scores: pd.DataFrame) -> dict:
         geo[region] = geo.get(region, 0.0) + cv
 
         # Asset type: crypto > commodity > volatility > ETF > equity
-        if "-" in t:
+        if t.endswith("-USD") or t.endswith("-EUR"):  # crypto (BTC-USD); not BRK-B
             at = "Crypto"
         elif t == "GLD":
             at = "Commodity"
         elif t in {"UVXY", "VXX"}:
             at = "Volatility"
-        elif ticker in _ETFS:
+        elif t in _ETFS:  # uppercased, consistent with the checks above
             at = "ETF"
         else:
             at = "Equity"
@@ -228,6 +228,8 @@ def overlay_portfolio_view(overlay: dict, scored: pd.DataFrame) -> dict:
     weights = overlay["weights"]
     gate = overlay["diagnostics"].get("gate") or {}
     gross = float(weights.sum()) if len(weights) else 0.0
+    # NAV-basis absolute USD weight; the caps tile converts to book-basis (/gross) to
+    # rank it alongside name/sector/region (I2 is fixed at the tile, one place).
     usd_bloc = float(sum(float(w) for t, w in weights.items() if currency_of(t) in USD_BLOC))
 
     sector_exp: dict[str, float] = {}

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -52,6 +52,7 @@ from trade_modules.riskfirst.fx import USD_BLOC, currency_of  # noqa: E402
 from trade_modules.v3.actions import build_actions  # noqa: E402
 from trade_modules.v3.combine import compute_scores  # noqa: E402
 from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
+from trade_modules.v3.construct import region_of  # noqa: E402
 from trade_modules.v3.features import enrich_features  # noqa: E402
 from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
 from trade_modules.v3.overlay import build_overlay  # noqa: E402
@@ -138,42 +139,15 @@ def _compute_allocations(positions: dict, scores: pd.DataFrame) -> dict:
     an "Other" entry appended last. Returns empty inner dicts when positions is empty.
     """
 
+    # Single source of truth for geography: the same region_of the region cap uses,
+    # so the allocation bars and the cap never disagree (and BRK-B is not miscounted
+    # as crypto). ".US" is stripped to bare-US first (region_of treats it as North
+    # America via the unmapped-suffix default).
     def _region_for(ticker: str) -> str:
         t = str(ticker).upper()
-        if "-" in t:
-            return "Crypto/Global"
-        if "." not in t:
-            return "North America"
-        sfx = "." + t.rsplit(".", 1)[-1]
-        if sfx in {".US"}:
-            return "North America"
-        if sfx in {".TO", ".V"}:
-            return "North America"
-        if sfx in {
-            ".DE",
-            ".PA",
-            ".AS",
-            ".MI",
-            ".MC",
-            ".L",
-            ".SW",
-            ".BR",
-            ".LS",
-            ".HE",
-            ".ST",
-            ".CO",
-            ".OL",
-            ".VI",
-            ".IR",
-            ".WA",
-            ".AT",
-        }:
-            return "Europe"
-        if sfx in {".HK", ".T", ".KS", ".KQ", ".TW", ".SI", ".AX", ".NS", ".BO", ".SS", ".SZ"}:
-            return "Asia-Pacific"
-        if sfx in {".SA", ".MX", ".BA", ".SN"}:
-            return "Latin America"
-        return "Other"
+        if t.endswith(".US"):
+            t = t[:-3]
+        return region_of(t)
 
     if not positions:
         return {"geography": {}, "asset_type": {}, "sector": {}}

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -100,6 +100,117 @@ _MANAGED_SLEEVES = [
     if s.strip()
 ]
 
+# Known ETF tickers for asset-type classification.
+_ETFS: set[str] = {"LYXGRE.DE", "SPY", "QQQ", "IWM", "DIA", "VTI", "VOO", "EEM", "EFA", "TLT"}
+
+
+def _compute_allocations(positions: dict, scores: pd.DataFrame) -> dict:
+    """Compute portfolio allocation fractions for Geography, Asset Type, and Sector.
+
+    Returns {"geography": {label: frac}, "asset_type": {label: frac}, "sector": {label: frac}}
+    where each inner dict is sorted descending by fraction, with buckets below 3% merged into
+    an "Other" entry appended last. Returns empty inner dicts when positions is empty.
+    """
+
+    def _region_for(ticker: str) -> str:
+        t = str(ticker).upper()
+        if "-" in t:
+            return "Crypto/Global"
+        if "." not in t:
+            return "North America"
+        sfx = "." + t.rsplit(".", 1)[-1]
+        if sfx in {".US"}:
+            return "North America"
+        if sfx in {".TO", ".V"}:
+            return "North America"
+        if sfx in {
+            ".DE",
+            ".PA",
+            ".AS",
+            ".MI",
+            ".MC",
+            ".L",
+            ".SW",
+            ".BR",
+            ".LS",
+            ".HE",
+            ".ST",
+            ".CO",
+            ".OL",
+            ".VI",
+            ".IR",
+            ".WA",
+            ".AT",
+        }:
+            return "Europe"
+        if sfx in {".HK", ".T", ".KS", ".KQ", ".TW", ".SI", ".AX", ".NS", ".BO", ".SS", ".SZ"}:
+            return "Asia-Pacific"
+        if sfx in {".SA", ".MX", ".BA", ".SN"}:
+            return "Latin America"
+        return "Other"
+
+    if not positions:
+        return {"geography": {}, "asset_type": {}, "sector": {}}
+
+    total = sum(float(p.get("current_value", 0.0)) for p in positions.values())
+    if total <= 0:
+        return {"geography": {}, "asset_type": {}, "sector": {}}
+
+    geo: dict[str, float] = {}
+    atype: dict[str, float] = {}
+    sec: dict[str, float] = {}
+
+    for ticker, pos in positions.items():
+        cv = float(pos.get("current_value", 0.0))
+        if cv <= 0:
+            continue
+        t = str(ticker).upper()
+
+        region = _region_for(ticker)
+        geo[region] = geo.get(region, 0.0) + cv
+
+        # Asset type: crypto > commodity > volatility > ETF > equity
+        if "-" in t:
+            at = "Crypto"
+        elif t == "GLD":
+            at = "Commodity"
+        elif t in {"UVXY", "VXX"}:
+            at = "Volatility"
+        elif ticker in _ETFS:
+            at = "ETF"
+        else:
+            at = "Equity"
+        atype[at] = atype.get(at, 0.0) + cv
+
+        # Sector from scores frame; fall back to "Other" for missing/NaN.
+        sector_label = "Other"
+        if scores is not None and hasattr(scores, "index") and ticker in scores.index:
+            try:
+                s = scores.loc[ticker, "sector"]
+                if s and not pd.isna(s) and str(s).strip():
+                    sector_label = str(s).strip()
+            except Exception:  # noqa: BLE001
+                pass
+        sec[sector_label] = sec.get(sector_label, 0.0) + cv
+
+    def _bucket(raw: dict) -> dict:
+        """Convert raw dollar totals to fractions; merge <3% into Other; sort desc."""
+        frac = {k: v / total for k, v in raw.items() if v > 0}
+        other = frac.pop("Other", 0.0)
+        small = [k for k, v in frac.items() if v < 0.03]
+        for k in small:
+            other += frac.pop(k)
+        out = dict(sorted(frac.items(), key=lambda kv: -kv[1]))
+        if other > 0:
+            out["Other"] = other
+        return out
+
+    return {
+        "geography": _bucket(geo),
+        "asset_type": _bucket(atype),
+        "sector": _bucket(sec),
+    }
+
 
 # ---------------------------------------------------------------------------
 # Render-view adapter (pure) — overlay result -> exec-panel-compatible dict
@@ -247,6 +358,29 @@ def build_overlay_preview_html() -> str:
             "profit_pct": 5.0,
             "available": 25_000.0,
             "invested_cost": 212_500.0,
+        },
+        "allocations": {
+            "geography": {
+                "North America": 0.62,
+                "Europe": 0.24,
+                "Asia-Pacific": 0.09,
+                "Other": 0.05,
+            },
+            "asset_type": {
+                "Equity": 0.82,
+                "ETF": 0.10,
+                "Commodity": 0.05,
+                "Volatility": 0.03,
+            },
+            "sector": {
+                "Technology": 0.34,
+                "Financials": 0.16,
+                "Health Care": 0.14,
+                "Industrials": 0.10,
+                "Consumer": 0.09,
+                "Energy": 0.07,
+                "Other": 0.10,
+            },
         },
     }
     return render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
@@ -411,6 +545,7 @@ def main() -> None:
         "generated_utc": now.strftime("%Y-%m-%d %H:%M UTC"),
         "current_weights_approx": approx,
         "account": account_block,
+        "allocations": _compute_allocations(_positions, scores),
     }
     html = render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -44,6 +44,7 @@ from scripts.v3_full_report import (  # noqa: E402  (pure helpers, reused)
     load_account_block,
     load_account_json,
     load_account_positions,
+    load_account_social,
     resolve_current_weights,
 )
 from scripts.v3_portfolio import trend_regime  # noqa: E402  (pure, unit-tested)
@@ -359,6 +360,24 @@ def build_overlay_preview_html() -> str:
             "available": 25_000.0,
             "invested_cost": 212_500.0,
         },
+        "social": {
+            "copiers": 1375,
+            "baseline_copiers": 1390,
+            "copiers_gain_pct": -1.08,
+            "risk_score": 3,
+            "max_daily_risk": 4,
+            "win_ratio": 54.57,
+            "trades_ytd": 361,
+            "gain_ytd": 3.4,
+            "gain_mtd": 2.08,
+            "daily_gain": -0.86,
+            "week_gain": -0.87,
+            "aum_tier_desc": "$1M-$2M",
+            "unique_assets": 48,
+            "open_positions": 175,
+            "shorts": 0,
+            "cash_pct": 11.0,
+        },
         "allocations": {
             "geography": {
                 "North America": 0.62,
@@ -524,6 +543,7 @@ def main() -> None:
     # Attach live P/L from the eToro account snapshot to held names (P/L $ / % / value).
     _positions = load_account_positions()
     account_block = load_account_block()
+    social_block = load_account_social()
     for _a in actions:
         _p = _positions.get(_a.get("ticker"))
         if _p:
@@ -545,6 +565,7 @@ def main() -> None:
         "generated_utc": now.strftime("%Y-%m-%d %H:%M UTC"),
         "current_weights_approx": approx,
         "account": account_block,
+        "social": social_block,
         "allocations": _compute_allocations(_positions, scores),
     }
     html = render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -41,6 +41,7 @@ from scripts.v3_full_report import (  # noqa: E402  (pure helpers, reused)
     _read_tickers,
     _synthetic_scores,
     _system_read,
+    load_account_block,
     load_account_json,
     load_account_positions,
     resolve_current_weights,
@@ -240,6 +241,13 @@ def build_overlay_preview_html() -> str:
         "enriched": int(scores["pb"].notna().sum()),
         "generated_utc": now.strftime("%Y-%m-%d %H:%M UTC"),
         "current_weights_approx": False,
+        "account": {
+            "total_equity": 250_000.0,
+            "unrealized_pnl": 12_500.0,
+            "profit_pct": 5.0,
+            "available": 25_000.0,
+            "invested_cost": 212_500.0,
+        },
     }
     return render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 
@@ -253,8 +261,8 @@ def _self_check(html: str) -> None:
     for cls in ("buy", "sell"):  # overlay's signature action groups
         if f"act-grp act-grp--{cls}" not in html:
             problems.append(f"action group {cls} missing")
-    if '<article class="card"' not in html:
-        problems.append("factor cards missing")
+    if '<article class="card card--action"' not in html:
+        problems.append("action cards missing")
     if "None" in html:
         problems.append("literal 'None' present")
     if "—" in html:
@@ -381,6 +389,7 @@ def main() -> None:
     actions = build_actions(overlay["weights"], current_weights, scores, nav=nav)
     # Attach live P/L from the eToro account snapshot to held names (P/L $ / % / value).
     _positions = load_account_positions()
+    account_block = load_account_block()
     for _a in actions:
         _p = _positions.get(_a.get("ticker"))
         if _p:
@@ -401,6 +410,7 @@ def main() -> None:
         "enriched": enriched,
         "generated_utc": now.strftime("%Y-%m-%d %H:%M UTC"),
         "current_weights_approx": approx,
+        "account": account_block,
     }
     html = render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -83,6 +83,29 @@ _SECTOR_CAP = float(os.environ.get("V3_SECTOR_CAP", "0.35"))
 _USD_BLOC_CAP = float(os.environ.get("V3_USD_BLOC_CAP", "0.60"))
 _REGION_CAP = float(os.environ.get("V3_REGION_CAP", "0.65"))
 _ADV_MIN = float(os.environ.get("V3_ADV_MIN", "1e6"))  # min avg dollar-volume/day (USD)
+# Polymarket deployment dial. The signal is a shadow / ZERO-conviction cross-repo
+# input, so the book-moving tilt is OFF by default (V3_PM_MAX_TILT=0 -> advisory
+# only: the signal is fetched + shown in the report but does not move deployment).
+# Set V3_PM_MAX_TILT (e.g. 0.03 = +-3pp) to go live once the signal is validated.
+_PM_MAX_TILT = float(os.environ.get("V3_PM_MAX_TILT", "0.0"))
+
+
+def _polymarket_signal() -> float | None:
+    """Latest normalised Polymarket signal in [-1, 1], or None.
+
+    Read from V3_POLYMARKET_SIGNAL (a float the VPS cron exports from the
+    trading-hub Polymarket tool). Absent / blank / unparseable -> None, so the
+    dial degrades gracefully where Gamma is unreachable (e.g. the NBG Mac).
+    """
+    raw = os.environ.get("V3_POLYMARKET_SIGNAL")
+    if not raw or not raw.strip():
+        return None
+    try:
+        return max(-1.0, min(1.0, float(raw)))
+    except ValueError:
+        return None
+
+
 _CAP_MODE: str | None = os.environ.get("V3_CAP_MODE") or None
 
 
@@ -510,7 +533,9 @@ def main() -> None:
 
     regime, _mult = trend_regime(spx_close)
     regime_label, regime_detail = compute_regime(spx_close)
-    gross_target, cond = resolve_deployment(regime, polymarket_signal=None)
+    gross_target, cond = resolve_deployment(
+        regime, polymarket_signal=_polymarket_signal(), max_pm_tilt=_PM_MAX_TILT
+    )
     print(f"regime: {regime}  deployment: {gross_target:.0%}")
 
     # --- Current book (live account anchors the overlay; else equal-split) ---

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -75,8 +75,8 @@ MEGA_CORE: list[str] = ["NVDA", "GOOG", "MSFT", "AAPL", "AMZN", "AVGO", "TSM", "
 
 # Overridable via env so the same runner produces any confirmed config.
 _VOL_CEILING = float(os.environ.get("V3_VOL_CEILING", "0.18"))
-_NAME_CAP = float(os.environ.get("V3_NAME_CAP", "0.08"))
-_SECTOR_CAP = float(os.environ.get("V3_SECTOR_CAP", "0.25"))
+_NAME_CAP = float(os.environ.get("V3_NAME_CAP", "0.10"))
+_SECTOR_CAP = float(os.environ.get("V3_SECTOR_CAP", "0.35"))
 _USD_BLOC_CAP = float(os.environ.get("V3_USD_BLOC_CAP", "0.60"))
 _CAP_MODE: str | None = os.environ.get("V3_CAP_MODE") or None
 

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -82,6 +82,7 @@ _NAME_CAP = float(os.environ.get("V3_NAME_CAP", "0.10"))
 _SECTOR_CAP = float(os.environ.get("V3_SECTOR_CAP", "0.35"))
 _USD_BLOC_CAP = float(os.environ.get("V3_USD_BLOC_CAP", "0.60"))
 _REGION_CAP = float(os.environ.get("V3_REGION_CAP", "0.65"))
+_ADV_MIN = float(os.environ.get("V3_ADV_MIN", "1e6"))  # min avg dollar-volume/day (USD)
 _CAP_MODE: str | None = os.environ.get("V3_CAP_MODE") or None
 
 
@@ -408,6 +409,7 @@ def build_overlay_preview_html() -> str:
             },
         },
         "caps": {"name": 0.10, "sector": 0.35, "usd_bloc": 0.60, "region": 0.65},
+        "coverage": {"n_scored": 22, "n_eligible": 20, "pct": 0.91, "adv_dropped": 3},
     }
     return render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 
@@ -467,9 +469,30 @@ def main() -> None:
     scores = compute_scores(feats, sector_neutral=True, cluster_weights=BALANCED_WEIGHTS)
     scores["is_portfolio"] = scores.index.isin(port_set)
 
+    # ADV liquidity gate: drop BUY CANDIDATES (not held) with a KNOWN ADV below the
+    # floor. Held names are exempt (never force-sold for liquidity); names with no
+    # volume data are kept (not penalized for a data gap). Positions run $5-10k, so a
+    # $1M/day floor clears cheaply. adv_usd is FX-normalized to USD in features.
+    _cov_scored_before = len(scores)
+    if "adv_usd" in scores.columns and _ADV_MIN > 0:
+        _adv = pd.to_numeric(scores["adv_usd"], errors="coerce")
+        _illiquid = (~scores["is_portfolio"]) & _adv.notna() & (_adv < _ADV_MIN)
+        _n_illiquid = int(_illiquid.sum())
+        if _n_illiquid:
+            scores = scores[~_illiquid].copy()
+            print(f"ADV gate: dropped {_n_illiquid} candidates below ${_ADV_MIN:,.0f}/day ADV")
+
     elig = scores.get("eligible", pd.Series(True, index=scores.index)).fillna(False).astype(bool)
     n_port = int((scores["is_portfolio"] & elig).sum())
     n_cand = int((~scores["is_portfolio"] & elig).sum())
+    # Coverage: how much of the scored universe clears the eligibility bar (equity +
+    # priced + >=3 of 6 clusters). A data-quality readout for the report.
+    coverage = {
+        "n_scored": len(scores),
+        "n_eligible": int(elig.sum()),
+        "pct": (int(elig.sum()) / len(scores)) if len(scores) else 0.0,
+        "adv_dropped": _cov_scored_before - len(scores),
+    }
 
     # --- Prices + market regime ---
     prices: pd.DataFrame = pd.DataFrame()
@@ -580,6 +603,7 @@ def main() -> None:
             "usd_bloc": _USD_BLOC_CAP,
             "region": _REGION_CAP,
         },
+        "coverage": coverage,
     }
     html = render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -81,6 +81,7 @@ _VOL_CEILING = float(os.environ.get("V3_VOL_CEILING", "0.18"))
 _NAME_CAP = float(os.environ.get("V3_NAME_CAP", "0.10"))
 _SECTOR_CAP = float(os.environ.get("V3_SECTOR_CAP", "0.35"))
 _USD_BLOC_CAP = float(os.environ.get("V3_USD_BLOC_CAP", "0.60"))
+_REGION_CAP = float(os.environ.get("V3_REGION_CAP", "0.65"))
 _CAP_MODE: str | None = os.environ.get("V3_CAP_MODE") or None
 
 
@@ -247,17 +248,22 @@ def overlay_portfolio_view(overlay: dict, scored: pd.DataFrame) -> dict:
 
     cvar_dep = gate.get("cvar_after")
     cvar_rb = float(cvar_dep) / gross if (cvar_dep is not None and gross > 0) else None
+    odiag = overlay["diagnostics"]
+    region_exp = odiag.get("region_exposures") or {}
+    max_region = odiag.get("max_region")
     return {
         "weights": weights,
         "gross": gross,
         "cash": max(0.0, 1.0 - gross),
         "usd_bloc": usd_bloc,
         "sector_exposures": sector_exp,
+        "region_exposures": region_exp,
         "selected": [t for t in weights.index if float(weights[t]) > 1e-9],
         "diagnostics": {
             "gate": gate,
             "cvar_95_deployed": cvar_dep,
             "cvar_95_risk_book": cvar_rb,
+            "max_region": max_region,
             "binding": {},
         },
     }
@@ -401,6 +407,7 @@ def build_overlay_preview_html() -> str:
                 "Other": 0.10,
             },
         },
+        "caps": {"name": 0.10, "sector": 0.35, "usd_bloc": 0.60, "region": 0.65},
     }
     return render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 
@@ -567,6 +574,12 @@ def main() -> None:
         "account": account_block,
         "social": social_block,
         "allocations": _compute_allocations(_positions, scores),
+        "caps": {
+            "name": _NAME_CAP,
+            "sector": _SECTOR_CAP,
+            "usd_bloc": _USD_BLOC_CAP,
+            "region": _REGION_CAP,
+        },
     }
     html = render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 

--- a/tests/unit/trade_modules/test_v3_conditioning.py
+++ b/tests/unit/trade_modules/test_v3_conditioning.py
@@ -17,9 +17,9 @@ from trade_modules.v3.conditioning import (
 
 
 def test_deployment_by_regime_values() -> None:
-    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.85
-    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.90
-    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.95
+    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.78
+    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.88
+    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.98
 
 
 # ---------------------------------------------------------------------------
@@ -29,23 +29,23 @@ def test_deployment_by_regime_values() -> None:
 
 class TestRegimeDeployment:
     def test_risk_off(self) -> None:
-        assert regime_deployment("risk_off") == pytest.approx(0.85)
+        assert regime_deployment("risk_off") == pytest.approx(0.78)
 
     def test_neutral(self) -> None:
-        assert regime_deployment("neutral") == pytest.approx(0.90)
+        assert regime_deployment("neutral") == pytest.approx(0.88)
 
     def test_risk_on(self) -> None:
-        assert regime_deployment("risk_on") == pytest.approx(0.95)
+        assert regime_deployment("risk_on") == pytest.approx(0.98)
 
     def test_unknown_returns_neutral(self) -> None:
-        assert regime_deployment("unknown") == pytest.approx(0.90)
+        assert regime_deployment("unknown") == pytest.approx(0.88)
 
     def test_empty_string_returns_neutral(self) -> None:
-        assert regime_deployment("") == pytest.approx(0.90)
+        assert regime_deployment("") == pytest.approx(0.88)
 
     def test_none_as_string_returns_neutral(self) -> None:
         # None is not in the dict; falls back to neutral.
-        assert regime_deployment("None") == pytest.approx(0.90)
+        assert regime_deployment("None") == pytest.approx(0.88)
 
 
 # ---------------------------------------------------------------------------
@@ -102,27 +102,27 @@ class TestPolymarketAdjustment:
 class TestResolveDeployment:
     def test_known_regime_no_pm(self) -> None:
         dep, diag = resolve_deployment("risk_on")
-        assert dep == pytest.approx(0.95)
-        assert diag["final_deployment"] == pytest.approx(0.95)
+        assert dep == pytest.approx(0.98)
+        assert diag["final_deployment"] == pytest.approx(0.98)
 
     def test_neutral_regime(self) -> None:
         dep, diag = resolve_deployment("neutral")
-        assert dep == pytest.approx(0.90)
+        assert dep == pytest.approx(0.88)
 
     def test_risk_off_regime(self) -> None:
         dep, diag = resolve_deployment("risk_off")
-        assert dep == pytest.approx(0.85)
+        assert dep == pytest.approx(0.78)
 
     def test_unknown_regime_neutral_fallback(self) -> None:
         dep, _ = resolve_deployment("garbage")
-        assert dep == pytest.approx(0.90)
+        assert dep == pytest.approx(0.88)
 
     # Polymarket inert by default
     def test_polymarket_inactive_by_default(self) -> None:
         _, diag = resolve_deployment("neutral", polymarket_signal=0.9)
         assert diag["polymarket_active"] is False
         assert diag["polymarket_tilt"] == pytest.approx(0.0)
-        assert diag["final_deployment"] == pytest.approx(0.90)
+        assert diag["final_deployment"] == pytest.approx(0.88)
 
     def test_polymarket_active_flag(self) -> None:
         _, diag = resolve_deployment("neutral", polymarket_signal=1.0, max_pm_tilt=0.03)
@@ -130,14 +130,14 @@ class TestResolveDeployment:
 
     # Band clamping
     def test_clamped_to_upper_band(self) -> None:
-        # risk_on (0.95) + large positive tilt should not exceed 0.95 (hi of default band)
+        # risk_on (0.98) + large positive tilt should not exceed 0.98 (hi of default band)
         dep, diag = resolve_deployment("risk_on", polymarket_signal=1.0, max_pm_tilt=0.10)
-        assert dep <= 0.95 + 1e-9
+        assert dep <= 0.98 + 1e-9
 
     def test_clamped_to_lower_band(self) -> None:
-        # risk_off (0.85) + large negative tilt should not go below 0.85 (lo of default band)
+        # risk_off (0.78) + large negative tilt should not go below 0.78 (lo of default band)
         dep, diag = resolve_deployment("risk_off", polymarket_signal=-1.0, max_pm_tilt=0.10)
-        assert dep >= 0.85 - 1e-9
+        assert dep >= 0.78 - 1e-9
 
     def test_custom_band(self) -> None:
         dep, _ = resolve_deployment("risk_on", band=(0.70, 0.80))

--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -16,7 +16,7 @@ mother market (Change 3).
 import numpy as np
 import pandas as pd
 
-from trade_modules.v3.construct import build_portfolio, dedup_dual_listings
+from trade_modules.v3.construct import build_portfolio, dedup_dual_listings, region_of
 
 # A rich synthetic universe: 9 USD-bloc + 3 EUR names; 6 Tech (sector-cap bait).
 _USD = ["AA1", "AA2", "AA3", "AA4", "AA5", "AA6", "AA7", "AA8", "AA9"]
@@ -178,6 +178,7 @@ def test_conviction_weight_zero_reproduces_pure_erc():
         name_cap=name_cap,
         sector_cap=sector_cap,
         usd_bloc_cap=usd_cap,
+        region_cap=1.0,  # disable region cap: the manual mirror below has no region step
         gross_target=gt,
         cvar_budget=10.0,
     )
@@ -466,6 +467,7 @@ def test_falls_back_to_single_factor_cov_when_prices_missing():
         name_cap=1.0,
         sector_cap=1.0,
         usd_bloc_cap=1.0,
+        region_cap=1.0,  # disable the region cap too, to isolate the cov fallback
         gross_target=1.0,
         cvar_budget=10.0,
     )
@@ -475,6 +477,43 @@ def test_falls_back_to_single_factor_cov_when_prices_missing():
     # Equal betas -> single-factor cov is (near) equal-variance -> ~equal ERC weights.
     sel_w = w[w > 1e-9]
     assert sel_w.std() / sel_w.mean() < 0.05
+
+
+def test_region_of_from_listing_suffix():
+    assert region_of("AAPL") == "North America"
+    assert region_of("SHOP.TO") == "North America"
+    assert region_of("SAP.DE") == "Europe"
+    assert region_of("ASML.AS") == "Europe"
+    assert region_of("8035.T") == "Asia-Pacific"
+    assert region_of("0700.HK") == "Asia-Pacific"
+    assert region_of("VALE.SA") == "Latin America"
+    assert region_of("BTC-USD") == "Crypto/Global"
+    assert region_of("BRK-B") == "North America"  # hyphen, but not crypto
+
+
+def test_region_cap_binds_on_us_heavy_book():
+    # _ALL is 9 US (bare) + 3 European (.DE/.PA) -> 75% North America at equal weight.
+    # The 65% region cap must trim North America to <= 65% of the deployed book.
+    scored = _make_scored(betas=1.0)
+    res = build_portfolio(
+        scored,
+        pd.DataFrame(),  # single-factor cov fallback -> ~equal risk
+        top_n=12,
+        conviction_weight=0.0,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+        region_cap=0.65,
+        gross_target=1.0,
+        cvar_budget=10.0,
+    )
+    w = res["weights"]
+    gross = float(w.sum())
+    na = sum(float(v) for t, v in w.items() if region_of(t) == "North America")
+    assert gross > 0.0
+    assert na / gross <= 0.65 + 1e-6  # region cap enforced
+    assert res["diagnostics"]["binding"]["region_cap"] is False  # holds on final book
+    assert "North America" in res["region_exposures"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -500,10 +500,11 @@ def test_region_cap_binds_on_us_heavy_book():
         pd.DataFrame(),  # single-factor cov fallback -> ~equal risk
         top_n=12,
         conviction_weight=0.0,
-        name_cap=1.0,
+        name_cap=0.10,  # PRODUCTION name cap: exercises the name-cap/region interaction
         sector_cap=1.0,
         usd_bloc_cap=1.0,
         region_cap=0.65,
+        region_hard=True,  # opt-in HARD enforcement (gate trims excess to cash)
         gross_target=1.0,
         cvar_budget=10.0,
     )
@@ -511,8 +512,40 @@ def test_region_cap_binds_on_us_heavy_book():
     gross = float(w.sum())
     na = sum(float(v) for t, v in w.items() if region_of(t) == "North America")
     assert gross > 0.0
-    assert na / gross <= 0.65 + 1e-6  # region cap enforced
-    assert res["diagnostics"]["binding"]["region_cap"] is False  # holds on final book
+    # Hard enforcement holds North America to <= 65% of the INTENDED capital
+    # (gross_target=1.0), even with the name cap active — the gate's joint name+region
+    # convergence + clamp must not let the name-cap re-assert flow weight back into NA
+    # above the absolute region threshold. (Region as a fraction of the FINAL book can
+    # read marginally higher if the vol gross-cut later shrinks the denominator.)
+    assert na <= 0.65 * 1.0 + 5e-3
+    # And hard enforcement holds NA well below the un-enforced ~75% it would otherwise be.
+    assert na / gross < 0.75
+    assert "North America" in res["region_exposures"]
+
+
+def test_region_cap_monitors_by_default_no_forced_cash():
+    """Default (region_hard=False): region is reported + flagged, never forces cash."""
+    scored = _make_scored(betas=1.0)
+    res = build_portfolio(
+        scored,
+        pd.DataFrame(),
+        top_n=12,
+        conviction_weight=0.0,
+        name_cap=1.0,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+        region_cap=0.65,  # US-heavy book breaches this, but default = monitor
+        gross_target=1.0,
+        cvar_budget=10.0,
+    )
+    w = res["weights"]
+    gross = float(w.sum())
+    na = sum(float(v) for t, v in w.items() if region_of(t) == "North America")
+    assert gross > 0.0
+    # Monitor does NOT trim region: North America stays OVER the 65% cap (the US-heavy
+    # book is left as-is by the region axis) but is honestly flagged as a breach.
+    assert na / gross > 0.65
+    assert res["diagnostics"]["binding"]["region_cap"] is True
     assert "North America" in res["region_exposures"]
 
 

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -302,9 +302,19 @@ def test_target_dispersion_math(tmp_path):
 
 def test_adv_usd_math(tmp_path):
     feats = _run(tmp_path)
-    # 1_000_000 * 200 = 2e8
+    # 1_000_000 * 200 = 2e8 (AAPL is a US listing -> FX rate 1.0, no conversion)
     assert feats.loc["AAPL", "adv_usd"] == 2e8
     assert feats.loc["MSFT", "adv_usd"] == 800_000 * 400.0
+
+
+def test_usd_rate_normalizes_local_currency_cap_and_adv():
+    """cap + adv_usd must convert local currency to USD via _usd_rate_for."""
+    from trade_modules.v3.features import _usd_rate_for
+
+    assert _usd_rate_for("AAPL") == 1.0  # US listing -> no conversion
+    assert _usd_rate_for("UNKNOWN.ZZ") == 1.0  # unmapped suffix -> USD (no-op)
+    assert _usd_rate_for("7203.T") < 0.02  # yen cap must shrink hard to USD
+    assert _usd_rate_for("SAP.DE") > 1.0  # euro is worth more than a dollar
 
 
 def test_ticker_missing_from_info_still_appears(tmp_path):

--- a/tests/unit/trade_modules/test_v3_full_report.py
+++ b/tests/unit/trade_modules/test_v3_full_report.py
@@ -104,6 +104,6 @@ def test_build_synthetic_preview_is_complete():
     assert '<div class="exec-panel">' in html
     for cls in ("buy", "add", "trim", "sell", "hold"):
         assert f"act-grp act-grp--{cls}" in html, f"missing action group: {cls}"
-    assert '<article class="card"' in html
+    assert '<article class="card' in html  # matches "card" and "card card--action"
     assert "None" not in html
     assert "—" not in html

--- a/tests/unit/trade_modules/test_v3_portfolio.py
+++ b/tests/unit/trade_modules/test_v3_portfolio.py
@@ -127,13 +127,13 @@ class TestTrendRegime:
 
 class TestDeploymentByRegime:
     def test_mapping_values(self):
-        assert DEPLOYMENT_BY_REGIME["risk_off"] == pytest.approx(0.85)
-        assert DEPLOYMENT_BY_REGIME["neutral"] == pytest.approx(0.90)
-        assert DEPLOYMENT_BY_REGIME["risk_on"] == pytest.approx(0.95)
+        assert DEPLOYMENT_BY_REGIME["risk_off"] == pytest.approx(0.78)
+        assert DEPLOYMENT_BY_REGIME["neutral"] == pytest.approx(0.88)
+        assert DEPLOYMENT_BY_REGIME["risk_on"] == pytest.approx(0.98)
 
-    def test_averages_about_ninety(self):
+    def test_averages_about_mid_band(self):
         vals = [DEPLOYMENT_BY_REGIME[r] for r in ("risk_off", "neutral", "risk_on")]
-        assert sum(vals) / len(vals) == pytest.approx(0.90)
+        assert sum(vals) / len(vals) == pytest.approx(0.88)
 
     def test_ordered_by_risk_appetite(self):
         assert (

--- a/tests/unit/trade_modules/test_v3_report.py
+++ b/tests/unit/trade_modules/test_v3_report.py
@@ -110,10 +110,24 @@ def test_render_contains_tickers_and_names():
 
 
 def test_render_contains_cluster_and_group_labels():
+    # Cluster labels appear in the methodology footer.
     html = render_report(_scores(), _meta())
     for label in ["Value", "Quality", "Momentum", "Low-vol", "Strength"]:
         assert label in html
-    # Added metrics surfaced prominently.
+    # Metric group labels (EV/EBITDA, ROA, …) appear inside action deep-dive cards.
+    scores = _scores()
+    actions = [
+        {
+            "ticker": "AAPL",
+            "action": "BUY",
+            "conviction": 1.5,
+            "current_pct": 0.0,
+            "target_pct": 0.05,
+            "delta_pct": 0.05,
+            "delta_usd": 5000.0,
+        },
+    ]
+    html = render_report(scores, _meta(), actions=actions)
     for label in ["EV/EBITDA", "ROA", "Current Ratio", "ADV"]:
         assert label in html
 
@@ -162,16 +176,12 @@ def test_overview_blank_cell_for_nan_cluster():
 
 
 def test_render_curates_candidate_cards_and_notes_count():
-    scores = _many_scores(n=34, n_port=4)  # 30 candidates
+    scores = _many_scores(n=34, n_port=4)
     html = render_report(scores, {"regime": "NEUTRAL"}, max_long_cards=5, max_avoid_cards=3)
     # overview still lists the FULL universe
     assert html.count('class="hm-row"') == 34
-    # detailed cards curated to portfolio(4) + top(5) + bottom(3) = 12
-    assert html.count('<article class="card"') == 12
-    # honest "showing X of Y" note for the curated candidate subset
-    assert "showing 8 of 30" in html
-    # the avoid block is separated by a labeled divider
-    assert "potential avoids" in html.lower()
+    # no action cards without an actions list
+    assert html.count('<article class="card"') == 0
 
 
 def test_render_curation_excludes_midpack_candidate_cards():
@@ -232,12 +242,33 @@ def test_render_shows_trade_levels():
     scores["stop_loss"] = [180.0, 360.0, np.nan]
     scores["take_profit"] = [230.0, 460.0, np.nan]
     scores["rr"] = [1.5, 1.5, np.nan]
-    html = render_report(scores, _meta())
+    # Trade levels only render inside BUY/ADD action cards.
+    actions = [
+        {
+            "ticker": "AAPL",
+            "action": "BUY",
+            "conviction": 1.5,
+            "current_pct": 0.0,
+            "target_pct": 0.05,
+            "delta_pct": 0.05,
+            "delta_usd": 5000.0,
+        },
+        {
+            "ticker": "ZZZ",
+            "action": "ADD",
+            "conviction": 0.5,
+            "current_pct": 0.02,
+            "target_pct": 0.05,
+            "delta_pct": 0.03,
+            "delta_usd": 3000.0,
+        },
+    ]
+    html = render_report(scores, _meta(), actions=actions)
     assert "Trade Levels" in html
     for lbl in ("Entry", "Stop", "Target", "R:R"):
         assert lbl in html
     assert "$180.00" in html  # AAPL stop-loss tile
-    assert "n/a" in html  # ZZZ has no vol -> degenerate levels
+    assert "n/a" in html  # ZZZ has NaN stop/target -> degenerate levels
 
 
 def test_cards_single_column_and_container_grid():
@@ -279,14 +310,49 @@ def test_compute_regime_short_series_neutral():
 
 
 def test_render_card_shows_description():
-    """Cards include the business description as a muted line when present."""
-    html = render_report(_scores(), _meta())
-    # AAPL has a description → should appear in the rendered HTML
+    """Action cards include the business description as a muted line when present."""
+    scores = _scores()
+    scores["entry"] = scores["price"]
+    scores["stop_loss"] = scores["price"] * 0.90
+    scores["take_profit"] = scores["price"] * 1.15
+    actions = [
+        {
+            "ticker": "AAPL",
+            "action": "BUY",
+            "conviction": 1.5,
+            "current_pct": 0.0,
+            "target_pct": 0.05,
+            "delta_pct": 0.05,
+            "delta_usd": 5000.0,
+        },
+        {
+            "ticker": "MSFT",
+            "action": "ADD",
+            "conviction": 1.2,
+            "current_pct": 0.05,
+            "target_pct": 0.08,
+            "delta_pct": 0.03,
+            "delta_usd": 3000.0,
+        },
+        {
+            "ticker": "ZZZ",
+            "action": "SELL",
+            "conviction": -1.0,
+            "current_pct": 0.03,
+            "target_pct": 0.0,
+            "delta_pct": -0.03,
+            "delta_usd": -3000.0,
+        },
+    ]
+    html = render_report(scores, _meta(), actions=actions)
+    # AAPL has a description → appears in its action card
     assert "designs and markets smartphones" in html
     # MSFT description also present
     assert "Microsoft develops software" in html
-    # ZZZ has empty description → no empty desc div should pollute the card
-    assert 'class="desc">' not in html.split("ZED CORP")[1].split("Energy")[0]
+    # ZZZ has empty description → no empty desc div in its card portion
+    # Use [-1] because "ZED CORP" appears first in the heatmap name column,
+    # then again inside the SELL action card; we want the card occurrence.
+    assert 'class="desc">' not in html.split("ZED CORP")[-1].split("Energy")[0]
 
 
 # ---------------------------------------------------------------------------
@@ -362,8 +428,8 @@ def test_render_shows_all_action_groups_and_note():
 def test_render_factor_cards_still_present_below():
     scores, result, actions, cond = _pac()
     html = render_report(scores, _meta(), portfolio=result, actions=actions, conditioning=cond)
-    # existing factor cards + overview still rendered
-    assert '<article class="card"' in html
+    # action deep-dive cards render (Portfolio/Candidates sections removed)
+    assert '<article class="card card--action"' in html
     assert "Overview" in html
     # exec/actions come ABOVE the overview heatmap
     assert html.index("Suggested Actions") < html.index(">Overview<")

--- a/tests/unit/trade_modules/test_v3_report.py
+++ b/tests/unit/trade_modules/test_v3_report.py
@@ -525,3 +525,39 @@ def test_exec_panel_deployed_cvar_uses_post_gate_value():
     assert "15.0%" not in html, "pre-gate cvar_95_deployed leaked into deployed-CVaR tile"
     # Risk-book tile must be unchanged (20.0% still present).
     assert "20.0%" in html, "risk-book CVaR tile was incorrectly modified"
+
+
+def test_allocation_bars_renders_heading_and_widths_and_is_absent_when_empty():
+    """_allocation_bars renders section heading + bar widths; empty inputs are crash-free."""
+    from trade_modules.v3.report import _allocation_bars
+
+    alloc = {
+        "geography": {"North America": 0.62, "Europe": 0.24, "Other": 0.14},
+        "asset_type": {"Equity": 0.82, "ETF": 0.10, "Other": 0.08},
+        "sector": {"Technology": 0.34, "Financials": 0.30, "Other": 0.36},
+    }
+
+    # Direct renderer: heading and at least one bar width present.
+    html = _allocation_bars(alloc)
+    assert "Portfolio Allocation" in html
+    assert "width:62%" in html  # North America 62 %
+
+    # Falsy inputs produce no output and do not raise.
+    assert _allocation_bars({}) == ""
+    assert _allocation_bars(None) == ""
+
+    # Via render_report: allocation section appears inside Section I when portfolio provided.
+    scores, result, actions, cond = _pac()
+    meta = dict(_meta())
+    meta["allocations"] = alloc
+    html_report = render_report(scores, meta, portfolio=result, actions=actions, conditioning=cond)
+    assert "Portfolio Allocation" in html_report
+    assert "width:62%" in html_report
+
+    # Empty allocations: section absent, no crash.
+    meta_empty = dict(_meta())
+    meta_empty["allocations"] = {}
+    html_empty = render_report(
+        scores, meta_empty, portfolio=result, actions=actions, conditioning=cond
+    )
+    assert "Portfolio Allocation" not in html_empty

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -54,7 +54,11 @@ DIRECTION = {
 
 # Scoring clusters -> member metrics.
 CLUSTERS = {
-    "value_z": ["pe_trailing", "pe_forward", "ps_sector", "pb", "ev_ebitda"],
+    # pe_forward + ps_sector pruned 2026-07-14: near-duplicates of pe_trailing
+    # (rho 0.75/0.77) and of each other (pe_forward~ps_sector 0.98) -> double-counted
+    # valuation. Kept a diverse trio: earnings (pe_trailing), book (pb), enterprise
+    # (ev_ebitda). Pruned metrics still SHOWN as raw context in the card, not scored.
+    "value_z": ["pe_trailing", "pb", "ev_ebitda"],
     "quality_z": [
         "roe",
         "roa",
@@ -65,7 +69,9 @@ CLUSTERS = {
         "de",
         "accruals",
     ],
-    "momentum_z": ["mom_12_1", "price_perf", "pct_52w_high"],
+    # price_perf pruned 2026-07-14: rho 0.95 with mom_12_1 (same price move counted
+    # twice). Kept the academic 12-1 skip-month + 52w-high proximity (distinct).
+    "momentum_z": ["mom_12_1", "pct_52w_high"],
     "growth_z": ["earn_growth", "rev_growth"],
     "lowvol_z": ["beta", "realized_vol"],
     "strength_z": ["analyst_mom", "upside", "buy_pct", "short_interest", "target_dispersion"],

--- a/trade_modules/v3/conditioning.py
+++ b/trade_modules/v3/conditioning.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 # Regime → base deployment fraction
 # ---------------------------------------------------------------------------
 
-# Fraction of capital deployed by market regime (band 85-95%).
+# Fraction of capital deployed by market regime (band 78-98%).
 # This is the SINGLE SOURCE OF TRUTH — imported back into v3_portfolio.py.
 DEPLOYMENT_BY_REGIME: dict[str, float] = {
-    "risk_off": 0.85,
-    "neutral": 0.90,
-    "risk_on": 0.95,
+    "risk_off": 0.78,
+    "neutral": 0.88,
+    "risk_on": 0.98,
 }
 
 _UNKNOWN_DEPLOYMENT = DEPLOYMENT_BY_REGIME["neutral"]
@@ -25,7 +25,7 @@ _UNKNOWN_DEPLOYMENT = DEPLOYMENT_BY_REGIME["neutral"]
 def regime_deployment(regime: str) -> float:
     """Return the base deployment fraction for a regime string.
 
-    Unknown / missing regime labels fall back to neutral (0.90).
+    Unknown / missing regime labels fall back to neutral (0.88).
 
     Args:
         regime: One of ``"risk_off"``, ``"neutral"``, ``"risk_on"``.
@@ -75,7 +75,7 @@ def resolve_deployment(
     polymarket_signal: float | None = None,
     *,
     max_pm_tilt: float = 0.0,
-    band: tuple[float, float] = (0.85, 0.95),
+    band: tuple[float, float] = (0.78, 0.98),
 ) -> tuple[float, dict]:
     """Resolve the final deployment fraction and emit a diagnostic dict.
 

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -76,6 +76,8 @@ _SUFFIX_COUNTRY = {
     ".V": "Canada",
     ".SA": "Brazil",
     ".MX": "Mexico",
+    ".BA": "Argentina",
+    ".SN": "Chile",
 }
 _HOME_COUNTRY = "United States"  # bare / unmapped suffix
 
@@ -111,6 +113,8 @@ _COUNTRY_REGION = {
     "Australia": "Asia-Pacific",
     "Brazil": "Latin America",
     "Mexico": "Latin America",
+    "Argentina": "Latin America",
+    "Chile": "Latin America",
 }
 _DEFAULT_REGION = "North America"  # bare/unmapped US listing
 

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -385,6 +385,7 @@ def build_portfolio(
     sector_cap: float = 0.25,
     usd_bloc_cap: float = 0.60,
     region_cap: float = 0.65,
+    region_hard: bool = False,
     gross_target: float = 0.90,
     cvar_budget: float = 0.25,
     vol_ceiling: float = 0.18,
@@ -489,7 +490,9 @@ def build_portfolio(
     if w_sum > 0:
         w = w / w_sum  # renormalize to sum = 1
 
-    # --- caps: name -> USD-bloc -> sector -> region (single-name reasserted between) ---
+    # --- caps: name -> USD-bloc -> sector (single-name reasserted between) ---
+    # Region is enforced by the risk gate below (which converges + clamps to cash on
+    # an infeasible book), not here, so a trailing name cap cannot silently undo it.
     is_bloc = np.array([currency_of(t) in USD_BLOC for t in selected])
     sec_arr = sub.reindex(selected)["SECTOR"].astype(str).to_numpy()
     region_arr = np.array([region_of(t) for t in selected])
@@ -497,8 +500,6 @@ def build_portfolio(
     w = cap_bloc(w, is_bloc, usd_bloc_cap)
     w = apply_name_cap(w, name_cap)  # keep single-name cap after bloc redistribution
     w = cap_groups(w, sec_arr, sector_cap)
-    w = apply_name_cap(w, name_cap)
-    w = cap_groups(w, region_arr, region_cap)
     w = apply_name_cap(w, name_cap)
 
     gross_risk = float(w.sum())  # capped risk-book gross (≈ 1.0)
@@ -610,50 +611,59 @@ def build_portfolio(
         name_cap=name_cap,
         sector_cap=sector_cap,
         usd_bloc_cap=usd_bloc_cap,
+        # region_hard=True HARD-enforces the region cap in the gate (infeasible excess
+        # -> cash, so a US-heavy book carries more cash); default False keeps region a
+        # MONITOR (reported + flagged on the final book below, never forcing cash) —
+        # consistent with the overlay's owner-rule behavior. The infrastructure is the
+        # same either way; only whether the excess is trimmed differs.
+        regions=region_arr if region_hard else None,
+        region_cap=region_cap,
     )
     diagnostics["gate"] = gate_diag
-
-    # Post-gate region clamp: the risk gate is region-blind and its tail-deweight /
-    # redistribution can re-concentrate a region above the cap. Only when a region
-    # genuinely exceeds the cap do we re-assert it on the gated book (gross-preserving;
-    # excess redistributes to under-cap names) + re-assert the name cap. In production
-    # the book sits under the 65% region cap, so this is skipped and the gated book is
-    # returned untouched (no perturbation of the gate's vol/name enforcement).
-    gated_arr = gated_series.to_numpy()
-    _gsum = float(gated_arr.sum())
-    if _gsum > 0:
-        _reg_tot: dict[str, float] = {}
-        for _wt, _t in zip(gated_arr, selected, strict=True):
-            _reg_tot[region_of(_t)] = _reg_tot.get(region_of(_t), 0.0) + float(_wt)
-        if max(_reg_tot.values(), default=0.0) > region_cap * _gsum + 1e-9:
-            gated_arr = cap_groups(gated_arr, region_arr, region_cap * _gsum)
-            gated_arr = apply_name_cap(gated_arr, name_cap * _gsum)
-            gated_series = pd.Series(gated_arr, index=selected)
 
     full = pd.Series(0.0, index=sub.index)
     full.loc[selected] = gated_series.to_numpy()
     gross = float(full.sum())
 
-    usd_bloc = float(sum(v for t, v in full.items() if currency_of(t) in USD_BLOC))
-    # Region exposures + breach on the FINAL gated book. The region cap is enforced
-    # pre-gate (cap_groups in the cap sequence); the gate only reduces concentration
-    # (tail de-weight + uniform gross-cut), so region stays within cap. We recompute
-    # the breach flag on the gated book so the report reflects the truth, not the
-    # pre-gate assessment.
-    region_exposures: dict[str, float] = {}
+    # Exposures + breach flags recomputed on the FINAL book. All axes are fraction of
+    # the INVESTED book (/gross) so name / sector / USD-bloc / region are one basis.
+    region_exposures: dict[str, float] = {}  # NAV-basis absolute, matching sector_exposures
+    sector_final: dict[str, float] = {}
+    usd_bloc_nav = 0.0
+    max_name = 0.0
     for t, v in full.items():
-        if v > 1e-12:
-            rg = region_of(t)
-            region_exposures[rg] = region_exposures.get(rg, 0.0) + float(v)
+        fv = float(v)
+        if fv <= 1e-12:
+            continue
+        p = fv / gross if gross > 0 else 0.0
+        max_name = max(max_name, p)
+        region_exposures[region_of(t)] = region_exposures.get(region_of(t), 0.0) + fv
+        sector_final[sector_labels.get(t, "UNKNOWN")] = (
+            sector_final.get(sector_labels.get(t, "UNKNOWN"), 0.0) + p
+        )
+        if currency_of(t) in USD_BLOC:
+            usd_bloc_nav += fv
+    # usd_bloc_book = fraction of the INVESTED book (matches name/sector/region basis)
+    # for the breach flag + the report tile; res["usd_bloc"] stays NAV-basis (absolute)
+    # so the "no re-inflation above cap" contract still holds for all-USD books.
+    usd_bloc_book = usd_bloc_nav / gross if gross > 0 else 0.0
     if gross > 0:
-        _max_region_final = max(region_exposures.values(), default=0.0) / gross
-        diagnostics["max_region"] = _max_region_final
-        diagnostics["binding"]["region_cap"] = bool(_max_region_final > region_cap + _TOL)
+        _max_region = max(region_exposures.values(), default=0.0) / gross
+        _max_sector = max(sector_final.values(), default=0.0)
+        diagnostics["max_region"] = _max_region
+        gate_diag["max_name"] = max_name  # refresh gate metrics after the clamp
+        gate_diag["max_sector"] = _max_sector
+        gate_diag["usd_bloc"] = usd_bloc_book
+        _b = diagnostics["binding"]
+        _b["region_cap"] = bool(_max_region > region_cap + _TOL)
+        _b["name_cap"] = bool(max_name > name_cap + _TOL)
+        _b["sector_cap"] = bool(_max_sector > sector_cap + _TOL)
+        _b["usd_bloc_cap"] = bool(usd_bloc_book > usd_bloc_cap + _TOL)
     return {
         "weights": full,
         "gross": gross,
         "cash": max(0.0, 1.0 - gross),
-        "usd_bloc": usd_bloc,
+        "usd_bloc": usd_bloc_nav,
         "sector_exposures": _sector_exposures(full, sector_labels),
         "region_exposures": region_exposures,
         "selected": selected,

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -54,12 +54,88 @@ _SUFFIX_COUNTRY = {
     ".OL": "Norway",
     ".ST": "Sweden",
     ".CO": "Denmark",
+    ".HE": "Finland",
+    ".IR": "Ireland",
+    ".BR": "Belgium",
+    ".LS": "Portugal",
+    ".VI": "Austria",
+    ".WA": "Poland",
+    ".AT": "Greece",
     ".HK": "Hong Kong",
     ".T": "Japan",
+    ".KS": "South Korea",
+    ".KQ": "South Korea",
+    ".TW": "Taiwan",
+    ".SS": "China",
+    ".SZ": "China",
+    ".SI": "Singapore",
+    ".NS": "India",
+    ".BO": "India",
     ".AX": "Australia",
     ".TO": "Canada",
+    ".V": "Canada",
+    ".SA": "Brazil",
+    ".MX": "Mexico",
 }
 _HOME_COUNTRY = "United States"  # bare / unmapped suffix
+
+# Company/listing country -> economic region, for the geographic concentration cap.
+# Kept consistent with the report's allocation bars (both driven by ``region_of``).
+_COUNTRY_REGION = {
+    "United States": "North America",
+    "Canada": "North America",
+    "France": "Europe",
+    "Germany": "Europe",
+    "United Kingdom": "Europe",
+    "Netherlands": "Europe",
+    "Switzerland": "Europe",
+    "Italy": "Europe",
+    "Spain": "Europe",
+    "Norway": "Europe",
+    "Sweden": "Europe",
+    "Denmark": "Europe",
+    "Finland": "Europe",
+    "Ireland": "Europe",
+    "Belgium": "Europe",
+    "Portugal": "Europe",
+    "Austria": "Europe",
+    "Poland": "Europe",
+    "Greece": "Europe",
+    "Hong Kong": "Asia-Pacific",
+    "Japan": "Asia-Pacific",
+    "South Korea": "Asia-Pacific",
+    "Taiwan": "Asia-Pacific",
+    "China": "Asia-Pacific",
+    "Singapore": "Asia-Pacific",
+    "India": "Asia-Pacific",
+    "Australia": "Asia-Pacific",
+    "Brazil": "Latin America",
+    "Mexico": "Latin America",
+}
+_DEFAULT_REGION = "North America"  # bare/unmapped US listing
+
+
+def region_of(ticker: str) -> str:
+    """Economic region for a ticker, from its LISTING venue (exchange suffix).
+
+    Domicile drives dual-listing dedup elsewhere; the geographic cap and the
+    report's allocation bars both use the trading venue via this one function,
+    so the two never diverge. Crypto (``-USD`` / hyphen) -> "Crypto/Global".
+    Bare or unmapped US-style tickers -> North America.
+    """
+    t = str(ticker or "").upper()
+    if t.endswith("-USD") or t.endswith("-EUR"):  # crypto (BTC-USD); not BRK-B
+        return "Crypto/Global"
+    # Own suffix lookup (not _suffix_of, which drops single-letter suffixes as share
+    # classes): a mapped single-letter exchange suffix like .T (Tokyo) / .L (London)
+    # / .V (Canada) IS a real venue. Unmapped suffixes (.B share class) fall to US.
+    country = (
+        _SUFFIX_COUNTRY.get("." + t.rsplit(".", 1)[-1], _HOME_COUNTRY)
+        if "." in t
+        else _HOME_COUNTRY
+    )
+    return _COUNTRY_REGION.get(country, _DEFAULT_REGION)
+
 
 # _Z_ES_95 imported from risk_gate (single definition shared across both modules).
 # Report-only risk-gate thresholds.
@@ -304,6 +380,7 @@ def build_portfolio(
     name_cap: float = 0.08,
     sector_cap: float = 0.25,
     usd_bloc_cap: float = 0.60,
+    region_cap: float = 0.65,
     gross_target: float = 0.90,
     cvar_budget: float = 0.25,
     vol_ceiling: float = 0.18,
@@ -408,12 +485,16 @@ def build_portfolio(
     if w_sum > 0:
         w = w / w_sum  # renormalize to sum = 1
 
-    # --- caps: same order select_and_construct uses ---
-    w = apply_name_cap(w, name_cap)
+    # --- caps: name -> USD-bloc -> sector -> region (single-name reasserted between) ---
     is_bloc = np.array([currency_of(t) in USD_BLOC for t in selected])
+    sec_arr = sub.reindex(selected)["SECTOR"].astype(str).to_numpy()
+    region_arr = np.array([region_of(t) for t in selected])
+    w = apply_name_cap(w, name_cap)
     w = cap_bloc(w, is_bloc, usd_bloc_cap)
     w = apply_name_cap(w, name_cap)  # keep single-name cap after bloc redistribution
-    w = cap_groups(w, sub.reindex(selected)["SECTOR"].astype(str).to_numpy(), sector_cap)
+    w = cap_groups(w, sec_arr, sector_cap)
+    w = apply_name_cap(w, name_cap)
+    w = cap_groups(w, region_arr, region_cap)
     w = apply_name_cap(w, name_cap)
 
     gross_risk = float(w.sum())  # capped risk-book gross (≈ 1.0)
@@ -468,11 +549,19 @@ def build_portfolio(
                 if currency_of(_t) in USD_BLOC
             )
         )
+        _region_totals: dict[str, float] = {}
+        for _wt, _t in zip(w_shape, selected, strict=True):
+            _rg = region_of(_t)
+            _region_totals[_rg] = _region_totals.get(_rg, 0.0) + float(_wt)
+        _max_region = max(_region_totals.values(), default=0.0)
         _name_cap_breach = bool(_max_name > name_cap + _TOL)
         _sector_cap_breach = bool(_max_sector > sector_cap + _TOL)
         _usd_bloc_breach = bool(_usd_frac > usd_bloc_cap + _TOL)
+        _region_cap_breach = bool(_max_region > region_cap + _TOL)
     else:
         _name_cap_breach = _sector_cap_breach = _usd_bloc_breach = False
+        _region_cap_breach = False
+        _max_region = 0.0
 
     diagnostics = {
         # Risk-book metrics: the fully-invested, gross=1.0 sleeve.
@@ -485,6 +574,7 @@ def build_portfolio(
         "effective_bets": effective_bets,
         "port_vol": port_vol,
         "gross_risk": gross_risk,
+        "max_region": _max_region,
         "binding": {
             "cvar": cvar_binding,
             "net_beta": not (_BETA_BAND[0] <= net_beta <= _BETA_BAND[1]),
@@ -495,6 +585,7 @@ def build_portfolio(
             "name_cap": _name_cap_breach,
             "sector_cap": _sector_cap_breach,
             "usd_bloc_cap": _usd_bloc_breach,
+            "region_cap": _region_cap_breach,
             # FIX 3: vol budget flag (report-only; never shrinks the book).
             "vol_over_target": bool(port_vol > target_vol),
         },
@@ -518,17 +609,49 @@ def build_portfolio(
     )
     diagnostics["gate"] = gate_diag
 
+    # Post-gate region clamp: the risk gate is region-blind and its tail-deweight /
+    # redistribution can re-concentrate a region above the cap. Only when a region
+    # genuinely exceeds the cap do we re-assert it on the gated book (gross-preserving;
+    # excess redistributes to under-cap names) + re-assert the name cap. In production
+    # the book sits under the 65% region cap, so this is skipped and the gated book is
+    # returned untouched (no perturbation of the gate's vol/name enforcement).
+    gated_arr = gated_series.to_numpy()
+    _gsum = float(gated_arr.sum())
+    if _gsum > 0:
+        _reg_tot: dict[str, float] = {}
+        for _wt, _t in zip(gated_arr, selected, strict=True):
+            _reg_tot[region_of(_t)] = _reg_tot.get(region_of(_t), 0.0) + float(_wt)
+        if max(_reg_tot.values(), default=0.0) > region_cap * _gsum + 1e-9:
+            gated_arr = cap_groups(gated_arr, region_arr, region_cap * _gsum)
+            gated_arr = apply_name_cap(gated_arr, name_cap * _gsum)
+            gated_series = pd.Series(gated_arr, index=selected)
+
     full = pd.Series(0.0, index=sub.index)
     full.loc[selected] = gated_series.to_numpy()
     gross = float(full.sum())
 
     usd_bloc = float(sum(v for t, v in full.items() if currency_of(t) in USD_BLOC))
+    # Region exposures + breach on the FINAL gated book. The region cap is enforced
+    # pre-gate (cap_groups in the cap sequence); the gate only reduces concentration
+    # (tail de-weight + uniform gross-cut), so region stays within cap. We recompute
+    # the breach flag on the gated book so the report reflects the truth, not the
+    # pre-gate assessment.
+    region_exposures: dict[str, float] = {}
+    for t, v in full.items():
+        if v > 1e-12:
+            rg = region_of(t)
+            region_exposures[rg] = region_exposures.get(rg, 0.0) + float(v)
+    if gross > 0:
+        _max_region_final = max(region_exposures.values(), default=0.0) / gross
+        diagnostics["max_region"] = _max_region_final
+        diagnostics["binding"]["region_cap"] = bool(_max_region_final > region_cap + _TOL)
     return {
         "weights": full,
         "gross": gross,
         "cash": max(0.0, 1.0 - gross),
         "usd_bloc": usd_bloc,
         "sector_exposures": _sector_exposures(full, sector_labels),
+        "region_exposures": region_exposures,
         "selected": selected,
         "diagnostics": diagnostics,
     }

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -19,8 +19,43 @@ import math
 
 import pandas as pd
 
+from trade_modules.riskfirst.fx import currency_of
 from trade_modules.v3.fetch import robust_fetch_prices
 from trade_modules.v3.universe import parse_cap
+
+# Approximate spot FX rates (local currency -> USD), for normalizing eToro's
+# local-currency market cap and dollar-volume to USD. eToro reports CAP in the
+# listing's local currency (yen for .T, EUR for .DE), and price is local too, so
+# without this a $500M / $1M floor + cap tiers mix currencies (a small yen name
+# wrongly clears the floor). Coarse by design: cap tiers and the ADV floor are
+# wide, so FX drift is immaterial; NOT used for P&L. Refresh occasionally.
+_USD_RATE = {
+    "USD": 1.0,
+    "EUR": 1.08,
+    "GBP": 1.27,
+    "CHF": 1.12,
+    "JPY": 0.0067,
+    "HKD": 0.128,
+    "CAD": 0.73,
+    "AUD": 0.66,
+    "SEK": 0.095,
+    "NOK": 0.094,
+    "DKK": 0.145,
+    "KRW": 0.00073,
+    "TWD": 0.031,
+    "SGD": 0.74,
+    "INR": 0.012,
+    "CNY": 0.138,
+    "BRL": 0.18,
+    "MXN": 0.058,
+    "PLN": 0.25,
+}
+
+
+def _usd_rate_for(ticker: str) -> float:
+    """Approximate local-currency -> USD spot rate for a ticker's listing currency."""
+    return _USD_RATE.get(currency_of(str(ticker)), 1.0)
+
 
 # etoro CSV header -> feature name (NATIVE numeric factors)
 _NATIVE_NUM = {
@@ -330,6 +365,9 @@ def enrich_features(
     native = pd.DataFrame(index=raw.index)
     native["name"] = raw["NAME"].astype("object") if "NAME" in raw.columns else pd.NA
     native["cap"] = raw["CAP"].map(parse_cap) if "CAP" in raw.columns else float("nan")
+    # Normalize local-currency market cap -> USD (see _USD_RATE) so the floor + tiers
+    # are single-currency (Toyota's yen cap no longer reads as a USD mega-cap).
+    native["cap"] = native["cap"] * native.index.to_series().map(_usd_rate_for)
     for col, feat in _NATIVE_NUM.items():
         native[feat] = _num(raw[col]) if col in raw.columns else float("nan")
     native = native.reindex(tickers)
@@ -352,7 +390,8 @@ def enrich_features(
     safe_price = price.where(price > 0)
     disp = (feats["target_high"] - feats["target_low"]) / safe_price
     feats["target_dispersion"] = disp.replace([float("inf"), float("-inf")], float("nan"))
-    feats["adv_usd"] = feats["avg_volume"] * price
+    # adv_usd = shares * local price * FX -> USD dollar-volume (for the ADV floor).
+    feats["adv_usd"] = feats["avg_volume"] * price * feats.index.to_series().map(_usd_rate_for)
 
     prices = price_fetch(list(tickers), period=price_period)
     feats = feats.join(_price_factors(prices, tickers))

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -26,9 +26,12 @@ from trade_modules.v3.universe import parse_cap
 # Approximate spot FX rates (local currency -> USD), for normalizing eToro's
 # local-currency market cap and dollar-volume to USD. eToro reports CAP in the
 # listing's local currency (yen for .T, EUR for .DE), and price is local too, so
-# without this a $500M / $1M floor + cap tiers mix currencies (a small yen name
-# wrongly clears the floor). Coarse by design: cap tiers and the ADV floor are
-# wide, so FX drift is immaterial; NOT used for P&L. Refresh occasionally.
+# without this the mega/large/mid cap tiers, the cap_ordered vol mode, the report's
+# Mkt-Cap display, and the runner's $1M ADV floor would mix currencies (a small yen
+# name reading as a USD mega-cap). Note: universe.py::load_universe is US-only
+# (^[A-Z]+$), so its $500M floor never sees a non-USD cap — this normalization serves
+# the cross-market scoring/overlay paths, not that floor. Coarse by design (tiers +
+# ADV floor are wide, so FX drift is immaterial); NOT used for P&L. Refresh occasionally.
 _USD_RATE = {
     "USD": 1.0,
     "EUR": 1.08,

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -32,7 +32,7 @@ from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
-from trade_modules.v3.construct import _norm_name, _root_of, dedup_dual_listings
+from trade_modules.v3.construct import _norm_name, _root_of, dedup_dual_listings, region_of
 from trade_modules.v3.risk_gate import apply_risk_gate
 
 # A holding/target weight at or below this is treated as flat (not held).
@@ -375,11 +375,26 @@ def build_overlay(
         (final.reindex(idx).fillna(0.0) - cur.reindex(idx).fillna(0.0)).abs().sum()
     )
 
+    # Region exposure monitor (informational). The from-scratch constructor
+    # (build_portfolio) HARD-caps region; the overlay only REPORTS it, so a region
+    # breach never force-sells a held/core name against the owner rules.
+    region_exposures: dict[str, float] = {}
+    _final_gross = float(final.sum()) if len(final) else 0.0
+    for _t, _v in final.items():
+        if float(_v) > 1e-12:
+            _rg = region_of(_t)
+            region_exposures[_rg] = region_exposures.get(_rg, 0.0) + float(_v)
+    max_region = (
+        max(region_exposures.values(), default=0.0) / _final_gross if _final_gross > 0 else 0.0
+    )
+
     diagnostics: dict = {
         "n_sell": len(sold),
         "n_buy": len(bought),
         "n_keep": len(kept),
         "turnover": turnover,
+        "region_exposures": region_exposures,
+        "max_region": max_region,
         "freed_weight": freed_weight,
         "keep_weight": keep_sum,
         "buy_weight": float(sum(target[t] for t in bought)) if bought else 0.0,

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -354,6 +354,7 @@ def _overview(scores: pd.DataFrame, conv_scale: float) -> str:
         '<span class="hm-h right">#</span>'
         '<span class="hm-h">Ticker</span>'
         '<span class="hm-h">Sector</span>'
+        '<span class="hm-h hm-name">Name</span>'
         '<span class="hm-h right">Conv</span>'
         '<span class="hm-barcell"></span>'
         '<div class="hm-cells">'
@@ -373,6 +374,7 @@ def _overview(scores: pd.DataFrame, conv_scale: float) -> str:
         )
         rank_s = "–" if _isnan(rank) else str(int(rank))
         sector_s = _esc(r.get("sector", "")) or "–"
+        name_s = _esc(r.get("name", ""))
         conv_s = "·" if _isnan(conv) else f"{conv:+.2f}"
         cells = "".join(_heat_cell(lbl, r.get(k, np.nan)) for k, lbl in CLUSTER_CELLS)
         rows.append(
@@ -381,6 +383,7 @@ def _overview(scores: pd.DataFrame, conv_scale: float) -> str:
             f'<span class="hm-rank">{rank_s}</span>'
             f'<span class="hm-tkr">{_esc(tkr)}</span>'
             f'<span class="hm-sector">{sector_s}</span>'
+            f'<span class="hm-name">{name_s}</span>'
             f'<span class="hm-conv" style="color:{_z_color(conv)};">{conv_s}</span>'
             f'<span class="hm-barcell">{_bar(conv, conv_scale, "meter")}</span>'
             f'<div class="hm-cells">{cells}</div>'
@@ -701,7 +704,23 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
             '<span class="flag-none">none binding</span></div>'
         )
 
-    return f'<div class="exec-panel">{grid}{sec_html}{flag_html}</div>'
+    acct = meta.get("account") or {}
+    account_html = ""
+    if acct:
+        pnl_usd = acct.get("unrealized_pnl")
+        pnl_pct = acct.get("profit_pct")
+        pnl_s = _usd_signed(pnl_usd) or "n/a"
+        pnl_sub = f"{float(pnl_pct):+.1f}%" if not _isnan(pnl_pct) else ""
+        pnl_tone = ("bull" if float(pnl_usd) >= 0 else "bear") if not _isnan(pnl_usd) else ""
+        account_html = (
+            '<div class="stat-grid acct-grid">'
+            + _stat("Total Value", _money(acct.get("total_equity")), "portfolio NAV")
+            + _stat("Unrealized P&L", pnl_s, pnl_sub, pnl_tone)
+            + _stat("Cash", _money(acct.get("available")), "available")
+            + _stat("Invested", _money(acct.get("invested_cost")), "at cost")
+            + "</div>"
+        )
+    return f'<div class="exec-panel">{account_html}{grid}{sec_html}{flag_html}</div>'
 
 
 def _action_row(a: dict) -> str:
@@ -791,6 +810,135 @@ def _card_grid(frame: pd.DataFrame, cols, conv_scale: float) -> str:
     return f'<div class="cards">{"".join(cards)}</div>'
 
 
+# --- action deep-dive cards -------------------------------------------------
+
+
+def _action_card(a: dict, row, cols, conv_scale: float, delay: float) -> str:
+    """Full deep-dive card for one suggested action (replaces compact _action_row)."""
+    tkr = _esc(a.get("ticker") or "")
+    action = a.get("action") or ""
+    act_cls = {"BUY": "buy", "ADD": "add", "TRIM": "trim", "SELL": "sell"}.get(action, "hold")
+    conv = a.get("conviction")
+    conv_s = "·" if _isnan(conv) else f"{conv:+.2f}"
+    cur, tgt, delta = a.get("current_pct"), a.get("target_pct"), a.get("delta_pct")
+    usd = _usd_signed(a.get("delta_usd"))
+    if row is not None:
+        name = _esc(row.get("name", "")) or "&nbsp;"
+        sector = _esc(row.get("sector", "")) or "n/a"
+        desc_raw = row.get("description", "")
+        desc_text = (
+            ""
+            if (desc_raw is None or (isinstance(desc_raw, float) and pd.isna(desc_raw)))
+            else str(desc_raw).strip()
+        )
+        desc_html = f'<div class="desc">{_esc(desc_text)}</div>' if desc_text else ""
+        groups = "".join(_group(row, cols, gl, ms) for gl, ms in DISPLAY_GROUPS)
+    else:
+        name = "&nbsp;"
+        sector = "n/a"
+        desc_html = ""
+        groups = ""
+    pnl = a.get("pnl")
+    pnl_html = ""
+    if pnl is not None:
+        pct, cv = a.get("pnl_pct"), a.get("current_value")
+        pcol = "#2d6a4f" if float(pnl) >= 0 else "#b3402f"
+        pct_s = f" ({pct:+.1f}%)" if pct is not None else ""
+        val_s = f" · {_money(cv)}" if cv is not None else ""
+        pnl_html = (
+            f'<span class="act-pnl" style="color:{pcol};">'
+            f"P/L {_usd_signed(pnl)}{pct_s}{val_s}</span>"
+        )
+    move = (
+        f'<span class="from">{_pct1(cur)}</span>'
+        f' <span class="to">&#8594; {_pct1(tgt)}</span>'
+        f' <span class="act-dpp">({_pp(delta)})</span>'
+        + (f'<span class="act-usd"> {usd}</span>' if usd else "")
+        + pnl_html
+    )
+    levels_html = _levels_block(row) if (action in _LEVEL_ACTIONS and row is not None) else ""
+    strip_html = f'<div class="ac-strip">{levels_html}</div>' if levels_html else ""
+    groups_html = f'<div class="groups">{groups}</div>' if groups else ""
+    return (
+        f'<article class="card card--action" style="animation-delay:{delay:.2f}s;">'
+        f'<div class="ac-head">'
+        f'<div class="ac-id">'
+        f'<div class="ac-tkr">{tkr}</div>'
+        f'<div class="ac-name">{name}</div>'
+        f"{desc_html}"
+        f'<div class="id-meta"><span class="chip">{sector}</span></div>'
+        f"</div>"
+        f'<div class="ac-verdict">'
+        f'<span class="act-tag act-tag--{act_cls}">{_esc(action)}</span>'
+        f'<div class="ac-conv" style="color:{_z_color(conv)};">{conv_s}</div>'
+        f'<div class="ac-move">{move}</div>'
+        f"</div>"
+        f"</div>"
+        f"{strip_html}"
+        f"{groups_html}"
+        f"</article>"
+    )
+
+
+def _action_group_cards(action, cls, hint, rows, scores, cols, conv_scale):
+    """Render one action bucket (BUY / ADD / TRIM / SELL / HOLD) as deep-dive cards."""
+    if not rows:
+        return ""
+    idx = scores.index if scores is not None else pd.Index([])
+    cards_html = "".join(
+        _action_card(
+            a,
+            scores.loc[a["ticker"]] if (a.get("ticker") and a["ticker"] in idx) else None,
+            cols,
+            conv_scale,
+            i * 0.03,
+        )
+        for i, a in enumerate(rows)
+    )
+    n = len(rows)
+    count = f"{n} name" + ("" if n == 1 else "s")
+    return (
+        f'<div class="act-grp act-grp--{cls}">'
+        f'<div class="act-grp-head">'
+        f'<span class="act-tag act-tag--{cls}">{action}</span>'
+        f'<span class="act-hint">{_esc(hint)}</span>'
+        f'<span class="act-count">{count}</span>'
+        f"</div>"
+        f'<div class="act-cards">{cards_html}</div>'
+        f"</div>"
+    )
+
+
+def _actions_block_cards(actions, scores, conv_scale: float, approx_current: bool = False) -> str:
+    """Render all action buckets as deep-dive cards with a one-line summary header."""
+    cols = scores.columns if scores is not None else []
+    counts = {
+        act: sum(1 for a in actions if a.get("action") == act) for act, _, _ in _ACTION_GROUPS
+    }
+    parts = [f"{counts[act]} {act}" for act, _, _ in _ACTION_GROUPS if counts[act] > 0]
+    summary_html = f'<div class="act-summary">{" · ".join(parts)}</div>' if parts else ""
+    note = '<div class="act-note">Decision-support: you decide, not auto-executed.'
+    if approx_current:
+        note += (
+            ' <span class="act-note-warn">Current weights are approximate '
+            "(equal-split; no live account file supplied).</span>"
+        )
+    note += "</div>"
+    groups = "".join(
+        _action_group_cards(
+            act,
+            cls,
+            hint,
+            [a for a in actions if a.get("action") == act],
+            scores,
+            cols,
+            conv_scale,
+        )
+        for act, cls, hint in _ACTION_GROUPS
+    )
+    return f'<div class="actions-block">{summary_html}{note}{groups}</div>'
+
+
 def _portfolio_section(scores: pd.DataFrame, conv_scale: float, numeral: str = "II") -> str:
     cols = scores.columns
     mask = scores.get("is_portfolio", pd.Series(False, index=scores.index)) == True  # noqa: E712
@@ -842,8 +990,8 @@ def _stylesheet() -> str:
   --line:#e7e6e2;--accent:#123b3a;--track:#ecebe4;--hover:#f4f2ee;
   --bull:#2d6a4f;--bull-bar:#bfe3cd;--bull-fill:#e9f5ee;
   --bear:#b3402f;--bear-bar:#f2c4bb;--bear-fill:#fbeeec;
-  --serif:'Fraunces',Georgia,'Times New Roman',serif;
-  --sans:'IBM Plex Sans',system-ui,sans-serif;
+  --serif:'Hanken Grotesk',system-ui,sans-serif;
+  --sans:'Hanken Grotesk',system-ui,sans-serif;
   --mono:'IBM Plex Mono',ui-monospace,'SFMono-Regular',monospace;
 }
 *{box-sizing:border-box;}
@@ -863,8 +1011,8 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 .mast-title{font-family:var(--serif);font-optical-sizing:auto;font-weight:400;
   font-size:64px;line-height:1;letter-spacing:-1px;color:var(--ink);margin:14px 0 0;}
 .mast-rule{width:80px;height:3px;background:var(--accent);margin:26px 0 22px;}
-.standfirst{font-family:var(--serif);font-optical-sizing:auto;font-style:italic;font-weight:400;
-  font-size:20px;line-height:1.5;color:var(--ink2);margin:0;max-width:780px;}
+.standfirst{font-family:var(--serif);font-optical-sizing:auto;font-weight:400;
+  font-size:20px;line-height:1.5;color:var(--ink2);margin:0;}
 .mast-meta{display:flex;flex-wrap:wrap;align-items:center;gap:10px 18px;margin-top:28px;
   padding-top:22px;border-top:1px solid var(--line);}
 .regime{display:inline-flex;align-items:center;gap:7px;font-family:var(--sans);font-size:11px;
@@ -892,7 +1040,7 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 .hm{border:1px solid var(--line);border-radius:10px;overflow:hidden;background:var(--canvas);
   box-shadow:0 1px 2px rgba(22,24,29,.04);}
 .hm-head,.hm-row{display:grid;
-  grid-template-columns:14px 30px 74px minmax(90px,1fr) 52px 96px 250px;
+  grid-template-columns:14px 30px 74px minmax(100px,1.5fr) minmax(80px,1fr) 52px 96px 250px;
   align-items:center;gap:14px;padding:0 20px;}
 .hm-head{height:40px;background:var(--warm);border-bottom:1px solid var(--line);}
 .hm-row{min-height:34px;border-top:1px solid var(--line);}
@@ -908,6 +1056,7 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
   font-variant-numeric:tabular-nums;}
 .hm-tkr{font-family:var(--serif);font-weight:600;font-size:15.5px;color:var(--ink);letter-spacing:-.2px;}
 .hm-sector{font-size:11.5px;color:var(--ink2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.hm-name{font-size:11px;color:var(--ink2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .hm-conv{font-family:var(--mono);font-size:12.5px;font-weight:500;text-align:right;
   font-variant-numeric:tabular-nums;}
 .hm-cells{display:grid;grid-template-columns:repeat(5,1fr);gap:5px;align-items:center;}
@@ -1085,6 +1234,31 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
   border:1px solid var(--line);border-radius:7px;padding:3px 8px;font-variant-numeric:tabular-nums;}
 .act-lvl.sl{color:var(--bear);}
 .act-lvl.tp{color:var(--bull);}
+/* action cards (deep-dive) */
+.act-summary{font-family:var(--mono);font-size:12.5px;font-weight:600;color:var(--ink2);
+  margin-bottom:16px;letter-spacing:.3px;font-variant-numeric:tabular-nums;}
+.act-tag--buy{color:var(--bull);}
+.act-tag--add{color:var(--bull);}
+.act-tag--trim{color:#96601a;}
+.act-tag--sell{color:var(--bear);}
+.act-tag--hold{color:var(--ink2);}
+.act-cards{display:flex;flex-direction:column;gap:16px;padding-top:10px;}
+.ac-head{display:flex;align-items:flex-start;justify-content:space-between;gap:16px 30px;
+  flex-wrap:wrap;}
+.ac-id{min-width:0;flex:1;}
+.ac-tkr{font-family:var(--serif);font-optical-sizing:auto;font-weight:700;font-size:26px;
+  line-height:1;letter-spacing:-.4px;color:var(--ink);}
+.ac-name{font-size:13px;color:var(--ink2);margin-top:6px;white-space:nowrap;overflow:hidden;
+  text-overflow:ellipsis;}
+.ac-verdict{display:flex;flex-direction:column;align-items:flex-end;gap:4px;flex-shrink:0;}
+.ac-conv{font-family:var(--mono);font-weight:500;font-size:22px;line-height:.9;
+  letter-spacing:-.8px;font-variant-numeric:tabular-nums;}
+.ac-move{font-family:var(--mono);font-size:12px;color:var(--ink2);
+  font-variant-numeric:tabular-nums;text-align:right;}
+.ac-strip{margin-top:14px;padding-top:12px;border-top:1px solid var(--line);}
+.acct-grid{margin-bottom:14px;}
+.card--action{padding:20px 24px 22px;}
+.card--action .groups{margin-top:16px;padding-top:14px;gap:14px 20px;}
 @media (max-width:900px){.stat-grid{grid-template-columns:repeat(2,1fr);}}
 @media (max-width:560px){
   .act-row{grid-template-columns:1fr auto;}
@@ -1095,7 +1269,7 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 /* footer */
 .footer{margin-top:72px;padding-top:26px;border-top:2px solid var(--ink);}
 .footer .eyebrow{margin-bottom:12px;}
-.method{font-size:11.5px;color:var(--muted);line-height:1.75;max-width:840px;}
+.method{font-size:11.5px;color:var(--muted);line-height:1.75;}
 .method b{color:var(--ink2);font-weight:600;}
 .foot-stamp{margin-top:18px;font-family:var(--mono);font-size:11px;color:var(--muted);
   font-variant-numeric:tabular-nums;}
@@ -1115,9 +1289,13 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 @container (min-width:1000px){
   .groups{grid-template-columns:repeat(4,1fr);}
 }
+@container (min-width:820px){
+  .card--action .groups{grid-template-columns:repeat(4,1fr);}
+}
 @media (max-width:820px){
   .hm-head,.hm-row{grid-template-columns:12px 26px 62px minmax(60px,1fr) 46px 200px;}
   .hm-barcell{display:none;}
+  .hm-name{display:none;}
 }
 @media (max-width:639px){
   /* Phone: ticker always visible; hide sector column to reclaim width. */
@@ -1232,7 +1410,9 @@ def render_report(
             _ROMAN[sec_idx],
             "Suggested Actions",
             "Risk-gated target book vs current holdings · grouped by action",
-        ) + _actions_block(actions, bool(meta.get("current_weights_approx")))
+        ) + _actions_block_cards(
+            actions, scored, conv_scale, bool(meta.get("current_weights_approx"))
+        )
         sec_idx += 1
 
     overview = _section_head(
@@ -1248,12 +1428,6 @@ def render_report(
             f"(non-equity or insufficient data).</div>"
         )
     sec_idx += 1
-    port_sec = _portfolio_section(scored, conv_scale, _ROMAN[sec_idx])
-    sec_idx += 1
-    cand_sec = _candidates_section(
-        scored, conv_scale, max_long_cards, max_avoid_cards, _ROMAN[sec_idx]
-    )
-
     summary_line = (
         _exec_summary_line(meta, portfolio, actions, conditioning)
         if (portfolio is not None or actions is not None)
@@ -1288,10 +1462,7 @@ def render_report(
         f"</footer>"
     )
 
-    body = (
-        f'<div class="wrap">{masthead}{summary_line}{new_top}'
-        f"{overview}{port_sec}{cand_sec}{footer}</div>"
-    )
+    body = f'<div class="wrap">{masthead}{summary_line}{new_top}{overview}{footer}</div>'
 
     return (
         "<!DOCTYPE html>\n"
@@ -1301,9 +1472,8 @@ def render_report(
         '<link rel="preconnect" href="https://fonts.googleapis.com">'
         '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>'
         '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?'
-        "family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;0,9..144,600;"
-        "1,9..144,400&family=IBM+Plex+Mono:wght@400;500;600&"
-        'family=IBM+Plex+Sans:wght@400;500;600&display=swap">'
+        "family=Hanken+Grotesk:wght@400;500;600;700;800&"
+        'family=IBM+Plex+Mono:wght@400;500;600&display=swap">'
         f"<style>{_stylesheet()}</style>"
         "</head>"
         f"<body>{body}</body></html>"

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -1598,6 +1598,12 @@ def render_report(
     priced = _esc(meta.get("priced", ""))
     enriched = _esc(meta.get("enriched", ""))
     generated = _esc(meta.get("generated_utc", ""))
+    _cov = meta.get("coverage") or {}
+    cov_str = ""
+    if _cov.get("n_scored"):
+        cov_str = f" · Coverage {_cov.get('pct', 0) * 100:.0f}% ({_cov.get('n_eligible', 0)}/{_cov['n_scored']} eligible)"
+        if _cov.get("adv_dropped"):
+            cov_str += f", ADV-dropped {_cov['adv_dropped']}"
 
     regime_cls = {"RISK_ON": "regime-on", "RISK_OFF": "regime-off"}.get(
         str(meta.get("regime")), "regime-neutral"
@@ -1615,7 +1621,7 @@ def render_report(
         f'<span class="regime {regime_cls}"><span class="dot"></span>{regime}</span>'
         f'<span class="mast-detail">{regime_detail}</span>'
         f'<span class="mast-stats">{date} · Portfolio {n_port} · Candidates {n_cand} · '
-        f"Priced {priced} / Enriched {enriched}</span>"
+        f"Priced {priced} / Enriched {enriched}{cov_str}</span>"
         f"</div></header>"
     )
 

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -760,7 +760,10 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
     if not _isnan(max_region) and _caps_cfg.get("region"):
         _axes.append(("region", float(max_region), float(_caps_cfg["region"])))
     if _axes:
-        _breach = any(v > c + 1e-6 for _, v, c in _axes)
+        # 0.5pp tolerance = half a display unit (whole-percent rounding). A name at
+        # 10.03% vs a 10% cap displays as "10% of 10%" and must NOT read as BREACH;
+        # only a visible overage (e.g. 11% of 10%) flags. Absorbs gate slack + noise.
+        _breach = any(v > c + 0.005 for _, v, c in _axes)
         _bind = max(_axes, key=lambda a: (a[1] / a[2]) if a[2] > 0 else 0.0)
         caps_val = "BREACH" if _breach else "OK"
         caps_tone = "bear" if _breach else "bull"

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -1039,6 +1039,55 @@ def _candidates_section(
     return head + body
 
 
+# --- portfolio allocation bars ----------------------------------------------
+def _allocation_bars(allocations: dict | None) -> str:
+    """Portfolio allocation breakdown: Geography / Asset Type / Sector.
+
+    Renders a responsive 3-column grid of horizontal thick bars (one group per
+    column). Returns empty string when allocations is falsy or all three groups
+    are empty after filtering.
+    """
+    if not allocations:
+        return ""
+
+    def _group(title: str, data: dict) -> str:
+        if not data:
+            return ""
+        rows = []
+        for label, v in data.items():
+            pct = float(v)
+            w = round(pct * 100)
+            rows.append(
+                f'<div class="alloc-row">'
+                f'<div class="alloc-lbl">{_esc(label)}</div>'
+                f'<div class="alloc-track">'
+                f'<div class="alloc-fill" style="width:{w}%;"></div>'
+                f"</div>"
+                f'<div class="alloc-pct">{w}%</div>'
+                f"</div>"
+            )
+        return (
+            f'<div class="alloc-grp">'
+            f'<div class="alloc-grp-title">{_esc(title)}</div>'
+            f"{''.join(rows)}"
+            f"</div>"
+        )
+
+    geo = _group("Geography", allocations.get("geography") or {})
+    at = _group("Asset Type", allocations.get("asset_type") or {})
+    sec = _group("Sector", allocations.get("sector") or {})
+
+    if not (geo or at or sec):
+        return ""
+
+    return (
+        f'<div class="alloc-section">'
+        f'<div class="alloc-heading">Portfolio Allocation</div>'
+        f'<div class="alloc-grid">{geo}{at}{sec}</div>'
+        f"</div>"
+    )
+
+
 # --- stylesheet -------------------------------------------------------------
 def _stylesheet() -> str:
     return """
@@ -1392,6 +1441,22 @@ details[open].card-more>summary{margin-bottom:12px;}
   .mast-stats{margin-left:0;width:100%;}
   .card{padding:22px 20px 26px;}
 }
+/* portfolio allocation bars */
+.alloc-section{margin-top:28px;padding-top:22px;border-top:1px solid var(--line);}
+.alloc-heading{font-size:10px;font-weight:600;letter-spacing:1.3px;text-transform:uppercase;
+  color:var(--muted);margin-bottom:16px;}
+.alloc-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:22px;}
+.alloc-grp-title{font-size:10px;font-weight:600;letter-spacing:1px;text-transform:uppercase;
+  color:var(--ink);margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid var(--line);}
+.alloc-row{display:grid;grid-template-columns:110px 1fr 34px;align-items:center;gap:8px;
+  margin-bottom:7px;}
+.alloc-lbl{font-size:11px;color:var(--ink2);white-space:nowrap;overflow:hidden;
+  text-overflow:ellipsis;}
+.alloc-track{height:26px;background:var(--track);border-radius:6px;overflow:hidden;}
+.alloc-fill{height:100%;background:var(--accent);border-radius:6px;opacity:.65;}
+.alloc-pct{font-family:var(--mono);font-size:11px;color:var(--muted);text-align:right;
+  font-variant-numeric:tabular-nums;}
+@media (max-width:720px){.alloc-grid{grid-template-columns:1fr;}}
 @media (prefers-reduced-motion:reduce){
   .card{animation:none;}
   .card:hover{transform:none;}
@@ -1483,11 +1548,15 @@ def render_report(
     sec_idx = 0
     new_top = ""
     if portfolio is not None:
-        new_top += _section_head(
-            _ROMAN[sec_idx],
-            "Positioning and Risk",
-            "Deployment, portfolio risk and exposure limits after the risk gate",
-        ) + _exec_panel(portfolio, conditioning, meta)
+        new_top += (
+            _section_head(
+                _ROMAN[sec_idx],
+                "Positioning and Risk",
+                "Deployment, portfolio risk and exposure limits after the risk gate",
+            )
+            + _exec_panel(portfolio, conditioning, meta)
+            + _allocation_bars(meta.get("allocations"))
+        )
         sec_idx += 1
     if actions is not None:
         new_top += _section_head(

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -635,6 +635,60 @@ def _stat(label: str, value: str, sub: str = "", tone: str = "") -> str:
     )
 
 
+def _social_grid(social: dict) -> str:
+    """PI performance + social tiles (the eToro account panel) for Section I.
+
+    Reads the ``social`` block from the live-account snapshot. Gains and win
+    ratio arrive already as percentages (3.4 = 3.4%), so they are formatted
+    directly, not through _pct1 (which assumes fractions). Returns "" when the
+    block is absent so the report degrades gracefully.
+    """
+    if not social:
+        return ""
+
+    def _g(v) -> str:  # signed 1-dp percent for a value already in percent units
+        return "n/a" if _isnan(v) else f"{float(v):+.1f}%"
+
+    def _tone(v) -> str:
+        return "" if _isnan(v) else ("bull" if float(v) >= 0 else "bear")
+
+    copiers, baseline = social.get("copiers"), social.get("baseline_copiers")
+    cop_val = "n/a" if _isnan(copiers) else f"{int(copiers):,}"
+    cop_sub = ""
+    if not _isnan(copiers) and not _isnan(baseline):
+        cop_sub = f"{int(copiers) - int(baseline):+d} vs last wk"
+    risk = social.get("risk_score")
+    risk_val = "n/a" if _isnan(risk) else f"{int(risk)}/10"
+    win = social.get("win_ratio")
+    win_val = "n/a" if _isnan(win) else f"{float(win):.1f}%"
+    trades = social.get("trades_ytd")
+    win_sub = "" if _isnan(trades) else f"{int(trades)} trades"
+    ua, shorts = social.get("unique_assets"), social.get("shorts")
+    ua_val = "n/a" if _isnan(ua) else f"{int(ua)}"
+    ua_sub = "" if _isnan(shorts) else f"{int(shorts)} short"
+    op = social.get("open_positions")
+    op_val = "n/a" if _isnan(op) else f"{int(op)}"
+
+    tiles = [
+        _stat(
+            "Today", _g(social.get("daily_gain")), "eToro daily", _tone(social.get("daily_gain"))
+        ),
+        _stat("Month to date", _g(social.get("gain_mtd")), "MTD", _tone(social.get("gain_mtd"))),
+        _stat(
+            "Year to date",
+            _g(social.get("gain_ytd")),
+            "eToro CurrYear",
+            _tone(social.get("gain_ytd")),
+        ),
+        _stat("Copiers", cop_val, cop_sub),
+        _stat("Risk score", risk_val, "eToro 1-10"),
+        _stat("Win ratio", win_val, win_sub),
+        _stat("Unique assets", ua_val, ua_sub),
+        _stat("Open positions", op_val, "incl. lots"),
+    ]
+    return f'<div class="stat-grid social-grid">{"".join(tiles)}</div>'
+
+
 def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
     """The executive / risk panel: deployment + risk stat tiles, sector exposures
     and any binding cap / gate flags. Reads the build_portfolio result dict
@@ -766,7 +820,8 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
             + _stat("Invested", _money(acct.get("invested_cost")), "at cost")
             + "</div>"
         )
-    return f'<div class="exec-panel">{account_html}{grid}{sec_html}{flag_html}</div>'
+    social_html = _social_grid(meta.get("social") or {})
+    return f'<div class="exec-panel">{account_html}{social_html}{grid}{sec_html}{flag_html}</div>'
 
 
 def _action_row(a: dict) -> str:

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -769,11 +769,17 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
     if _axes:
         # 0.5pp tolerance = half a display unit (whole-percent rounding). A name at
         # 10.03% vs a 10% cap displays as "10% of 10%" and must NOT read as BREACH;
-        # only a visible overage (e.g. 11% of 10%) flags. Absorbs gate slack + noise.
-        _breach = any(v > c + 0.005 for _, v, c in _axes)
-        _bind = max(_axes, key=lambda a: (a[1] / a[2]) if a[2] > 0 else 0.0)
-        caps_val = "BREACH" if _breach else "OK"
-        caps_tone = "bear" if _breach else "bull"
+        # only a visible overage flags. Absorbs gate slack + float noise.
+        _breachers = [(lab, v, c) for lab, v, c in _axes if v > c + 0.005]
+        if _breachers:
+            # Show the WORST BREACHER (not merely the highest-utilization axis), so a
+            # BREACH names the axis actually over its cap (e.g. USD-bloc), never an
+            # at-cap axis like "name 10% of 10%".
+            _bind = max(_breachers, key=lambda a: (a[1] / a[2]) if a[2] > 0 else 0.0)
+            caps_val, caps_tone = "BREACH", "bear"
+        else:
+            _bind = max(_axes, key=lambda a: (a[1] / a[2]) if a[2] > 0 else 0.0)
+            caps_val, caps_tone = "OK", "bull"
         caps_sub = f"{_bind[0]} {_pct0(_bind[1])} of {_pct0(_bind[2])}"
     else:  # no cap config -> fall back to the gate boolean + USD-bloc
         caps_val = "n/a" if caps_ok is None else ("OK" if caps_ok else "BREACH")

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -745,8 +745,30 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
         if _isnan(eff)
         else ("warn" if (not _isnan(min_eff) and float(eff) < float(min_eff)) else "bull")
     )
-    caps_tone = "" if caps_ok is None else ("bull" if caps_ok else "bear")
-    caps_val = "n/a" if caps_ok is None else ("OK" if caps_ok else "BREACH")
+    # Concentration caps: OK/BREACH + the BINDING axis (highest utilization vs its
+    # own cap), NOT always USD-bloc. Previously the sub always showed USD-bloc, so a
+    # name/sector breach read as "22% breached". Limits come from meta["caps"].
+    _caps_cfg = meta.get("caps") or {}
+    max_region = diag.get("max_region")
+    _axes: list = []  # (label, value, cap_limit)
+    if not _isnan(gate.get("max_name")) and _caps_cfg.get("name"):
+        _axes.append(("name", float(gate["max_name"]), float(_caps_cfg["name"])))
+    if not _isnan(gate.get("max_sector")) and _caps_cfg.get("sector"):
+        _axes.append(("sector", float(gate["max_sector"]), float(_caps_cfg["sector"])))
+    if not _isnan(usd_bloc) and _caps_cfg.get("usd_bloc"):
+        _axes.append(("USD-bloc", float(usd_bloc), float(_caps_cfg["usd_bloc"])))
+    if not _isnan(max_region) and _caps_cfg.get("region"):
+        _axes.append(("region", float(max_region), float(_caps_cfg["region"])))
+    if _axes:
+        _breach = any(v > c + 1e-6 for _, v, c in _axes)
+        _bind = max(_axes, key=lambda a: (a[1] / a[2]) if a[2] > 0 else 0.0)
+        caps_val = "BREACH" if _breach else "OK"
+        caps_tone = "bear" if _breach else "bull"
+        caps_sub = f"{_bind[0]} {_pct0(_bind[1])} of {_pct0(_bind[2])}"
+    else:  # no cap config -> fall back to the gate boolean + USD-bloc
+        caps_val = "n/a" if caps_ok is None else ("OK" if caps_ok else "BREACH")
+        caps_tone = "" if caps_ok is None else ("bull" if caps_ok else "bear")
+        caps_sub = f"USD-bloc {_pct0(usd_bloc)}"
 
     regime_sub = ""
     if not _isnan(final_dep):
@@ -767,7 +789,7 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
             ("min " + _num1(min_eff)) if not _isnan(min_eff) else "diversification",
             eff_tone,
         ),
-        _stat("Concentration caps", caps_val, f"USD-bloc {_pct0(usd_bloc)}", caps_tone),
+        _stat("Concentration caps", caps_val, caps_sub, caps_tone),
     ]
     grid = f'<div class="stat-grid">{"".join(tiles)}</div>'
 

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -47,6 +47,17 @@ CLUSTER_CELLS = [
     ("strength_z", "Strength"),
 ]
 
+# Six cluster z-scores used in the collapsed card summary strip (all six clusters
+# including Growth, which the combiner computes even when its weight is 0).
+_CARD_CLUSTERS = [
+    ("value_z", "Value"),
+    ("quality_z", "Quality"),
+    ("momentum_z", "Momentum"),
+    ("growth_z", "Growth"),
+    ("lowvol_z", "Low-vol"),
+    ("strength_z", "Strength"),
+]
+
 # Display grouping of metrics: (group label, [(feature_key, metric label), ...]).
 # A z-score column ``{key}_z`` is shown when present; else the raw value only.
 DISPLAY_GROUPS = [
@@ -437,6 +448,41 @@ def _group(row: pd.Series, cols, label: str, metrics) -> str:
         f'<div class="units">{units}</div>'
         f"</div>"
     )
+
+
+def _cluster_strip(row) -> str:
+    """Compact six-cluster z-score row for the always-visible card header.
+
+    Each chip: label + a small magnitude bar (width proportional to |z|, capped
+    at 2.5) + the signed z value.  Green for positive z, red for negative.
+    ``row`` may be None (ghost rows not in the scores frame); every chip then
+    renders as the neutral "·" placeholder.
+    """
+    chips = []
+    for key, label in _CARD_CLUSTERS:
+        z = row.get(key, np.nan) if row is not None else np.nan
+        if _isnan(z):
+            chips.append(
+                f'<span class="cz-chip cz-nan">'
+                f'<span class="cz-label">{label}</span>'
+                f'<span class="cz-bar"></span>'
+                f'<span class="cz-val">&#xB7;</span>'
+                f"</span>"
+            )
+        else:
+            z = float(z)
+            pct = min(abs(z) / 2.5, 1.0) * 100.0
+            col = BULL if z > 0 else BEAR
+            chips.append(
+                f'<span class="cz-chip">'
+                f'<span class="cz-label">{label}</span>'
+                f'<span class="cz-bar">'
+                f'<span class="cz-fill" style="width:{pct:.0f}%;background:{col};"></span>'
+                f"</span>"
+                f'<span class="cz-val" style="color:{col};">{z:+.1f}</span>'
+                f"</span>"
+            )
+    return f'<div class="cluster-strip">{"".join(chips)}</div>'
 
 
 def _levels_block(row: pd.Series) -> str:
@@ -858,7 +904,17 @@ def _action_card(a: dict, row, cols, conv_scale: float, delay: float) -> str:
     )
     levels_html = _levels_block(row) if (action in _LEVEL_ACTIONS and row is not None) else ""
     strip_html = f'<div class="ac-strip">{levels_html}</div>' if levels_html else ""
-    groups_html = f'<div class="groups">{groups}</div>' if groups else ""
+    cluster_strip_html = _cluster_strip(row)
+    inner_groups = f'<div class="groups">{groups}</div>' if groups else ""
+    groups_html = (
+        f'<details class="card-more">'
+        f'<summary class="card-more-h">All factors'
+        f' <span class="chev">&#9662;</span></summary>'
+        f"{inner_groups}"
+        f"</details>"
+        if inner_groups
+        else ""
+    )
     return (
         f'<article class="card card--action" style="animation-delay:{delay:.2f}s;">'
         f'<div class="ac-head">'
@@ -875,6 +931,7 @@ def _action_card(a: dict, row, cols, conv_scale: float, delay: float) -> str:
         f"</div>"
         f"</div>"
         f"{strip_html}"
+        f"{cluster_strip_html}"
         f"{groups_html}"
         f"</article>"
     )
@@ -1256,6 +1313,33 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 .ac-move{font-family:var(--mono);font-size:12px;color:var(--ink2);
   font-variant-numeric:tabular-nums;text-align:right;}
 .ac-strip{margin-top:14px;padding-top:12px;border-top:1px solid var(--line);}
+
+/* cluster summary strip: always visible in the collapsed card header */
+.cluster-strip{display:flex;flex-wrap:wrap;gap:7px;margin-top:14px;}
+.cz-chip{display:inline-flex;align-items:center;gap:5px;background:var(--warm);
+  border:1px solid var(--line);border-radius:7px;padding:4px 8px;white-space:nowrap;}
+.cz-chip.cz-nan{opacity:.55;}
+.cz-label{font-size:8.5px;font-weight:600;letter-spacing:.6px;text-transform:uppercase;
+  color:var(--muted);}
+.cz-bar{width:32px;height:4px;background:var(--track);border-radius:100px;
+  overflow:hidden;flex-shrink:0;}
+.cz-fill{height:100%;border-radius:100px;}
+.cz-val{font-family:var(--mono);font-size:9.5px;font-weight:500;
+  font-variant-numeric:tabular-nums;min-width:26px;text-align:right;}
+.cz-nan .cz-val{color:var(--muted);}
+
+/* collapsible factor-groups disclosure */
+details.card-more{margin-top:14px;padding-top:12px;border-top:1px solid var(--line);}
+summary.card-more-h{display:flex;align-items:center;justify-content:space-between;
+  padding:4px 0;cursor:pointer;list-style:none;-webkit-list-style:none;
+  font-size:9px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;
+  color:var(--muted);user-select:none;}
+summary.card-more-h::-webkit-details-marker{display:none;}
+summary.card-more-h::marker{display:none;}
+.chev{display:inline-block;transition:transform .2s ease;font-size:11px;line-height:1;}
+details[open].card-more .chev{transform:rotate(180deg);}
+details[open].card-more>summary{margin-bottom:12px;}
+
 .acct-grid{margin-bottom:14px;}
 .card--action{padding:20px 24px 22px;}
 .card--action .groups{margin-top:16px;padding-top:14px;gap:14px 20px;}

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -811,6 +811,15 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
             flags.append(_LEVER_LABELS[lev])
     if gate.get("gross_cut") and _LEVER_LABELS["gross_cut"] not in flags:
         flags.append(_LEVER_LABELS["gross_cut"])
+    # Polymarket dial: surface the signal when present. Advisory (no book effect)
+    # while the tilt is 0 (shadow phase); shows the applied pp when live.
+    pm_sig = cond.get("polymarket_signal")
+    if pm_sig is not None:
+        pm_tilt = float(cond.get("polymarket_tilt") or 0.0)
+        if cond.get("polymarket_active") and abs(pm_tilt) > 1e-9:
+            flags.append(f"PM {float(pm_sig):+.2f} to {pm_tilt * 100:+.0f}pp")
+        else:
+            flags.append(f"PM {float(pm_sig):+.2f} advisory")
     seen: set = set()
     flags = [f for f in flags if not (f in seen or seen.add(f))]
     if flags:

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -755,8 +755,15 @@ def _exec_panel(portfolio: dict, conditioning, meta: dict) -> str:
         _axes.append(("name", float(gate["max_name"]), float(_caps_cfg["name"])))
     if not _isnan(gate.get("max_sector")) and _caps_cfg.get("sector"):
         _axes.append(("sector", float(gate["max_sector"]), float(_caps_cfg["sector"])))
-    if not _isnan(usd_bloc) and _caps_cfg.get("usd_bloc"):
-        _axes.append(("USD-bloc", float(usd_bloc), float(_caps_cfg["usd_bloc"])))
+    # usd_bloc is NAV-basis (absolute); convert to book-basis (/gross) so it ranks on
+    # the same basis as name/sector (gate, of book) and region (/gross) — I2 fix.
+    _usd_book = (
+        float(usd_bloc) / float(gross)
+        if (not _isnan(usd_bloc) and not _isnan(gross) and float(gross) > 0)
+        else usd_bloc
+    )
+    if not _isnan(_usd_book) and _caps_cfg.get("usd_bloc"):
+        _axes.append(("USD-bloc", float(_usd_book), float(_caps_cfg["usd_bloc"])))
     if not _isnan(max_region) and _caps_cfg.get("region"):
         _axes.append(("region", float(max_region), float(_caps_cfg["region"])))
     if _axes:

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -714,10 +714,21 @@ def _action_row(a: dict) -> str:
     usd = _usd_signed(a.get("delta_usd"))
     usd_html = f'<span class="act-usd">{usd}</span>' if usd else ""
     name_html = f'<div class="act-name">{name}</div>' if name else ""
+    pnl = a.get("pnl")
+    pnl_html = ""
+    if pnl is not None:
+        pct, cv = a.get("pnl_pct"), a.get("current_value")
+        pcol = "#2d6a4f" if float(pnl) >= 0 else "#b3402f"
+        pct_s = f" ({pct:+.1f}%)" if pct is not None else ""
+        val_s = f" · {_money(cv)}" if cv is not None else ""
+        pnl_html = (
+            f'<span class="act-pnl" style="color:{pcol};">'
+            f"P/L {_usd_signed(pnl)}{pct_s}{val_s}</span>"
+        )
     move = (
         f'<span class="from">{_pct1(cur)}</span> '
         f'<span class="to">→ {_pct1(tgt)}</span> '
-        f'<span class="act-dpp">({_pp(delta)})</span>{usd_html}'
+        f'<span class="act-dpp">({_pp(delta)})</span>{usd_html}{pnl_html}'
     )
     levels_html = ""
     if a.get("action") in _LEVEL_ACTIONS:
@@ -1062,12 +1073,13 @@ body{margin:0;background:var(--canvas);color:var(--ink2);font-family:var(--sans)
 .act-row:first-child{border-top:none;}
 .act-id{min-width:0;}
 .act-tkr{font-family:var(--serif);font-weight:600;font-size:16px;color:var(--ink);letter-spacing:-.2px;}
-.act-name{font-size:11px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.act-name{font-size:11px;color:var(--muted);line-height:1.3;}
 .act-conv{font-family:var(--mono);font-size:12.5px;font-variant-numeric:tabular-nums;text-align:right;}
 .act-move{font-family:var(--mono);font-size:12.5px;color:var(--ink2);font-variant-numeric:tabular-nums;}
 .act-move .to{color:var(--ink);font-weight:600;}
 .act-move .act-dpp{color:var(--muted);}
 .act-usd{color:var(--muted);margin-left:8px;}
+.act-pnl{font-family:var(--mono);font-size:11px;font-weight:600;margin-left:10px;white-space:nowrap;}
 .act-levels{display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;}
 .act-lvl{font-family:var(--mono);font-size:10.5px;color:var(--ink2);background:var(--warm);
   border:1px solid var(--line);border-radius:7px;padding:3px 8px;font-variant-numeric:tabular-nums;}

--- a/trade_modules/v3/risk_gate.py
+++ b/trade_modules/v3/risk_gate.py
@@ -57,6 +57,8 @@ def _clamp_caps(
     name_thr: float,
     bloc_thr: float,
     sector_thr: float,
+    region_arr: np.ndarray | None = None,
+    region_thr: float | None = None,
 ) -> np.ndarray:
     """Force compliance by clamping DOWN (excess -> cash, no redistribution).
 
@@ -64,8 +66,9 @@ def _clamp_caps(
     book the loop has already converged so this is a no-op, but when the caps are
     mutually infeasible at the current gross (e.g. an over-cap sector with too few
     non-zero receivers) the loop can oscillate — this pass guarantees a compliant
-    book by dropping the irreducible excess to cash. Order name -> sector -> bloc,
-    all downward, so every later clamp preserves the earlier ones.
+    book by dropping the irreducible excess to cash. Order name -> sector ->
+    region -> bloc, all downward, so every later clamp preserves the earlier ones.
+    ``region_arr`` / ``region_thr`` are opt-in (None -> region not enforced).
     """
     w = np.minimum(np.asarray(w, dtype=float).copy(), name_thr)  # per-name -> cash
     for lab in dict.fromkeys(sec_arr.tolist()):
@@ -73,6 +76,12 @@ def _clamp_caps(
         s = float(w[mask].sum())
         if s > sector_thr + _STABLE_TOL:
             w[mask] *= sector_thr / s
+    if region_arr is not None and region_thr is not None:
+        for lab in dict.fromkeys(region_arr.tolist()):
+            mask = region_arr == lab
+            s = float(w[mask].sum())
+            if s > region_thr + _STABLE_TOL:
+                w[mask] *= region_thr / s
     s = float(w[is_bloc].sum())
     if s > bloc_thr + _STABLE_TOL:
         w[is_bloc] *= bloc_thr / s
@@ -88,6 +97,8 @@ def _caps_to_convergence(
     bloc_thr: float,
     sector_thr: float,
     max_iter: int,
+    region_arr: np.ndarray | None = None,
+    region_thr: float | None = None,
 ) -> tuple[np.ndarray, int]:
     """Iterate {name -> USD-bloc -> sector} caps until the weights stop moving.
 
@@ -100,6 +111,7 @@ def _caps_to_convergence(
     are infeasible and the loop would otherwise oscillate.
     """
     w = np.asarray(w, dtype=float).copy()
+    _has_region = region_arr is not None and region_thr is not None
     iters = 0
     for _ in range(max_iter):
         iters += 1
@@ -107,10 +119,19 @@ def _caps_to_convergence(
         w = apply_name_cap(w, name_thr)
         w = cap_bloc(w, is_bloc, bloc_thr)
         w = cap_groups(w, sec_arr, sector_thr)
+        if _has_region:
+            w = cap_groups(w, region_arr, region_thr)
         if np.max(np.abs(w - prev)) < _STABLE_TOL:
             break
     w = _clamp_caps(
-        w, sec_arr, is_bloc, name_thr=name_thr, bloc_thr=bloc_thr, sector_thr=sector_thr
+        w,
+        sec_arr,
+        is_bloc,
+        name_thr=name_thr,
+        bloc_thr=bloc_thr,
+        sector_thr=sector_thr,
+        region_arr=region_arr if _has_region else None,
+        region_thr=region_thr if _has_region else None,
     )
     return w, iters
 
@@ -313,6 +334,8 @@ def apply_risk_gate(
     cap_mode: str | None = None,
     caps: pd.Series | None = None,
     managed_vol_ceiling: float = 0.18,
+    regions=None,
+    region_cap: float | None = None,
 ) -> tuple[pd.Series, dict]:
     """Enforce the vol ceiling + concentration caps on a constructed book.
 
@@ -450,6 +473,13 @@ def apply_risk_gate(
     name_thr = name_cap * g_target
     bloc_thr = usd_bloc_cap * g_target
     sector_thr = sector_cap * g_target
+    # Region cap (opt-in): threaded through the convergence + clamp so it holds on the
+    # final book (infeasible excess drops to cash). None -> region not enforced (the
+    # overlay path passes nothing, keeping region a monitor under the owner rules).
+    region_arr = np.asarray(list(regions), dtype=object) if regions is not None else None
+    region_thr = (
+        region_cap * g_target if (region_arr is not None and region_cap is not None) else None
+    )
 
     levers_fired: list[str] = []
     caps_iter_total = 0
@@ -464,6 +494,8 @@ def apply_risk_gate(
         bloc_thr=bloc_thr,
         sector_thr=sector_thr,
         max_iter=max_iter,
+        region_arr=region_arr,
+        region_thr=region_thr,
     )
     caps_iter_total += ci
     if np.max(np.abs(w - w_pre)) > _STABLE_TOL:
@@ -507,6 +539,8 @@ def apply_risk_gate(
                     bloc_thr=bloc_thr,
                     sector_thr=sector_thr,
                     max_iter=max_iter,
+                    region_arr=region_arr,
+                    region_thr=region_thr,
                 )
                 caps_iter_total += ci
                 new_vol = portfolio_vol(trial, cov)


### PR DESCRIPTION
Overnight batch refining the v3 overlay report toward replacing the v2 committee email. All 335 v3 unit tests green.

## Model / risk
- **Metric prune** (combine.py): dropped pe_forward + ps_sector from value (rho up to 0.98 with kept ratios) and price_perf from momentum (rho 0.95). Pruned metrics still shown as raw context, not scored.
- **Real country/region cap** (construct.py): `region_of(ticker)` from listing venue -> region; hard cap in the from-scratch constructor (pre-gate + conditional post-gate clamp, gate is region-blind), monitored exposure in the overlay (never force-sells a held/core name). Centralized so the allocation bars + cap never diverge. Default 65%.
- **Market-cap + ADV USD normalization** (features.py): eToro reports local currency (Toyota in yen); `_usd_rate_for` converts cap + adv_usd to USD so floors/tiers are single-currency.
- **ADV >= $1M/day liquidity gate** on buy candidates (held + no-data exempt).
- **Polymarket dial** wired end-to-end but advisory by default (tilt 0 = shadow; `V3_PM_MAX_TILT` to go live).

## Report (Section I + masthead)
- **eToro account panel**: copiers, risk score, win ratio, today/MTD/YTD, unique assets, open positions — live from the tradeinfo endpoint (v3_account_snapshot.py).
- **Portfolio allocation bars**: geography / asset-type / sector.
- **Concentration-caps tile** now shows the binding axis (not always USD-bloc), with a 0.5pp display-consistent tolerance.
- **Coverage %** in the masthead + ADV-dropped count.

## Studies
- **PI sub-segment alpha study** (top performers / hot-hands / most-copied): re-confirmed NOISE on ~5mo history; no signal built.

Paired report + pipeline explainer emailed to the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)