### PR TITLE
vps: daily v3 factor-snapshot report cron (replaces v2 committee brief)

### DIFF
--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Generate and email the daily Trading Model v3 "Factor Snapshot".
+#
+# Successor to the v2 committee brief (run-committee-brief.sh): reads the live
+# eToro account + master daily signals, runs the v3 overlay pipeline, and emails
+# the HTML report via outlook-cli. Repo-tracked; the systemd unit ExecStart
+# points at this file so the repo path IS the runtime.
+set -euo pipefail
+
+source ~/.config/nbg-vertex/env 2>/dev/null || true
+source ~/.config/etoro/env 2>/dev/null || true
+export PATH="$HOME/.local/bin:$HOME/.pyenv/shims:$HOME/scripts:$PATH"
+
+REPO="$HOME/SourceCode/etorotrade"
+cd "$REPO"
+
+# Stay on master with today's committed signals (daily-signals.yml -> etoro.csv/buy.csv).
+git pull --ff-only --quiet 2>/dev/null \
+  || echo "WARN: etorotrade pull skipped (local changes or diverged)"
+
+# 1) Live eToro account snapshot -> per-position P/L (keys from ~/.config/etoro/env).
+.venv/bin/python scripts/v3_account_snapshot.py 2>&1 \
+  || echo "WARN: account snapshot failed - report falls back to portfolio.csv weights"
+
+# 2) Overlay report with the locked decision-support config.
+V3_FLOOR_CORE=0 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
+V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 \
+  .venv/bin/python scripts/v3_overlay_report.py
+
+# 3) Email the freshest report.
+REPORT="$(ls -t "$HOME/Downloads/"*_v3_overlay_report.html 2>/dev/null | head -1 || true)"
+if [ -z "${REPORT:-}" ]; then
+  echo "ERROR: no v3 overlay report produced" >&2
+  exit 1
+fi
+
+SUBJECT="trading model v3 · factor snapshot $(TZ=Europe/Athens date +%Y-%m-%d)"
+
+~/scripts/outlook-cli send-mail \
+  --to dimitrios.plessas@nbg.gr \
+  --subject "$SUBJECT" \
+  --html "$REPORT" \
+  --send-now --no-signature
+
+echo "OK: emailed $(basename "$REPORT") ($(wc -c < "$REPORT" | tr -d ' ') bytes)"

--- a/scripts/vps/v3-report.service
+++ b/scripts/vps/v3-report.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily Trading Model v3 Factor Snapshot — generate + email (replaces v2 committee brief)
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/SourceCode/etorotrade
+ExecStart=%h/SourceCode/etorotrade/scripts/vps/run-v3-report.sh
+StandardOutput=append:%h/logs/v3-report/service.log
+StandardError=append:%h/logs/v3-report/service.err
+TimeoutStartSec=900
+Environment=HOME=%h

--- a/scripts/vps/v3-report.timer
+++ b/scripts/vps/v3-report.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily Trading Model v3 Factor Snapshot timer
+
+[Timer]
+# 06:37 Athens local — after the 05:17 signals-refresh, before the workday.
+# Persistent=true catches up a missed run after downtime.
+# Install: cp scripts/vps/v3-report.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload && systemctl --user enable --now v3-report.timer
+OnCalendar=*-*-* 06:37:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Stands up the daily v3 report email that replaces the v2 committee brief.

- `scripts/vps/run-v3-report.sh` — account snapshot → v3 overlay pipeline → email via outlook-cli
- `scripts/vps/v3-report.{service,timer}` — once daily 06:37 Athens, Persistent

Deploy: VPS pull → cp units → enable timer → disable committee-brief.timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)