### PR TITLE
vps: v3 report every 4h to match v2 cadence

### DIFF
--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -35,7 +35,7 @@ if [ -z "${REPORT:-}" ]; then
   exit 1
 fi
 
-SUBJECT="trading model v3 · factor snapshot $(TZ=Europe/Athens date +%Y-%m-%d)"
+SUBJECT="trading model v3 · factor snapshot $(TZ=Europe/Athens date '+%Y-%m-%d %H:%M')"
 
 ~/scripts/outlook-cli send-mail \
   --to dimitrios.plessas@nbg.gr \

--- a/scripts/vps/v3-report.service
+++ b/scripts/vps/v3-report.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Daily Trading Model v3 Factor Snapshot — generate + email (replaces v2 committee brief)
+Description=Trading Model v3 Factor Snapshot — generate + email (replaces v2 committee brief)
 After=network-online.target
 
 [Service]

--- a/scripts/vps/v3-report.timer
+++ b/scripts/vps/v3-report.timer
@@ -1,11 +1,11 @@
 [Unit]
-Description=Daily Trading Model v3 Factor Snapshot timer
+Description=Trading Model v3 Factor Snapshot timer (every 4h)
 
 [Timer]
-# 06:37 Athens local — after the 05:17 signals-refresh, before the workday.
-# Persistent=true catches up a missed run after downtime.
+# Every 4 hours at 00,04,08,12,16,20 Athens local — matches the cadence of the
+# retired v2 committee brief this replaces. Persistent catches up a missed run.
 # Install: cp scripts/vps/v3-report.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload && systemctl --user enable --now v3-report.timer
-OnCalendar=*-*-* 06:37:00
+OnCalendar=*-*-* 00,04,08,12,16,20:00:00
 Persistent=true
 
 [Install]


### PR DESCRIPTION
The v3 factor snapshot replaces the v2 committee brief, which ran 6x/day (00,04,08,12,16,20). Match that cadence (was once-daily 06:37) and add HH:MM to the subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)