### PR TITLE
feat(v3): factor-model redesign — FIX-NOW combiner batch + BUILD Tier 0/1 + liquidity/cost/benchmark

### DIFF
--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -26,6 +26,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from trade_modules.v3.constants import V3_IC_HORIZONS  # noqa: E402
 from trade_modules.validation.xsection_ic import cross_sectional_ic  # noqa: E402
 
 PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
@@ -177,7 +178,7 @@ def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
 
 def ic_from_log(
     log_df: pd.DataFrame,
-    horizons: tuple[int, ...] = (5, 10, 21, 63),
+    horizons: tuple[int, ...] = V3_IC_HORIZONS,
 ) -> dict:
     """Compute cross-sectional IC for each horizon from the IC log.
 

--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -263,15 +263,18 @@ def main() -> None:
         load_offline_sector_map,
         update_sector_cache,
     )
+    from trade_modules.v3.universe import assemble_scored_universe  # noqa: PLC0415
 
     # --- Universe assembly (mirrors v3_full_report.py exactly) ---
     port = _read_tickers(PORTFOLIO_CSV)
     buy = _read_tickers(BUY_CSV)
     port_set = set(port)
-    universe = list(dict.fromkeys(port + buy))
+    # BUILD ④: coverage-gated broad universe ∪ holdings ∪ analyst candidates,
+    # replacing the analyst AND-gate (which scored only ~3% of the universe).
+    universe = assemble_scored_universe(ETORO_CSV, port, buy)
     print(
-        f"universe: {len(universe)} tickers ({len(port_set)} portfolio + "
-        f"{len(set(buy) - port_set)} candidates)"
+        f"universe: {len(universe)} tickers (coverage-gated ∪ {len(port_set)} held "
+        f"∪ {len(set(buy) - port_set)} analyst candidates)"
     )
 
     # --- Feature enrichment + scoring ---

--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -259,6 +259,10 @@ def main() -> None:
     # Lazy imports: avoid module-level yahoofinance.core.config import.
     from trade_modules.v3.combine import compute_scores  # noqa: PLC0415
     from trade_modules.v3.features import enrich_features  # noqa: PLC0415
+    from trade_modules.v3.sectors import (  # noqa: PLC0415
+        load_offline_sector_map,
+        update_sector_cache,
+    )
 
     # --- Universe assembly (mirrors v3_full_report.py exactly) ---
     port = _read_tickers(PORTFOLIO_CSV)
@@ -271,9 +275,15 @@ def main() -> None:
     )
 
     # --- Feature enrichment + scoring ---
+    sector_map = load_offline_sector_map()
     feats = enrich_features(
-        universe, ETORO_CSV, price_period="2y", accruals_fetch=lambda _tickers: {}
+        universe,
+        ETORO_CSV,
+        price_period="2y",
+        accruals_fetch=lambda _tickers: {},
+        sector_map=sector_map,
     )
+    update_sector_cache(feats["sector"].dropna().to_dict())  # grow the cache from live sectors
     scores = compute_scores(feats, sector_neutral=True)
 
     # --- Filter to eligible names only ---

--- a/scripts/v3_ic_report.py
+++ b/scripts/v3_ic_report.py
@@ -1,8 +1,8 @@
 """Trading Model v3 — IC-join report (Phase 5E).
 
 Reads the forward-IC log at $V3_IC_LOG (or ~/.weirdapps-trading/v3_ic_log.csv),
-computes cross-sectional Spearman IC for each horizon in (5, 10, 21, 63) log-date
-steps, prints a summary, and saves a markdown report to:
+computes cross-sectional Spearman IC for each horizon in (5, 21, 63) log-date
+steps (primary = V3_SIGNAL_HORIZON), prints a summary, and saves a markdown report to:
 
     ~/Downloads/<UTCstamp>_v3_ic_report.md
 
@@ -24,12 +24,12 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from scripts.v3_ic_logger import DEFAULT_LOG, ic_from_log  # noqa: E402
+from trade_modules.v3.constants import V3_IC_HORIZONS  # noqa: E402
 
-HORIZONS = (5, 10, 21, 63)
+HORIZONS = V3_IC_HORIZONS
 
 _HORIZON_LABELS = {
     5: " ~1w",
-    10: " ~2w",
     21: " ~1m",
     63: " ~3m",
 }

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -493,6 +493,14 @@ def main() -> None:
     if len(_dropped_adv):
         print(f"ADV gate: dropped {len(_dropped_adv)} candidates below their cap-tier ADV floor")
 
+    # BUILD ⑥b: attach each name's round-trip cost (spread-by-tier + eToro financing
+    # over the ~30d holding horizon) so the book's trading hurdle is surfaced. The
+    # net-of-cost IR gate + action-level cost suppression are deferred follow-ups.
+    from trade_modules.v3.costs import roundtrip_cost_pct
+
+    if "cap" in scores.columns:
+        scores["roundtrip_cost_pct"] = scores["cap"].map(roundtrip_cost_pct)
+
     elig = scores.get("eligible", pd.Series(True, index=scores.index)).fillna(False).astype(bool)
     n_port = int((scores["is_portfolio"] & elig).sum())
     n_cand = int((~scores["is_portfolio"] & elig).sum())
@@ -503,6 +511,11 @@ def main() -> None:
         "n_eligible": int(elig.sum()),
         "pct": (int(elig.sum()) / len(scores)) if len(scores) else 0.0,
         "adv_dropped": _cov_scored_before - len(scores),
+        "median_roundtrip_cost_pct": (
+            float(scores["roundtrip_cost_pct"].median())
+            if "roundtrip_cost_pct" in scores.columns and len(scores)
+            else None
+        ),
     }
 
     # --- Prices + market regime ---

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -508,7 +508,7 @@ def main() -> None:
     from trade_modules.v3.benchmark import fetch_spy_eur_return_pct
 
     spy_eur_1y = fetch_spy_eur_return_pct("1y")
-    if spy_eur_1y == spy_eur_1y:  # not NaN
+    if pd.notna(spy_eur_1y):
         print(f"benchmark: S&P 500 (EUR) 1y = {spy_eur_1y:+.1f}%")
 
     # Coverage: how much of the scored universe clears the eligibility bar (equity +
@@ -523,7 +523,7 @@ def main() -> None:
             if "roundtrip_cost_pct" in scores.columns and len(scores)
             else None
         ),
-        "spy_eur_1y_pct": (spy_eur_1y if spy_eur_1y == spy_eur_1y else None),
+        "spy_eur_1y_pct": (float(spy_eur_1y) if pd.notna(spy_eur_1y) else None),
     }
 
     # --- Prices + market regime ---

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -461,9 +461,17 @@ def main() -> None:
     )
 
     # --- Feature enrichment + scoring with BALANCED cluster weights ---
+    from trade_modules.v3.sectors import load_offline_sector_map, update_sector_cache
+
+    sector_map = load_offline_sector_map()
     feats = enrich_features(
-        universe, ETORO_CSV, price_period="2y", accruals_fetch=lambda _tickers: {}
+        universe,
+        ETORO_CSV,
+        price_period="2y",
+        accruals_fetch=lambda _tickers: {},
+        sector_map=sector_map,
     )
+    update_sector_cache(feats["sector"].dropna().to_dict())  # grow the cache from live sectors
     priced = int(feats["mom_12_1"].notna().sum())
     enriched = int(feats["pb"].notna().sum())
     scores = compute_scores(feats, sector_neutral=True, cluster_weights=BALANCED_WEIGHTS)

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -84,7 +84,9 @@ _NAME_CAP = float(os.environ.get("V3_NAME_CAP", "0.10"))
 _SECTOR_CAP = float(os.environ.get("V3_SECTOR_CAP", "0.35"))
 _USD_BLOC_CAP = float(os.environ.get("V3_USD_BLOC_CAP", "0.60"))
 _REGION_CAP = float(os.environ.get("V3_REGION_CAP", "0.65"))
-_ADV_MIN = float(os.environ.get("V3_ADV_MIN", "1e6"))  # min avg dollar-volume/day (USD)
+_COPIER_MULT = float(
+    os.environ.get("V3_COPIER_MULT", "1.0")
+)  # scales the tier ADV floor for a copied book
 # Polymarket deployment dial. The signal is a shadow / ZERO-conviction cross-repo
 # input, so the book-moving tilt is OFF by default (V3_PM_MAX_TILT=0 -> advisory
 # only: the signal is fetched + shown in the report but does not move deployment).
@@ -480,18 +482,16 @@ def main() -> None:
     scores = compute_scores(feats, sector_neutral=True, cluster_weights=BALANCED_WEIGHTS)
     scores["is_portfolio"] = scores.index.isin(port_set)
 
-    # ADV liquidity gate: drop BUY CANDIDATES (not held) with a KNOWN ADV below the
-    # floor. Held names are exempt (never force-sold for liquidity); names with no
-    # volume data are kept (not penalized for a data gap). Positions run $5-10k, so a
-    # $1M/day floor clears cheaply. adv_usd is FX-normalized to USD in features.
+    # BUILD ⑥a: tiered, copier-aware ADV liquidity gate (replaces the flat $1M floor).
+    # Non-held names whose KNOWN adv_usd is below their cap-tier floor (MEGA $50M ..
+    # SMALL $5M, scaled by the copier multiplier) are dropped; held names and
+    # unknown-ADV names are exempt. adv_usd is FX-normalized to USD in features.
+    from trade_modules.v3.liquidity import liquidity_gate
+
     _cov_scored_before = len(scores)
-    if "adv_usd" in scores.columns and _ADV_MIN > 0:
-        _adv = pd.to_numeric(scores["adv_usd"], errors="coerce")
-        _illiquid = (~scores["is_portfolio"]) & _adv.notna() & (_adv < _ADV_MIN)
-        _n_illiquid = int(_illiquid.sum())
-        if _n_illiquid:
-            scores = scores[~_illiquid].copy()
-            print(f"ADV gate: dropped {_n_illiquid} candidates below ${_ADV_MIN:,.0f}/day ADV")
+    scores, _dropped_adv = liquidity_gate(scores, copier_multiplier=_COPIER_MULT)
+    if len(_dropped_adv):
+        print(f"ADV gate: dropped {len(_dropped_adv)} candidates below their cap-tier ADV floor")
 
     elig = scores.get("eligible", pd.Series(True, index=scores.index)).fillna(False).astype(bool)
     n_port = int((scores["is_portfolio"] & elig).sum())

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -504,6 +504,13 @@ def main() -> None:
     elig = scores.get("eligible", pd.Series(True, index=scores.index)).fillna(False).astype(bool)
     n_port = int((scores["is_portfolio"] & elig).sum())
     n_cand = int((~scores["is_portfolio"] & elig).sum())
+    # BUILD ⑥c (D25): EUR-denominated S&P 500 benchmark reference for the report.
+    from trade_modules.v3.benchmark import fetch_spy_eur_return_pct
+
+    spy_eur_1y = fetch_spy_eur_return_pct("1y")
+    if spy_eur_1y == spy_eur_1y:  # not NaN
+        print(f"benchmark: S&P 500 (EUR) 1y = {spy_eur_1y:+.1f}%")
+
     # Coverage: how much of the scored universe clears the eligibility bar (equity +
     # priced + >=3 of 6 clusters). A data-quality readout for the report.
     coverage = {
@@ -516,6 +523,7 @@ def main() -> None:
             if "roundtrip_cost_pct" in scores.columns and len(scores)
             else None
         ),
+        "spy_eur_1y_pct": (spy_eur_1y if spy_eur_1y == spy_eur_1y else None),
     }
 
     # --- Prices + market regime ---

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -450,14 +450,17 @@ def write_preview(out: str = PREVIEW_OUT) -> str:
 
 
 def main() -> None:
-    # --- Universe assembly (mirrors v3_full_report.py) ---
+    # --- Universe assembly: coverage-gated ∪ holdings ∪ analyst candidates (BUILD ④) ---
+    from trade_modules.v3.universe import assemble_scored_universe
+
     port = _read_tickers(PORTFOLIO_CSV)
     buy = _read_tickers(BUY_CSV)
     port_set = set(port)
-    universe = list(dict.fromkeys(port + buy))
+    # Coverage-gated broad universe replaces the analyst AND-gate (which scored ~3%).
+    universe = assemble_scored_universe(ETORO_CSV, port, buy)
     print(
-        f"universe: {len(universe)} tickers ({len(port_set)} portfolio + "
-        f"{len(set(buy) - port_set)} candidates)"
+        f"universe: {len(universe)} tickers (coverage-gated ∪ {len(port_set)} held "
+        f"∪ {len(set(buy) - port_set)} analyst candidates)"
     )
 
     # --- Feature enrichment + scoring with BALANCED cluster weights ---

--- a/scripts/v3_spine_gate.py
+++ b/scripts/v3_spine_gate.py
@@ -15,6 +15,7 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
+from trade_modules.v3.constants import V3_IC_HORIZONS
 from trade_modules.v3.fetch import robust_fetch_prices
 from trade_modules.v3.labels import forward_returns
 from trade_modules.v3.prices import load_eur_close
@@ -23,7 +24,7 @@ from trade_modules.v3.universe import load_universe
 from trade_modules.v3.validate_spine import classify_regimes, run_gate
 
 ETORO_CSV = "yahoofinance/output/etoro.csv"
-HORIZONS = [5, 21, 63]
+HORIZONS = list(V3_IC_HORIZONS)
 
 
 def weekly_rebalances(index) -> list:

--- a/tests/unit/trade_modules/test_v3_attribution.py
+++ b/tests/unit/trade_modules/test_v3_attribution.py
@@ -1,0 +1,43 @@
+"""TDD tests for trade_modules.v3.attribution — FIX-NOW (D21): measure the owner
+core sleeve (de-launder it) + the 3-layer attribution taxonomy classifier."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trade_modules.v3.attribution import attribution_layer, core_attribution
+
+
+def test_core_attribution_variance_share_exceeds_weight_for_hot_core():
+    """The core's share of BOOK VARIANCE can far exceed its weight — exactly the
+    'the AI core dominates book risk' fact the self-review demanded be measured."""
+    w = pd.Series({"CORE": 0.5, "OTHER": 0.5})
+    cov = np.array([[0.16, 0.0], [0.0, 0.04]])  # core carries 4x the variance
+    out = core_attribution(w, cov, ["CORE"], betas=[1.4, 0.8])
+    assert out["core_weight"] == pytest.approx(0.5)
+    assert out["core_variance_share"] == pytest.approx(0.8)  # 50% of weight, 80% of risk
+    assert out["n_core_held"] == 1
+    assert out["book_net_beta"] == pytest.approx(0.5 * 1.4 + 0.5 * 0.8)
+    assert out["core_net_beta_contribution"] == pytest.approx(0.5 * 1.4)
+
+
+def test_core_attribution_all_cash_is_zero_safe():
+    """An empty / all-cash book returns zeros, never divides by zero."""
+    out = core_attribution(pd.Series(dtype=float), np.zeros((0, 0)), ["CORE"])
+    assert out["core_weight"] == 0.0
+    assert out["core_variance_share"] == 0.0
+    assert out["n_core_held"] == 0
+
+
+def test_attribution_layer_classifies_saa_forecast_and_override():
+    """3-layer taxonomy at the ticker level: managed sleeves = SAA (owned policy);
+    scored equities = forecast (IC-gated); protect_core/core_floor names carry an
+    owner_override flag (measured discretion, not process)."""
+    managed = ["GLD", "UVXY", "LYXGRE.DE"]
+    core = ["NVDA", "MSFT"]
+    saa = attribution_layer("GLD", managed_sleeves=managed, core_list=core)
+    assert saa["layer"] == "SAA" and saa["owner_override"] is False
+    fc = attribution_layer("AAPL", managed_sleeves=managed, core_list=core)
+    assert fc["layer"] == "forecast" and fc["owner_override"] is False
+    ovr = attribution_layer("NVDA", managed_sleeves=managed, core_list=core)
+    assert ovr["layer"] == "forecast" and ovr["owner_override"] is True

--- a/tests/unit/trade_modules/test_v3_benchmark.py
+++ b/tests/unit/trade_modules/test_v3_benchmark.py
@@ -1,0 +1,65 @@
+"""TDD — BUILD ⑥c (2026-07-18, D25): EUR-denominated S&P 500 benchmark.
+
+The owner's home currency is EUR, so the benchmark is the EUR return of holding SPY
+= SPY's USD return combined with the EUR/USD move. Pure conversion + period-return
+helpers (tested here) plus a thin fetch wrapper (tested with an injected fetcher).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from trade_modules.v3.benchmark import (
+    fetch_spy_eur_return_pct,
+    period_return_pct,
+    spy_eur_return_pct,
+    to_eur,
+)
+
+
+def test_to_eur_divides_by_usd_per_eur():
+    assert to_eur(110.0, 1.10) == pytest.approx(100.0)  # $110 at 1.10 USD/EUR = 100 EUR
+
+
+def test_period_return_pct():
+    assert period_return_pct([100.0, 110.0]) == pytest.approx(10.0)
+    assert pd.isna(period_return_pct([100.0]))  # need >= 2 points
+    assert pd.isna(period_return_pct([0.0, 100.0]))  # zero base
+
+
+def test_spy_eur_return_pure_usd_move():
+    spy = pd.Series([100.0, 120.0])  # +20% USD
+    fx = pd.Series([1.0, 1.0])  # no FX move
+    assert spy_eur_return_pct(spy, fx) == pytest.approx(20.0)
+
+
+def test_spy_eur_return_pure_fx_move():
+    spy = pd.Series([100.0, 100.0])  # flat USD
+    fx = pd.Series([1.0, 1.25])  # EUR strengthens 25% -> SPY worth less in EUR
+    # EUR value: 100/1.0=100 -> 100/1.25=80 -> -20%
+    assert spy_eur_return_pct(spy, fx) == pytest.approx(-20.0)
+
+
+def test_spy_eur_return_aligns_on_common_dates():
+    idx1 = pd.date_range("2026-01-01", periods=3, freq="D")
+    spy = pd.Series([100.0, 110.0, 120.0], index=idx1)
+    fx = pd.Series([1.0, 1.0], index=idx1[:2])  # missing the 3rd date
+    # aligned window is the first two dates: 100 -> 110 = +10%
+    assert spy_eur_return_pct(spy, fx) == pytest.approx(10.0)
+
+
+def test_fetch_spy_eur_return_with_injected_fetcher():
+    def fake_fetch(tickers, period="1y", **_kw):
+        return pd.DataFrame({"SPY": [100.0, 120.0], "EURUSD=X": [1.0, 1.0]})
+
+    assert fetch_spy_eur_return_pct("1y", fetch=fake_fetch) == pytest.approx(20.0)
+
+
+def test_fetch_spy_eur_return_nan_on_empty_or_error():
+    assert pd.isna(fetch_spy_eur_return_pct(fetch=lambda *a, **k: pd.DataFrame()))
+
+    def boom(*a, **k):
+        raise RuntimeError("network")
+
+    assert pd.isna(fetch_spy_eur_return_pct(fetch=boom))

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -114,23 +114,9 @@ def test_no_quote_type_column_means_all_eligible():
     assert scores["rank"].notna().all()
 
 
-def test_accruals_in_quality_negated_low_accruals_scores_higher():
-    """Low (more negative) accruals = higher earnings quality = higher quality_z.
-
-    accruals direction is -1 (negated), consistent with the existing quality
-    metrics that penalise leverage (de: -1).  CLEAN has negative accruals
-    (cash-flow exceeds reported income) which is the gold standard for
-    earnings quality and must rank above DIRTY (high accruals = inflated
-    earnings, lower quality).
-    """
-    df = _base(["CLEAN", "DIRTY"])
-    df["accruals"] = [-0.10, 0.15]  # CLEAN: quality earner; DIRTY: accrual-heavy
-    scores = compute_scores(df, sector_neutral=False)
-    # CLEAN (low/negative accruals) must outscore DIRTY on quality_z.
-    assert scores.loc["CLEAN", "quality_z"] > scores.loc["DIRTY", "quality_z"]
-    # With only one metric, the direction must produce the right sign.
-    assert scores.loc["CLEAN", "quality_z"] > 0
-    assert scores.loc["DIRTY", "quality_z"] < 0
+# (removed 2026-07-18, D8) test_accruals_in_quality_* — accruals is no longer a
+# scored quality metric (moved to shadow; non-PIT, needs a point-in-time balance
+# sheet). Coverage is now via test_fixnow_quality_interim_is_roe_fcf.
 
 
 def test_eligibility_excludes_non_equity_and_dataless():
@@ -513,3 +499,41 @@ def test_backward_compat_default_ignores_growth_data():
         equal_nan=True,
     )
     assert list(without["rank"].astype("float")) == list(withg["rank"].astype("float"))
+
+
+# --------------------------------------------------------------------------- #
+# FIX-NOW (agreed setup 2026-07-18): rebuilt scored factor set
+# --------------------------------------------------------------------------- #
+
+
+def test_fixnow_strength_cluster_is_analyst_mom_only():
+    """strength_z collapses to analyst_mom alone: upside, buy_pct, short_interest
+    and target_dispersion are removed from ALL scored clusters (D2-D6)."""
+    from trade_modules.v3.combine import CLUSTERS
+
+    assert CLUSTERS["strength_z"] == ["analyst_mom"]
+    for dead in ("upside", "buy_pct", "short_interest", "target_dispersion"):
+        for members in CLUSTERS.values():
+            assert dead not in members, f"{dead} must not be scored in any cluster"
+
+
+def test_fixnow_value_drops_raw_pb_anchors_ev_ebitda():
+    """Value = EV/EBITDA (anchor) + trailing P/E; raw P/B is dropped from scoring
+    (intangible-heavy tech universe degrades it) (D7)."""
+    from trade_modules.v3.combine import CLUSTERS
+
+    assert CLUSTERS["value_z"] == ["pe_trailing", "ev_ebitda"]
+    for members in CLUSTERS.values():
+        assert "pb" not in members, "raw P/B must not be scored in any cluster"
+
+
+def test_fixnow_quality_interim_is_roe_fcf():
+    """Interim quality = ROE + FCF (panel-available). Per-sales margins + roa retired
+    (GP/assets is the right anchor but unbuildable now → BUILD); current_ratio + de move
+    to a distress filter; accruals is shadow-only (non-PIT) (D8)."""
+    from trade_modules.v3.combine import CLUSTERS
+
+    assert CLUSTERS["quality_z"] == ["roe", "fcf"]
+    for dead in ("roa", "gross_margin", "op_margin", "current_ratio", "de", "accruals"):
+        for members in CLUSTERS.values():
+            assert dead not in members, f"{dead} must not be scored in quality (interim)"

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -534,3 +534,34 @@ def test_fixnow_equal_weight_core_no_vq_floor():
     assert 0.0 < w["strength_z"] < w["growth_z"], "strength is a small cap"
     assert (w["value_z"] + w["quality_z"]) < 0.55, "no Value+Quality cap-as-floor"
     assert abs(sum(w.values()) - 1.0) < 1e-9
+
+
+def test_fixnow_equal_vol_standardize_gives_unit_std_columns():
+    """Equal-VOL: each cluster column is scaled to ~unit cross-sectional std, so equal
+    nominal weights are equal-RISK (a low-dispersion cluster no longer under-contributes).
+    Contemporaneous / per-snapshot -> look-ahead-free (D14 refinement)."""
+    from trade_modules.v3.combine import _equal_vol_standardize
+
+    zmat = pd.DataFrame(
+        {"a": [1.0, 2.0, 3.0, 4.0], "b": [10.0, 20.0, 30.0, 40.0]}  # b has 10x the spread
+    )
+    out = _equal_vol_standardize(zmat)
+    assert abs(float(out["a"].std(ddof=0)) - 1.0) < 1e-9
+    assert abs(float(out["b"].std(ddof=0)) - 1.0) < 1e-9
+
+
+def test_fixnow_equal_vol_standardize_is_nan_and_zero_std_safe():
+    """A NaN-bearing column keeps its NaNs; a constant (zero-std) column is left
+    unchanged (no divide-by-zero)."""
+    from trade_modules.v3.combine import _equal_vol_standardize
+
+    zmat = pd.DataFrame(
+        {
+            "with_nan": [1.0, np.nan, 3.0, 5.0],
+            "constant": [2.0, 2.0, 2.0, 2.0],  # zero std -> unchanged
+        }
+    )
+    out = _equal_vol_standardize(zmat)
+    assert pd.isna(out.loc[1, "with_nan"])
+    assert abs(float(out["with_nan"].std(ddof=0)) - 1.0) < 1e-9
+    assert list(out["constant"]) == [2.0, 2.0, 2.0, 2.0]

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -95,13 +95,9 @@ def test_nans_tolerated():
     assert scores["rank"].notna().all()
 
 
-def test_value_quality_weight_cap_about_55pct():
-    """Value + Quality jointly carry ~55% of conviction weight."""
-    from trade_modules.v3.combine import CLUSTER_WEIGHTS
-
-    total = sum(CLUSTER_WEIGHTS.values())
-    vq = CLUSTER_WEIGHTS["value_z"] + CLUSTER_WEIGHTS["quality_z"]
-    assert abs(vq / total - 0.55) < 0.01
+# (removed 2026-07-18, D7/D14) test_value_quality_weight_cap_about_55pct — the
+# Value+Quality 0.55 cap-as-floor is deleted; core clusters are now equal-risk.
+# See test_fixnow_equal_weight_core_no_vq_floor.
 
 
 def test_no_quote_type_column_means_all_eligible():
@@ -270,16 +266,28 @@ def test_derive_cluster_weights_equal_spread_when_rest_ic_nonpositive():
 
 
 def test_ic_weighting_shifts_conviction_toward_high_ic_cluster():
-    """A momentum-favoring IC vector flips the value-name / momentum-name ranking."""
+    """IC weighting shifts the ranking: a value-heavy IC ranks the value name first,
+    a momentum-heavy IC flips it to the momentum name. (Default weights are now
+    equal-risk, so the shift is shown via explicit IC vectors, not the default.)"""
     df = _base(["MOM_STAR", "VAL_STAR", "MID1", "MID2"])
     df["pe_trailing"] = [50.0, 5.0, 20.0, 25.0]  # VAL_STAR cheapest -> best value
     df["mom_12_1"] = [0.50, -0.20, 0.10, 0.05]  # MOM_STAR strongest momentum
 
-    default = compute_scores(df, sector_neutral=False)
-    # Fixed weights lean on Value (Value+Quality ~55%) -> the value name wins.
-    assert default.loc["VAL_STAR", "rank"] < default.loc["MOM_STAR", "rank"]
+    val = compute_scores(
+        df,
+        sector_neutral=False,
+        ic_weights={
+            "value_z": 1.0,
+            "quality_z": 0.05,
+            "momentum_z": 0.05,
+            "lowvol_z": 0.05,
+            "strength_z": 0.05,
+        },
+    )
+    # Value-heavy IC -> the value name wins.
+    assert val.loc["VAL_STAR", "rank"] < val.loc["MOM_STAR", "rank"]
 
-    ic = compute_scores(
+    mom = compute_scores(
         df,
         sector_neutral=False,
         ic_weights={
@@ -291,7 +299,7 @@ def test_ic_weighting_shifts_conviction_toward_high_ic_cluster():
         },
     )
     # Momentum-heavy IC -> the momentum name now out-ranks the value name.
-    assert ic.loc["MOM_STAR", "rank"] < ic.loc["VAL_STAR", "rank"]
+    assert mom.loc["MOM_STAR", "rank"] < mom.loc["VAL_STAR", "rank"]
 
 
 # --------------------------------------------------------------------------- #
@@ -355,13 +363,8 @@ def test_growth_z_nan_safe_single_metric():
     assert scores.loc["A", "growth_z"] > scores.loc["B", "growth_z"]
 
 
-def test_default_growth_weight_is_zero():
-    """Backward-compat contract: growth carries ZERO weight in the default model."""
-    from trade_modules.v3.combine import CLUSTER_WEIGHTS
-
-    assert CLUSTER_WEIGHTS["growth_z"] == 0.0
-    # The five evidence clusters still sum to 1.0 (growth adds nothing by default).
-    assert abs(sum(CLUSTER_WEIGHTS.values()) - 1.0) < 1e-12
+# (removed 2026-07-18, D11/D14) test_default_growth_weight_is_zero — growth is now a
+# weighted satellite (not zero). See test_fixnow_equal_weight_core_no_vq_floor.
 
 
 # --------------------------------------------------------------------------- #
@@ -443,12 +446,12 @@ def test_backward_compat_none_equals_explicit_default_weights():
         df,
         sector_neutral=False,
         cluster_weights={
-            "value": 0.275,
-            "quality": 0.275,
-            "momentum": 0.20,
-            "growth": 0.0,
-            "lowvol": 0.15,
-            "strength": 0.10,
+            "value": 0.21,
+            "quality": 0.21,
+            "momentum": 0.21,
+            "growth": 0.11,
+            "lowvol": 0.21,
+            "strength": 0.05,
         },
     )
     assert np.allclose(
@@ -478,27 +481,8 @@ def test_rank_normalization_bounds_outlier_magnitude():
     assert abs(ze) < 2.0  # bounded by rank, not blown up by the 5000x value
 
 
-def test_backward_compat_default_ignores_growth_data():
-    """With the default weights, adding growth data does NOT change conviction/rank."""
-    df = _base(["A", "B", "C", "D"])
-    df["pe_trailing"] = [5.0, 12.0, 25.0, 60.0]
-    df["roe"] = [40.0, 25.0, 15.0, 5.0]
-    df["mom_12_1"] = [0.30, 0.10, -0.05, -0.20]
-
-    without = compute_scores(df, sector_neutral=False)
-    withg = df.copy()
-    withg["earn_growth"] = [2.0, 50.0, 5.0, 40.0]  # would reorder if growth were weighted
-    withg["rev_growth"] = [0.01, 0.40, 0.03, 0.30]
-    withg = compute_scores(withg, sector_neutral=False)
-
-    # growth_z is computed, but weight 0 -> conviction identical to the no-growth run.
-    assert withg["growth_z"].notna().all()
-    assert np.allclose(
-        without["conviction"].to_numpy(dtype=float),
-        withg["conviction"].to_numpy(dtype=float),
-        equal_nan=True,
-    )
-    assert list(without["rank"].astype("float")) == list(withg["rank"].astype("float"))
+# (removed 2026-07-18, D11/D14) test_backward_compat_default_ignores_growth_data —
+# growth now carries a satellite weight, so growth data DOES affect conviction.
 
 
 # --------------------------------------------------------------------------- #
@@ -537,3 +521,16 @@ def test_fixnow_quality_interim_is_roe_fcf():
     for dead in ("roa", "gross_margin", "op_margin", "current_ratio", "de", "accruals"):
         for members in CLUSTERS.values():
             assert dead not in members, f"{dead} must not be scored in quality (interim)"
+
+
+def test_fixnow_equal_weight_core_no_vq_floor():
+    """Default weights: core (value/quality/momentum/lowvol) equal — no discretionary
+    tilt; growth = satellite (reduced, >0); strength = small cap; NO Value+Quality
+    cap-as-floor (VQ well below 0.55); weights sum to 1 (D14, D6b, D11, D7)."""
+    from trade_modules.v3.combine import CLUSTER_WEIGHTS as w
+
+    assert w["value_z"] == w["quality_z"] == w["momentum_z"] == w["lowvol_z"]
+    assert 0.0 < w["growth_z"] < w["value_z"], "growth is a reduced satellite (>0)"
+    assert 0.0 < w["strength_z"] < w["growth_z"], "strength is a small cap"
+    assert (w["value_z"] + w["quality_z"]) < 0.55, "no Value+Quality cap-as-floor"
+    assert abs(sum(w.values()) - 1.0) < 1e-9

--- a/tests/unit/trade_modules/test_v3_costs.py
+++ b/tests/unit/trade_modules/test_v3_costs.py
@@ -1,0 +1,56 @@
+"""TDD — BUILD ⑥b (2026-07-18): transaction-cost model for v3.
+
+Round-trip cost = entry+exit spread (by cap tier) + eToro overnight financing over
+the holding horizon. Reuses liquidity_filter's TIER_SPREAD_BPS +
+ETORO_OVERNIGHT_ANNUAL_RATE so the cost constants have one home. Its principled use
+is a net-of-cost IC in validation (trial-register net_ir_min) — grading net alpha,
+not changing live trading.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.liquidity_filter import ETORO_OVERNIGHT_ANNUAL_RATE, TIER_SPREAD_BPS
+from trade_modules.v3.costs import (
+    DEFAULT_HOLDING_DAYS,
+    cost_map_from_panel,
+    net_of_cost_return,
+    roundtrip_cost_pct,
+)
+
+
+def test_roundtrip_cost_is_spread_plus_financing():
+    c = roundtrip_cost_pct(3e11)  # MEGA
+    spread = TIER_SPREAD_BPS["MEGA"] / 10000.0 * 2.0 * 100.0  # round-trip, in %
+    fin = ETORO_OVERNIGHT_ANNUAL_RATE * (DEFAULT_HOLDING_DAYS / 365.0) * 100.0
+    assert abs(c - (spread + fin)) < 1e-9
+
+
+def test_smaller_caps_cost_more():
+    assert roundtrip_cost_pct(2e8) > roundtrip_cost_pct(3e11)  # MICRO spread > MEGA spread
+
+
+def test_financing_scales_with_holding_days():
+    short = roundtrip_cost_pct(3e11, holding_days=30)
+    longer = roundtrip_cost_pct(3e11, holding_days=60)
+    fin30 = ETORO_OVERNIGHT_ANNUAL_RATE * (30 / 365.0) * 100.0
+    assert abs((longer - short) - fin30) < 1e-9  # exactly one extra 30d of financing
+
+
+def test_unknown_cap_uses_mid_tier():
+    assert roundtrip_cost_pct(float("nan")) == roundtrip_cost_pct(5e9)  # both MID
+
+
+def test_net_of_cost_subtracts_roundtrip():
+    c = roundtrip_cost_pct(1e9)
+    assert abs(net_of_cost_return(5.0, 1e9) - (5.0 - c)) < 1e-9
+
+
+def test_cost_map_from_panel(tmp_path):
+    csv = tmp_path / "etoro.csv"
+    pd.DataFrame({"TKR": ["AAA", "bbb"], "CAP": ["300B", "600M"]}).to_csv(csv, index=False)
+    m = cost_map_from_panel(str(csv))
+    assert set(m) == {"AAA", "BBB"}  # keys upper-cased
+    assert m["BBB"] > m["AAA"]  # 600M (SMALL) costs more than 300B (MEGA)
+    assert abs(m["AAA"] - roundtrip_cost_pct(300e9)) < 1e-9

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -222,6 +222,46 @@ def _run(tmp_path):
     )
 
 
+def test_enrich_honors_injected_sector_map_for_uncovered_names(tmp_path):
+    """BUILD ③: an injected offline map fills sectors yfinance did not provide."""
+    feats = enrich_features(
+        ["AAPL", "MSFT", "ZZZ"],
+        _write_csv(tmp_path),
+        info_fetch=_fake_info,
+        price_fetch=_fake_prices,
+        accruals_fetch=lambda tickers: {},
+        sector_map={"ZZZ": "Energy"},  # ZZZ has no live sector
+    )
+    assert feats.loc["ZZZ", "sector"] == "Energy"
+    assert feats.loc["AAPL", "sector"] == "Technology"  # not in map -> live fallback
+
+
+def test_enrich_offline_map_overrides_live_sector(tmp_path):
+    """BUILD ③: static/offline sector outranks live yfinance (higher trust)."""
+    feats = enrich_features(
+        ["AAPL", "MSFT", "ZZZ"],
+        _write_csv(tmp_path),
+        info_fetch=_fake_info,
+        price_fetch=_fake_prices,
+        accruals_fetch=lambda tickers: {},
+        sector_map={"AAPL": "Consumer Cyclical"},
+    )
+    assert feats.loc["AAPL", "sector"] == "Consumer Cyclical"
+
+
+def test_enrich_without_sector_map_is_unchanged(tmp_path):
+    """BUILD ③ back-compat: no map -> exactly today's live-only behavior."""
+    feats = enrich_features(
+        ["AAPL", "MSFT", "ZZZ"],
+        _write_csv(tmp_path),
+        info_fetch=_fake_info,
+        price_fetch=_fake_prices,
+        accruals_fetch=lambda tickers: {},
+    )
+    assert feats.loc["AAPL", "sector"] == "Technology"
+    assert pd.isna(feats.loc["ZZZ", "sector"])
+
+
 def test_frame_indexed_by_ticker_with_all_tickers(tmp_path):
     feats = _run(tmp_path)
     assert feats.index.name == "ticker"

--- a/tests/unit/trade_modules/test_v3_horizon_alignment.py
+++ b/tests/unit/trade_modules/test_v3_horizon_alignment.py
@@ -1,0 +1,124 @@
+"""TDD — BUILD ① (2026-07-18): a single declared V3_SIGNAL_HORIZON (21 trading
+days, ~1 month) that the IC logger, the price-spine gate, AND the referee all
+grade the model against.
+
+Before this increment the model was graded at two horizons at once:
+``run_gate`` screened IC at ``horizons[0]`` (= 5, one week) while the harness DSR
+resolved to 21 via a nearest-30 fallback. These tests lock the alignment and the
+v2 back-compat guarantee (the shared harness default stays 30).
+
+Owner decision: primary = 21 td, co-report 5 & 63. Sources: Grinold-Kahn (grade
+IC at the rebalance horizon); Jegadeesh-Titman (momentum 1-12mo).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# The declared constant is the single source of truth
+# ---------------------------------------------------------------------------
+
+
+def test_signal_horizon_declared_and_on_grid():
+    from trade_modules.v3.constants import V3_IC_HORIZONS, V3_SIGNAL_HORIZON
+
+    assert V3_SIGNAL_HORIZON == 21
+    assert V3_IC_HORIZONS == (5, 21, 63)
+    assert V3_SIGNAL_HORIZON in V3_IC_HORIZONS  # invariant: primary is on the grid
+
+
+# ---------------------------------------------------------------------------
+# Every measurement surface reads the same grid / primary
+# ---------------------------------------------------------------------------
+
+
+def test_ic_logger_default_grid_is_the_declared_grid():
+    from scripts.v3_ic_logger import ic_from_log
+    from trade_modules.v3.constants import V3_IC_HORIZONS
+
+    default = inspect.signature(ic_from_log).parameters["horizons"].default
+    assert default == V3_IC_HORIZONS  # no more stray 10-step horizon
+
+
+def test_ic_report_grid_is_the_declared_grid():
+    import scripts.v3_ic_report as rep
+    from trade_modules.v3.constants import V3_IC_HORIZONS
+
+    assert rep.HORIZONS == V3_IC_HORIZONS
+
+
+def test_spine_gate_grid_is_the_declared_grid():
+    import scripts.v3_spine_gate as gate
+    from trade_modules.v3.constants import V3_IC_HORIZONS
+
+    assert gate.HORIZONS == list(V3_IC_HORIZONS)
+
+
+def test_evaluate_exposes_primary_horizon_defaulting_to_30_for_v2():
+    """The shared harness default MUST stay 30 — v2 callers are byte-identical."""
+    from trade_modules.validation.harness import evaluate
+
+    p = inspect.signature(evaluate).parameters["primary_horizon"]
+    assert p.default == 30
+
+
+def test_run_gate_defaults_primary_horizon_to_declared_constant():
+    from trade_modules.v3.constants import V3_SIGNAL_HORIZON
+    from trade_modules.v3.validate_spine import run_gate
+
+    p = inspect.signature(run_gate).parameters["primary_horizon"]
+    assert p.default == V3_SIGNAL_HORIZON == 21
+
+
+# ---------------------------------------------------------------------------
+# The behavioural fix: run_gate grades the IC screen at the PRIMARY, not [0]
+# ---------------------------------------------------------------------------
+
+
+def _synthetic():
+    tickers = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    dates = ["2026-01-01", "2026-01-02", "2026-01-03"]
+    scores = pd.DataFrame(
+        [{"as_of": d, "ticker": t, "score": float(i)} for d in dates for i, t in enumerate(tickers)]
+    )
+    fwd = pd.DataFrame(
+        [
+            {"as_of": d, "ticker": t, "horizon": h, "fwd_ret": 0.01 * i}
+            for d in dates
+            for i, t in enumerate(tickers)
+            for h in (5, 21, 63)
+        ]
+    )
+    return scores, fwd
+
+
+def test_run_gate_grades_ic_at_primary_not_horizons_zero():
+    """Default grades at 21 — NOT the old horizons[0] = 5 (one-week noise)."""
+    from trade_modules.v3.validate_spine import run_gate
+
+    scores, fwd = _synthetic()
+    out = run_gate(scores, fwd, [5, 21, 63], n_trials=2, min_obs=5)
+    assert out["primary_horizon"] == 21
+
+
+def test_run_gate_primary_horizon_override_and_nearest_fallback():
+    from trade_modules.v3.validate_spine import run_gate
+
+    scores, fwd = _synthetic()
+    # explicit member is honoured
+    assert (
+        run_gate(scores, fwd, [5, 21, 63], primary_horizon=5, n_trials=2, min_obs=5)[
+            "primary_horizon"
+        ]
+        == 5
+    )
+    # off-grid primary -> nearest member (30 -> 21)
+    assert (
+        run_gate(scores, fwd, [5, 21, 63], primary_horizon=30, n_trials=2, min_obs=5)[
+            "primary_horizon"
+        ]
+        == 21
+    )

--- a/tests/unit/trade_modules/test_v3_integrity.py
+++ b/tests/unit/trade_modules/test_v3_integrity.py
@@ -1,0 +1,99 @@
+"""TDD — BUILD ② (2026-07-18): fail-loud integrity gate for the etoro.csv panel.
+
+The v3 loaders previously did a bare ``pd.read_csv`` with no schema/dtype check,
+so a silently dropped column or a same-field-count column-shift degraded every
+downstream factor to NaN with no signal. This gate ASSERTS the panel's shape.
+
+Scoping the gate deliberately guards CORRUPTION, not COVERAGE:
+  - missing required column / non-numeric data in a numeric factor column -> RAISE
+  - a legitimately non-numeric suffixed column (CAP='39.2T') -> never checked
+  - a sparse or entirely-empty column (coverage) -> tolerated (that is ③/④'s job)
+The panel is clean today; this is a forward guard.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from trade_modules.v3.integrity import PanelIntegrityError, validate_panel
+
+
+def _good_panel(n: int = 6) -> pd.DataFrame:
+    """A well-formed panel: every required column present + an extra column."""
+    return pd.DataFrame(
+        {
+            "TKR": [f"T{i}" for i in range(n)],
+            "NAME": [f"Name {i}" for i in range(n)],
+            "CAP": ["39.2T", "1.2B", "500M", "2.3B", "10B", "900M"][:n],  # suffixed
+            "PRC": [10.0, 20.5, 3.1, 100.0, 55.5, 7.7][:n],
+            "PET": [16.4, 9.8, 12.0, 22.0, 8.0, 30.0][:n],
+            "ROE": [9.4, 10.2, 5.0, 15.0, 20.0, 1.0][:n],
+            "FCF": ["-3.5%", "2.0%", "5.0%", "1.0%", "-1.0%", "3.0%"][:n],  # % cleans
+            "52W": [93.0, 72.0, 50.0, 88.0, 99.0, 20.0][:n],
+            "B": [0.3, 1.1, 0.9, 1.5, 0.7, 1.2][:n],
+            "AM": [-7.0, -3.0, 2.0, 5.0, 0.0, 1.0][:n],
+            "EG": [12.4, -2.9, 3.0, 8.0, -1.0, 4.0][:n],
+            "EXTRA_UNKNOWN": list(range(n)),  # extra column must be tolerated
+        }
+    )
+
+
+def test_clean_panel_passes_and_returns_same_object():
+    df = _good_panel()
+    assert validate_panel(df, source="test") is df  # pass-through, no copy
+
+
+def test_extra_columns_tolerated():
+    validate_panel(_good_panel())  # EXTRA_UNKNOWN present -> no raise
+
+
+def test_missing_required_column_raises():
+    df = _good_panel().drop(columns=["PRC"])
+    with pytest.raises(PanelIntegrityError, match="PRC"):
+        validate_panel(df)
+
+
+def test_column_shift_injecting_strings_into_numeric_raises():
+    df = _good_panel()
+    # Simulate a shift: company names land in the numeric PRC column.
+    df["PRC"] = ["Toyota", "Mitsubishi", "Apple", "Sony", "Nintendo", "Honda"][: len(df)]
+    with pytest.raises(PanelIntegrityError, match="PRC"):
+        validate_panel(df)
+
+
+def test_suffixed_cap_does_not_trigger_a_numeric_failure():
+    # CAP='39.2T' is legitimately non-numeric and must NEVER be numeric-checked.
+    validate_panel(_good_panel())  # would raise if CAP were numeric-gated
+
+
+def test_sparse_but_clean_numeric_column_tolerated():
+    df = _good_panel()
+    df["AM"] = [None, None, None, None, 5.0, -2.0][: len(df)]  # mostly NA, rest numeric
+    validate_panel(df)
+
+
+def test_all_null_numeric_column_is_coverage_not_corruption():
+    df = _good_panel()
+    df["EG"] = [None] * len(df)  # entirely empty -> tolerated (coverage)
+    validate_panel(df)
+
+
+def test_empty_panel_raises():
+    with pytest.raises(PanelIntegrityError, match="empty"):
+        validate_panel(_good_panel().iloc[0:0])
+
+
+def test_mostly_null_ticker_raises():
+    df = _good_panel()
+    df["TKR"] = ["", "", "", "", "", "T5"][: len(df)]  # 5/6 blank -> catastrophic
+    with pytest.raises(PanelIntegrityError, match="TKR"):
+        validate_panel(df)
+
+
+def test_minimal_universe_requirement_set_passes():
+    """load_universe only needs TKR/PRC/CAP — the gate is parameterizable."""
+    df = pd.DataFrame({"TKR": ["AAPL", "MSFT"], "PRC": [200.0, 400.0], "CAP": ["3.5T", "2.5T"]})
+    validate_panel(
+        df, source="universe", required_columns=("TKR", "PRC", "CAP"), required_numeric=("PRC",)
+    )

--- a/tests/unit/trade_modules/test_v3_liquidity.py
+++ b/tests/unit/trade_modules/test_v3_liquidity.py
@@ -1,0 +1,88 @@
+"""TDD — BUILD ⑥a (2026-07-18): tiered, copier-aware ADV liquidity gate.
+
+v3 gated liquidity with a single flat $1M floor applied inline in the report. After
+④ expanded the scored universe ~25x (many smaller/less-liquid names), the floor
+should scale with market-cap tier (a $500M small-cap needs less ADV than a mega-cap
+position) and — for a copied book — with a copier multiplier. Uses v3's own
+``adv_usd`` (avg_volume x price x fx, already computed) so there is NO extra fetch.
+Held names and names with unknown ADV are never dropped.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.liquidity_filter import TIER_MIN_ADV
+from trade_modules.v3.liquidity import cap_tier, liquidity_gate, required_adv
+
+
+def test_cap_tier_thresholds():
+    assert cap_tier(3e11) == "MEGA"  # >= $200B
+    assert cap_tier(5e10) == "LARGE"  # >= $10B
+    assert cap_tier(5e9) == "MID"  # >= $2B
+    assert cap_tier(1e9) == "SMALL"  # >= $300M
+    assert cap_tier(2e8) == "MICRO"  # < $300M
+    assert cap_tier(float("nan")) == "MID"  # unknown cap -> neutral MID floor
+
+
+def test_required_adv_uses_tier_floor():
+    assert required_adv(3e11) == TIER_MIN_ADV["MEGA"]
+    assert required_adv(1e9) == TIER_MIN_ADV["SMALL"]
+
+
+def test_required_adv_scales_with_copier_multiplier():
+    base = required_adv(1e9)
+    assert required_adv(1e9, copier_multiplier=3.0) == base * 3.0
+    assert required_adv(1e9, copier_multiplier=0.5) == base  # clamped at >= 1.0
+
+
+def _scores(rows):
+    idx = [r[0] for r in rows]
+    return pd.DataFrame(
+        {
+            "cap": [r[1] for r in rows],
+            "adv_usd": [r[2] for r in rows],
+            "is_portfolio": [r[3] for r in rows],
+        },
+        index=idx,
+    )
+
+
+def test_gate_drops_illiquid_non_held_keeps_liquid():
+    scores = _scores(
+        [
+            ("ILLIQ", 1e9, 1e6, False),  # SMALL, 1M ADV < 5M floor -> drop
+            ("MEGA", 3e11, 1e9, False),  # huge ADV -> keep
+            ("LIQ", 1e9, 8e6, False),  # SMALL, 8M >= 5M -> keep
+        ]
+    )
+    kept, dropped = liquidity_gate(scores)
+    assert "ILLIQ" in dropped.index and "ILLIQ" not in kept.index
+    assert {"MEGA", "LIQ"}.issubset(set(kept.index))
+
+
+def test_gate_exempts_held_names():
+    scores = _scores([("HELD", 1e9, 1e6, True)])  # illiquid but held
+    kept, dropped = liquidity_gate(scores)
+    assert "HELD" in kept.index
+    assert dropped.empty
+
+
+def test_gate_keeps_unknown_adv_no_data_penalty():
+    scores = _scores([("NOADV", 1e9, float("nan"), False)])
+    kept, dropped = liquidity_gate(scores)
+    assert "NOADV" in kept.index
+    assert dropped.empty
+
+
+def test_gate_copier_multiplier_tightens_floor():
+    # SMALL name, 8M ADV: passes at mult=1 (floor 5M), fails at mult=2 (floor 10M).
+    scores = _scores([("MIDLIQ", 1e9, 8e6, False)])
+    assert "MIDLIQ" in liquidity_gate(scores, copier_multiplier=1.0)[0].index
+    assert "MIDLIQ" in liquidity_gate(scores, copier_multiplier=2.0)[1].index
+
+
+def test_gate_returns_all_when_no_adv_column():
+    scores = pd.DataFrame({"cap": [1e9], "is_portfolio": [False]}, index=["X"])
+    kept, dropped = liquidity_gate(scores)
+    assert "X" in kept.index and dropped.empty  # no adv_usd -> gate is a no-op

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -398,3 +398,69 @@ def test_buy_skips_candidate_already_held_as_dual_listing():
     assert "AMC.AX" not in d["bought"]  # same company as a held name -> skipped
     assert "BUYME" in d["bought"]  # the unrelated strong name is still bought
     assert "AMCR" in d["kept"]
+
+
+# --------------------------------------------------------------------------- #
+# FIX-NOW (D4/D8): squeeze-exclude gate + de/current_ratio distress filter on BUYS
+# --------------------------------------------------------------------------- #
+
+
+def test_fixnow_squeeze_gate_excludes_high_si_buy_candidate():
+    """A strong non-held candidate with short interest above the squeeze threshold
+    is NOT bought (squeeze/borrow risk); clean candidates are bought instead. The
+    screen applies to BUYS only — it never force-sells a holding."""
+    _tks, _convs, sc = _universe20()
+    sc["short_interest"] = np.nan
+    sc.loc["U00", "short_interest"] = 40.0  # % of float, above the 20% default
+    current = pd.Series({"U10": 0.3})  # a middling holding
+
+    d = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert "U00" not in d["bought"], "high-short-interest name must be screened from buys"
+    assert set(d["bought"]) == {"U01", "U02"}
+    assert "U00" in d.get("screened_out", [])
+
+
+def test_fixnow_distress_filter_excludes_low_current_ratio_buy():
+    """A strong non-held candidate with current_ratio below the distress floor
+    (< 1.0 = cannot cover short-term liabilities) is not bought."""
+    _tks, _convs, sc = _universe20()
+    sc["current_ratio"] = np.nan
+    sc.loc["U00", "current_ratio"] = 0.5  # distressed liquidity
+    current = pd.Series({"U10": 0.3})
+
+    d = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert "U00" not in d["bought"]
+    assert set(d["bought"]) == {"U01", "U02"}
+
+
+def test_fixnow_de_distress_screen_only_when_threshold_set():
+    """The debt/equity leg is opt-in (max_de): OFF by default (scale unconfirmed),
+    active only when a threshold is passed."""
+    _tks, _convs, sc = _universe20()
+    sc["de"] = np.nan
+    sc.loc["U00", "de"] = 5.0
+    current = pd.Series({"U10": 0.3})
+
+    # default: de screen OFF -> U00 (strongest) is bought.
+    off = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert "U00" in off["bought"]
+    # threshold set -> U00 excluded as over-levered.
+    on = build_overlay(sc, current, pd.DataFrame(), max_new=2, max_de=2.0)["diagnostics"]
+    assert "U00" not in on["bought"]
+    assert set(on["bought"]) == {"U01", "U02"}
+
+
+def test_fixnow_screen_tolerates_missing_data_and_spares_holdings():
+    """No screen columns / NaN values -> no exclusion (buys unchanged); a HELD name
+    with high SI is never force-sold by the screen (buys-only)."""
+    _tks, _convs, sc = _universe20()  # no short_interest/current_ratio/de columns
+    current = pd.Series({"U10": 0.3})
+    base = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert set(base["bought"]) == {"U00", "U01"}  # unchanged from the no-screen contract
+
+    # A held, squeeze-risky name is NOT sold by the screen (screen only gates buys).
+    sc2 = sc.copy()
+    sc2["short_interest"] = np.nan
+    sc2.loc["U10", "short_interest"] = 90.0  # held + very high SI
+    held = build_overlay(sc2, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert "U10" not in held["sold"] and "U10" in held["kept"]

--- a/tests/unit/trade_modules/test_v3_sectors.py
+++ b/tests/unit/trade_modules/test_v3_sectors.py
@@ -1,0 +1,106 @@
+"""TDD — BUILD ③ (2026-07-18): offline, cache-backed sector resolution.
+
+v3 sector data came ONLY from live yfinance ``.info["sector"]``, so when yfinance
+throttled, ``sector`` went NaN -> ``_sector_demean`` collapsed to a single ``__NA__``
+bucket (global demean = no-op) and the risk-gate sector cap became a single-bucket
+no-op. The v2 static index map covers only ~14% of our 3,345-name universe, so the
+fix is a 3-tier resolver: static index map (high trust) > persistent cache > live
+yfinance (written back to the cache so coverage grows and runs are reproducible).
+"""
+
+from __future__ import annotations
+
+from trade_modules.v3.sectors import (
+    _read_cache,
+    load_offline_sector_map,
+    merge_offline_map,
+    update_sector_cache,
+)
+
+
+def test_merge_static_wins_over_cache():
+    m = merge_offline_map({"AAPL": "Technology"}, {"AAPL": "Energy", "XYZ": "Utilities"})
+    assert m["AAPL"] == "Technology"  # static is authoritative
+    assert m["XYZ"] == "Utilities"  # cache fills where static is silent
+
+
+def test_merge_keys_are_uppercased():
+    m = merge_offline_map({"aapl": "Technology"}, {"xyz": "Energy"})
+    assert m["AAPL"] == "Technology"
+    assert m["XYZ"] == "Energy"
+
+
+def test_merge_drops_blank_values():
+    m = merge_offline_map({"AAPL": ""}, {"XYZ": None})
+    assert m == {}
+
+
+def test_load_offline_map_merges_static_csv_and_cache(tmp_path):
+    static = tmp_path / "market.csv"
+    static.write_text("symbol,name,sector\nAAPL,Apple,Technology\n")
+    cache = tmp_path / "cache.json"
+    cache.write_text('{"XYZ": "Energy", "AAPL": "ShouldLoseToStatic"}')
+    m = load_offline_sector_map(static_paths=(str(static),), cache_path=str(cache))
+    assert m["AAPL"] == "Technology"  # static wins over cache
+    assert m["XYZ"] == "Energy"
+
+
+def test_update_cache_persists_only_non_static(tmp_path):
+    static = tmp_path / "market.csv"
+    static.write_text("symbol,name,sector\nAAPL,Apple,Technology\n")
+    cache = tmp_path / "cache.json"
+    added = update_sector_cache(
+        {"AAPL": "Technology", "XYZ": "Energy"},
+        cache_path=str(cache),
+        static_paths=(str(static),),
+    )
+    assert added == 1  # AAPL is static -> not cached; only XYZ persisted
+    c = _read_cache(str(cache))
+    assert c["XYZ"] == "Energy"
+    assert "AAPL" not in c
+
+
+def test_update_cache_is_idempotent(tmp_path):
+    static = tmp_path / "m.csv"
+    static.write_text("symbol,name,sector\n")
+    cache = tmp_path / "c.json"
+    update_sector_cache({"XYZ": "Energy"}, cache_path=str(cache), static_paths=(str(static),))
+    again = update_sector_cache(
+        {"XYZ": "Energy"}, cache_path=str(cache), static_paths=(str(static),)
+    )
+    assert again == 0  # already cached, nothing new written
+
+
+def test_update_cache_creates_missing_parent_dir(tmp_path):
+    static = tmp_path / "m.csv"
+    static.write_text("symbol,name,sector\n")
+    cache = tmp_path / "deep" / "nested" / "c.json"
+    added = update_sector_cache(
+        {"XYZ": "Energy"}, cache_path=str(cache), static_paths=(str(static),)
+    )
+    assert added == 1
+    assert cache.exists()
+
+
+def test_update_cache_skips_blank_sectors(tmp_path):
+    static = tmp_path / "m.csv"
+    static.write_text("symbol,name,sector\n")
+    cache = tmp_path / "c.json"
+    added = update_sector_cache(
+        {"XYZ": "", "ABC": None}, cache_path=str(cache), static_paths=(str(static),)
+    )
+    assert added == 0
+
+
+def test_read_cache_missing_or_corrupt_returns_empty(tmp_path):
+    assert _read_cache(str(tmp_path / "nope.json")) == {}
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    assert _read_cache(str(bad)) == {}
+
+
+def test_default_static_paths_point_at_repo_market_files():
+    from trade_modules.v3.sectors import DEFAULT_STATIC_PATHS
+
+    assert any(p.endswith("market.csv") for p in DEFAULT_STATIC_PATHS)
+    assert any(p.endswith("usindex.csv") for p in DEFAULT_STATIC_PATHS)

--- a/tests/unit/trade_modules/test_v3_trial_register.py
+++ b/tests/unit/trade_modules/test_v3_trial_register.py
@@ -1,0 +1,37 @@
+"""TDD tests for trade_modules.v3.trial_register — FIX-NOW (D23/spec §7): a frozen,
+auditable acceptance gate + trial register so DSR sees the true trial count and the
+thresholds cannot be quietly relaxed to pass a favoured signal."""
+
+import pytest
+
+
+def test_acceptance_thresholds_frozen_and_correct():
+    from trade_modules.v3.trial_register import ACCEPTANCE_THRESHOLDS
+
+    assert ACCEPTANCE_THRESHOLDS["dsr_min"] == 0.95
+    assert ACCEPTANCE_THRESHOLDS["min_regimes"] == 2
+    assert ACCEPTANCE_THRESHOLDS["ic_t_min"] == 3.0
+    assert ACCEPTANCE_THRESHOLDS["pbo_max"] == 0.05
+    # read-only (frozen): the gate cannot be mutated in place.
+    with pytest.raises(TypeError):
+        ACCEPTANCE_THRESHOLDS["dsr_min"] = 0.5  # type: ignore[index]
+
+
+def test_trial_register_counts_candidates_for_dsr():
+    from trade_modules.v3.trial_register import CANDIDATE_TRIALS, trial_count
+
+    assert trial_count() == len(CANDIDATE_TRIALS)
+    assert trial_count() >= 10  # the whole shadow queue is honestly counted for DSR
+    assert "investment_cma" in CANDIDATE_TRIALS
+    assert "pead_sue" in CANDIDATE_TRIALS
+    assert "analyst_eps_revision" in CANDIDATE_TRIALS
+
+
+def test_is_relaxation_detects_loosening_both_directions():
+    from trade_modules.v3.trial_register import is_relaxation
+
+    assert is_relaxation("dsr_min", 0.90) is True  # lowering a _min gate = loosening
+    assert is_relaxation("dsr_min", 0.99) is False
+    assert is_relaxation("pbo_max", 0.10) is True  # raising a _max gate = loosening
+    assert is_relaxation("pbo_max", 0.02) is False
+    assert is_relaxation("min_regimes", 1) is True  # fewer regimes = loosening

--- a/tests/unit/trade_modules/test_v3_universe.py
+++ b/tests/unit/trade_modules/test_v3_universe.py
@@ -21,3 +21,99 @@ def test_load_universe_filters(tmp_path):
     ).to_csv(csv, index=False)
     u = load_universe(str(csv), min_price=1.0, min_cap_usd=5e8)
     assert u == ["AAPL", "MSFT"]  # PENNY (price), SMALL (cap), 7203.T (non-USD) excluded
+
+
+# ---------------------------------------------------------------------------
+# BUILD ④ — coverage-gate universe (replaces the analyst AND-gate)
+# ---------------------------------------------------------------------------
+
+_FULL = {"PET": "10", "ROE": "9", "FCF": "1", "52W": "80", "B": "1.0", "AM": "2", "EG": "5"}
+
+
+def _write_panel(tmp_path, rows):
+    """Write a panel CSV with TKR/PRC/CAP + the 7 coverage factor columns."""
+    cols = ["TKR", "PRC", "CAP", "PET", "ROE", "FCF", "52W", "B", "AM", "EG"]
+    df = pd.DataFrame(rows)
+    for c in cols:
+        if c not in df.columns:
+            df[c] = ""
+    p = tmp_path / "etoro.csv"
+    df[cols].to_csv(p, index=False)
+    return str(p)
+
+
+def test_coverage_constants_declared():
+    from trade_modules.v3.constants import COVERAGE_FACTORS, MIN_FACTOR_COVERAGE
+
+    assert MIN_FACTOR_COVERAGE == 6
+    assert set(COVERAGE_FACTORS) == {"PET", "ROE", "FCF", "52W", "B", "AM", "EG"}
+
+
+def test_load_universe_coverage_gate_keeps_only_well_covered(tmp_path):
+    from trade_modules.v3.universe import load_universe
+
+    rows = [
+        {"TKR": "AAA", "PRC": "10", "CAP": "1B", **_FULL},  # 7/7
+        {"TKR": "BBB", "PRC": "10", "CAP": "1B", **{**_FULL, "AM": "--"}},  # 6/7
+        {"TKR": "CCC", "PRC": "10", "CAP": "1B", **{**_FULL, "AM": "--", "EG": "--"}},  # 5/7
+    ]
+    u = load_universe(_write_panel(tmp_path, rows), min_factor_coverage=6)
+    assert u == ["AAA", "BBB"]  # CCC (5/7) excluded
+
+
+def test_load_universe_default_has_no_coverage_gate(tmp_path):
+    from trade_modules.v3.universe import load_universe
+
+    rows = [
+        {"TKR": "AAA", "PRC": "10", "CAP": "1B", **_FULL},
+        {"TKR": "CCC", "PRC": "10", "CAP": "1B", **{**_FULL, "AM": "--", "EG": "--", "PET": "--"}},
+    ]
+    u = load_universe(_write_panel(tmp_path, rows))  # default coverage=0 -> gate off
+    assert u == ["AAA", "CCC"]
+
+
+def test_coverage_gate_still_applies_cap_and_price_floors(tmp_path):
+    from trade_modules.v3.universe import load_universe
+
+    rows = [
+        {"TKR": "AAA", "PRC": "10", "CAP": "1B", **_FULL},  # ok
+        {"TKR": "SMALL", "PRC": "10", "CAP": "100M", **_FULL},  # 7/7 but sub-cap
+        {"TKR": "PENNY", "PRC": "0.5", "CAP": "1B", **_FULL},  # 7/7 but penny
+    ]
+    u = load_universe(_write_panel(tmp_path, rows), min_factor_coverage=6)
+    assert u == ["AAA"]  # coverage never overrides the cap/price/US base filters
+
+
+def test_coverage_gate_missing_factor_column_counts_as_absent(tmp_path):
+    from trade_modules.v3.universe import load_universe
+
+    # Panel with no AM column at all -> AM absent for everyone -> max coverage 6/7.
+    rows = [
+        {"TKR": "AAA", "PRC": "10", "CAP": "1B", **{k: v for k, v in _FULL.items() if k != "AM"}}
+    ]
+    csv = _write_panel(tmp_path, rows)
+    # AAA has 6 of the other factors -> passes >=6, but would fail >=7.
+    assert load_universe(csv, min_factor_coverage=6) == ["AAA"]
+    assert load_universe(csv, min_factor_coverage=7) == []
+
+
+def test_assemble_scored_universe_unions_and_always_includes_holdings(tmp_path):
+    from trade_modules.v3.universe import assemble_scored_universe
+
+    rows = [
+        {"TKR": "COVA", "PRC": "10", "CAP": "1B", **_FULL},  # covered 7/7
+        {"TKR": "COVB", "PRC": "10", "CAP": "1B", **_FULL},  # covered 7/7
+        {
+            "TKR": "HELD",
+            "PRC": "10",
+            "CAP": "1B",
+            **{**_FULL, "AM": "--", "EG": "--", "PET": "--"},
+        },  # 4/7
+    ]
+    csv = _write_panel(tmp_path, rows)
+    u = assemble_scored_universe(csv, holdings=["HELD"], candidates=["CAND"], min_factor_coverage=6)
+    assert "HELD" in u  # low-coverage holding is never dropped
+    assert "CAND" in u  # analyst candidate still included
+    assert "COVA" in u and "COVB" in u  # coverage-gated names included
+    assert u.index("HELD") < u.index("COVA")  # holdings first, then covered
+    assert len(u) == len(set(u))  # de-duped

--- a/trade_modules/v3/attribution.py
+++ b/trade_modules/v3/attribution.py
@@ -1,0 +1,91 @@
+"""FIX-NOW 2026-07-18 (D21): measure the owner-core sleeve + classify holdings by
+attribution layer.
+
+"Owned discretion" (protect_core / core_floor) is a DECISION right, not an exemption
+from MEASUREMENT. These helpers quantify the core sleeve's share of book RISK (not
+just weight) and tag each holding by attribution layer, so a dominant, unmeasured
+owner bet cannot hide behind the 6-cluster forecast's IC. Pure numpy/pandas; no I/O.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def core_attribution(weights, cov, core_list, betas=None) -> dict:
+    """Attribution of a deployed book to its owner-core sleeve.
+
+    Args:
+        weights: deployed book weights (Series / dict, fractions of NAV), by ticker.
+        cov: annualised covariance aligned POSITIONALLY to ``weights`` order.
+        core_list: the owner-core tickers (the protect_core / core_floor names).
+        betas: optional per-name betas aligned to ``weights`` (NaN -> 1.0).
+
+    Returns (all on invested proportions; an all-cash book -> zeros, never a
+    divide-by-zero):
+        ``core_weight`` — core share of the invested book;
+        ``core_variance_share`` — core share of ex-ante book VARIANCE (the number
+            that reveals a small-weight / high-vol core dominating book risk);
+        ``core_net_beta_contribution`` / ``book_net_beta``;
+        ``n_core_held``.
+    """
+    ws = weights if isinstance(weights, pd.Series) else pd.Series(weights, dtype=float)
+    idx = [str(t) for t in ws.index]
+    w = pd.to_numeric(ws, errors="coerce").fillna(0.0).to_numpy(dtype=float)
+    gross = float(w.sum())
+    if gross <= 0.0 or len(idx) == 0:
+        return {
+            "core_weight": 0.0,
+            "core_variance_share": 0.0,
+            "core_net_beta_contribution": float("nan"),
+            "book_net_beta": float("nan"),
+            "n_core_held": 0,
+        }
+
+    p = w / gross
+    core = {str(t) for t in (core_list or [])}
+    core_mask = np.array([t in core for t in idx], dtype=bool)
+    core_weight = float(p[core_mask].sum())
+
+    core_var_share = 0.0
+    cov = np.asarray(cov, dtype=float)
+    if cov.shape == (len(idx), len(idx)):
+        port_var = float(p @ cov @ p)
+        if port_var > 1e-18:
+            rc = p * (cov @ p)  # per-name risk contribution (sums to port_var)
+            core_var_share = float(rc[core_mask].sum() / port_var)
+
+    if betas is not None:
+        b = pd.to_numeric(pd.Series(list(betas)), errors="coerce").fillna(1.0).to_numpy(dtype=float)
+        book_net_beta = float(p @ b)
+        core_net_beta = float((p * core_mask) @ b)
+    else:
+        book_net_beta = core_net_beta = float("nan")
+
+    return {
+        "core_weight": core_weight,
+        "core_variance_share": core_var_share,
+        "core_net_beta_contribution": core_net_beta,
+        "book_net_beta": book_net_beta,
+        "n_core_held": int(core_mask.sum()),
+    }
+
+
+def attribution_layer(ticker, *, managed_sleeves, core_list) -> dict:
+    """3-layer attribution taxonomy at the ticker level.
+
+    * ``SAA`` — owner-managed sleeves (gold / vol / Greece): owned policy, never
+      scored as security-selection alpha.
+    * ``forecast`` — a scored equity driven by the 6-cluster IC-gated model.
+
+    (The ``process`` layer — gates / caps / deadband / deployment — is not per-ticker
+    and is judged on Sharpe / turnover / drawdown, not IC.)
+
+    ``owner_override`` flags a name held under protect_core / core_floor: a MEASURED
+    discretionary override (see :func:`core_attribution`), not process, not exempt.
+    """
+    t = str(ticker).upper()
+    managed = {str(s).upper() for s in (managed_sleeves or [])}
+    core = {str(s).upper() for s in (core_list or [])}
+    return {"layer": "SAA" if t in managed else "forecast", "owner_override": t in core}

--- a/trade_modules/v3/benchmark.py
+++ b/trade_modules/v3/benchmark.py
@@ -1,0 +1,55 @@
+"""BUILD ⑥c (2026-07-18, D25): EUR-denominated S&P 500 benchmark.
+
+The owner's home currency is EUR, so the benchmark is the EUR return of holding SPY
+= SPY's USD return combined with the EUR/USD move. Pure conversion + period-return
+helpers plus a thin fetch wrapper (SPY + EURUSD via robust_fetch_prices) that
+degrades to NaN when prices are unavailable.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+SPY_TICKER = "SPY"
+EURUSD_TICKER = "EURUSD=X"  # yfinance forex: USD per 1 EUR
+
+
+def to_eur(usd_close, eurusd):
+    """Convert a USD price (series or scalar) to EUR: EUR = USD / (USD per EUR)."""
+    return usd_close / eurusd
+
+
+def period_return_pct(series) -> float:
+    """Total return % over a price series: (last / first - 1) x 100. NaN if < 2
+    clean points or a zero base."""
+    s = pd.Series(series).dropna()
+    if len(s) < 2 or float(s.iloc[0]) == 0.0:
+        return float("nan")
+    return (float(s.iloc[-1]) / float(s.iloc[0]) - 1.0) * 100.0
+
+
+def spy_eur_return_pct(spy_usd_close, eurusd_close) -> float:
+    """EUR total return % of holding SPY over the series window (aligned on common
+    dates)."""
+    spy = pd.Series(spy_usd_close).dropna()
+    fx = pd.Series(eurusd_close).dropna()
+    idx = spy.index.intersection(fx.index)
+    if len(idx) < 2:
+        return float("nan")
+    return period_return_pct(spy.loc[idx] / fx.loc[idx])
+
+
+def fetch_spy_eur_return_pct(period: str = "1y", *, fetch=None) -> float:
+    """Fetch SPY + EURUSD and return the EUR return % over ``period``. NaN on any
+    failure (unreachable prices, missing columns) so callers degrade gracefully."""
+    if fetch is None:
+        from trade_modules.v3.fetch import robust_fetch_prices
+
+        fetch = robust_fetch_prices
+    try:
+        df = fetch([SPY_TICKER, EURUSD_TICKER], period=period)
+    except Exception:  # noqa: BLE001 - benchmark is best-effort; never break the report
+        return float("nan")
+    if df is None or df.empty or SPY_TICKER not in df.columns or EURUSD_TICKER not in df.columns:
+        return float("nan")
+    return spy_eur_return_pct(df[SPY_TICKER], df[EURUSD_TICKER])

--- a/trade_modules/v3/benchmark.py
+++ b/trade_modules/v3/benchmark.py
@@ -23,9 +23,12 @@ def period_return_pct(series) -> float:
     """Total return % over a price series: (last / first - 1) x 100. NaN if < 2
     clean points or a zero base."""
     s = pd.Series(series).dropna()
-    if len(s) < 2 or float(s.iloc[0]) == 0.0:
+    if len(s) < 2:
         return float("nan")
-    return (float(s.iloc[-1]) / float(s.iloc[0]) - 1.0) * 100.0
+    first = float(s.iloc[0])
+    if abs(first) < 1e-12:  # ~zero base -> return undefined (avoid float == and /0)
+        return float("nan")
+    return (float(s.iloc[-1]) / first - 1.0) * 100.0
 
 
 def spy_eur_return_pct(spy_usd_close, eurusd_close) -> float:

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -80,17 +80,20 @@ CLUSTERS = {
     "strength_z": ["analyst_mom"],
 }
 
-# Cluster weights: Value + Quality = 0.55 (the ~55% joint cap), rest sum to 0.45.
-# Growth carries ZERO weight by default — it exists as a 6th cluster but is OFF
-# in the default / IC path (backward-compat: the default model is unchanged).
-# The growth rebalance is exposed only via the explicit ``cluster_weights`` arg.
+# FIX-NOW 2026-07-18 (D14/D6b/D11/D7): equal-risk core, NO discretionary tilt, and
+# NO Value+Quality cap-as-floor. Core (value/quality/momentum/lowvol) equal; growth a
+# reduced satellite; strength (analyst_mom only) a small cap. Sum = 1.0. Weight
+# ESTIMATION is frozen (no MVO/IC-fit on the ~5-mo panel — forecast-combination puzzle);
+# the ic_weights path stays available for the later sizing tier. (True equal-VOL
+# standardization of the cluster z's is a fast-follow refinement; this sets the
+# equal-risk nominal shares and removes the 0.55 VQ floor.)
 CLUSTER_WEIGHTS = {
-    "value_z": 0.275,
-    "quality_z": 0.275,
-    "momentum_z": 0.20,
-    "growth_z": 0.0,
-    "lowvol_z": 0.15,
-    "strength_z": 0.10,
+    "value_z": 0.21,
+    "quality_z": 0.21,
+    "momentum_z": 0.21,
+    "growth_z": 0.11,
+    "lowvol_z": 0.21,
+    "strength_z": 0.05,
 }
 
 # The Value+Quality joint weight is capped here regardless of the weighting scheme.

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -231,6 +231,22 @@ def _z_plain(s: pd.Series) -> pd.Series:
     return (x - mu) / sd
 
 
+def _equal_vol_standardize(zmat: pd.DataFrame) -> pd.DataFrame:
+    """Scale each cluster-z column to ~unit cross-sectional std (population, ddof=0).
+
+    FIX-NOW 2026-07-18 (D14): "true equal-vol". Cluster-z's are means of member
+    rank-z's, so a cluster with more (or more-correlated) members has a lower
+    cross-sectional dispersion and would UNDER-contribute under equal nominal
+    weights. Dividing each cluster by its own cross-sectional std makes the
+    equal-risk nominal weights genuinely equal-RISK. A zero-/near-zero-std or
+    all-NaN column is left unchanged (no divide-by-zero); NaNs are preserved.
+    Computed per-snapshot on the current cross-section only -> no look-ahead.
+    """
+    std = zmat.std(axis=0, ddof=0)
+    denom = std.where(std > 1e-12, 1.0)
+    return zmat.divide(denom, axis=1)
+
+
 def _sector_demean(z: pd.Series, sector: pd.Series) -> pd.Series:
     """Subtract the within-sector mean of z. Missing sectors form one fallback
     group (their own subset mean), leaving the global ~0-mean z ~unchanged."""
@@ -322,6 +338,10 @@ def compute_scores(
     # Weighted conviction, renormalized per-row over the clusters actually present.
     cluster_names = list(CLUSTERS.keys())
     zmat = out[cluster_names]
+    # Equal-VOL standardize the cluster-z's so the equal-risk nominal weights are
+    # truly equal-RISK (the stored {cluster}_z columns stay RAW; only conviction
+    # uses the standardized matrix).
+    zmat_ev = _equal_vol_standardize(zmat)
     weights = pd.Series(resolve_cluster_weights(cluster_weights, ic_weights, cluster_names))[
         cluster_names
     ]
@@ -329,9 +349,9 @@ def compute_scores(
         np.tile(weights.to_numpy(), (len(out), 1)),
         index=out.index,
         columns=cluster_names,
-    ).where(zmat.notna())
+    ).where(zmat_ev.notna())
     wsum = wmat.sum(axis=1)
-    conv_raw = (zmat * wmat).sum(axis=1) / wsum.where(wsum > 0)
+    conv_raw = (zmat_ev * wmat).sum(axis=1) / wsum.where(wsum > 0)
 
     # Eligibility gate: ineligible names never enter the ranked cross-section,
     # so their conviction is NaN (which yields a NaN rank) and the re-z baseline

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -58,23 +58,26 @@ CLUSTERS = {
     # (rho 0.75/0.77) and of each other (pe_forward~ps_sector 0.98) -> double-counted
     # valuation. Kept a diverse trio: earnings (pe_trailing), book (pb), enterprise
     # (ev_ebitda). Pruned metrics still SHOWN as raw context in the card, not scored.
-    "value_z": ["pe_trailing", "pb", "ev_ebitda"],
-    "quality_z": [
-        "roe",
-        "roa",
-        "gross_margin",
-        "op_margin",
-        "fcf",
-        "current_ratio",
-        "de",
-        "accruals",
-    ],
+    # FIX-NOW 2026-07-18 (D7): raw P/B dropped (degrades in an intangible-heavy
+    # mega-cap-tech universe — shorts the R&D/brand compounders). Anchor on
+    # EV/EBITDA + trailing earnings yield. Intangibles-adjusted book -> BUILD.
+    "value_z": ["pe_trailing", "ev_ebitda"],
+    # FIX-NOW 2026-07-18 (D8): interim quality = ROE + FCF (panel-available).
+    # GP/assets + operating-profitability/assets are the Novy-Marx anchors but need
+    # Total Assets / Gross Profit -> BUILD. de + current_ratio -> distress filter
+    # (financial strength, not profitability). accruals -> shadow (non-PIT, needs a
+    # point-in-time balance sheet). roa / per-sales margins retired for the interim.
+    "quality_z": ["roe", "fcf"],
     # price_perf pruned 2026-07-14: rho 0.95 with mom_12_1 (same price move counted
     # twice). Kept the academic 12-1 skip-month + 52w-high proximity (distinct).
     "momentum_z": ["mom_12_1", "pct_52w_high"],
     "growth_z": ["earn_growth", "rev_growth"],
     "lowvol_z": ["beta", "realized_vol"],
-    "strength_z": ["analyst_mom", "upside", "buy_pct", "short_interest", "target_dispersion"],
+    # FIX-NOW 2026-07-18 (agreed setup D2-D6): strength collapses to analyst_mom
+    # alone. upside (contaminated/contrarian), buy_pct (zero-IC level),
+    # short_interest (→ squeeze-exclude gate) and target_dispersion (non-PIT,
+    # discarded) are removed from scoring. Raw columns stay in the feature frame.
+    "strength_z": ["analyst_mom"],
 }
 
 # Cluster weights: Value + Quality = 0.55 (the ~55% joint cap), rest sum to 0.45.

--- a/trade_modules/v3/constants.py
+++ b/trade_modules/v3/constants.py
@@ -1,0 +1,25 @@
+"""Trading Model v3 — declared model constants (single source of truth).
+
+The signal horizon is the ONE number the whole validation stack must agree on:
+the IC logger (``scripts/v3_ic_logger.py``), the price-spine gate
+(``scripts/v3_spine_gate.py``), and the referee (``trade_modules/validation/
+harness.py`` via ``trade_modules/v3/validate_spine.py``) all grade the model at
+``V3_SIGNAL_HORIZON`` so every DSR / IC statistic measures the SAME target.
+
+Owner decision 2026-07-18: primary = 21 trading days (~1 month). The equal-risk
+blend is ~74% slow signals (value/quality/low-vol/growth) + ~26% fast (momentum,
+analyst strength), but the no-trade-band construction implies a ~monthly holding
+period and the fastest-decaying sleeves need a ~1mo read; value/quality are still
+co-reported at 63. Sources: Grinold-Kahn (grade IC at the rebalance horizon);
+Jegadeesh-Titman (momentum 1-12mo).
+"""
+
+from __future__ import annotations
+
+# Primary signal horizon in trading-day steps (== IC-logger log-date steps on a
+# daily schedule). Everything that grades the model grades at THIS horizon.
+V3_SIGNAL_HORIZON = 21
+
+# Unified IC / gate measurement grid: fast diagnostic (5), primary (21), slow
+# value/quality secondary (63). V3_SIGNAL_HORIZON MUST be a member of this grid.
+V3_IC_HORIZONS = (5, 21, 63)

--- a/trade_modules/v3/constants.py
+++ b/trade_modules/v3/constants.py
@@ -23,3 +23,12 @@ V3_SIGNAL_HORIZON = 21
 # Unified IC / gate measurement grid: fast diagnostic (5), primary (21), slow
 # value/quality secondary (63). V3_SIGNAL_HORIZON MUST be a member of this grid.
 V3_IC_HORIZONS = (5, 21, 63)
+
+# BUILD ④ (2026-07-18): coverage-gate universe selector — replaces the analyst
+# AND-gate (which scored only ~3% of the universe and anti-selected momentum:
+# upside<->52wk-high rho = -0.72). A name is scored when >= MIN_FACTOR_COVERAGE of
+# these seven panel-native factor inputs are present. Owner decision: >=6/7 — at
+# most one of the six clusters is degraded per name (52W is always present), 25x
+# today's universe (~2,580 names), and it cuts the data-thin tail (1-2 factors).
+COVERAGE_FACTORS = ("PET", "ROE", "FCF", "52W", "B", "AM", "EG")
+MIN_FACTOR_COVERAGE = 6

--- a/trade_modules/v3/costs.py
+++ b/trade_modules/v3/costs.py
@@ -1,0 +1,60 @@
+"""BUILD ⑥b (2026-07-18): transaction-cost model for v3.
+
+Round-trip cost = entry+exit spread (by cap tier) + eToro overnight financing over
+the holding horizon. Reuses ``liquidity_filter``'s ``TIER_SPREAD_BPS`` and
+``ETORO_OVERNIGHT_ANNUAL_RATE`` so the cost constants have a single home.
+
+Principled use: a NET-of-cost IC in validation (trial-register ``net_ir_min``) —
+grading net alpha. Applying cost at the ACTION level (suppressing trades whose
+expected gain does not clear the round trip) would change LIVE trading and is a
+separate, sign-off-required increment.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.liquidity_filter import ETORO_OVERNIGHT_ANNUAL_RATE, TIER_SPREAD_BPS
+from trade_modules.v3.liquidity import cap_tier
+from trade_modules.v3.universe import parse_cap
+
+# V3_SIGNAL_HORIZON is 21 trading days ~ 30 calendar days; eToro financing accrues
+# on calendar days, so the cost horizon is expressed in calendar days.
+DEFAULT_HOLDING_DAYS = 30
+
+
+def roundtrip_cost_pct(cap_usd, *, holding_days: int = DEFAULT_HOLDING_DAYS) -> float:
+    """Round-trip cost as a % of position for a name of this cap tier: entry+exit
+    spread (2x the tier's bps) + eToro overnight financing over the holding period."""
+    tier = cap_tier(cap_usd)
+    spread_pct = TIER_SPREAD_BPS[tier] / 10000.0 * 2.0 * 100.0
+    financing_pct = ETORO_OVERNIGHT_ANNUAL_RATE * (holding_days / 365.0) * 100.0
+    return spread_pct + financing_pct
+
+
+def net_of_cost_return(
+    gross_return_pct, cap_usd, *, holding_days: int = DEFAULT_HOLDING_DAYS
+) -> float:
+    """Gross return % minus this name's round-trip cost %."""
+    return float(gross_return_pct) - roundtrip_cost_pct(cap_usd, holding_days=holding_days)
+
+
+def cost_map_from_panel(etoro_csv_path, *, holding_days: int = DEFAULT_HOLDING_DAYS) -> dict:
+    """``{TICKER_UPPER: roundtrip_cost_pct}`` built from the panel's CAP column.
+
+    Cap is slow-changing, so a current-panel lookup is an adequate per-name cost for
+    grading the (short) IC log net of cost. An unreadable panel returns ``{}``.
+    """
+    try:
+        df = pd.read_csv(etoro_csv_path, na_values=["--"])
+    except (OSError, ValueError):
+        return {}
+    if "TKR" not in df.columns or "CAP" not in df.columns:
+        return {}
+    out: dict[str, float] = {}
+    for tkr, cap in zip(df["TKR"], df["CAP"], strict=False):
+        t = str(tkr).strip().upper()
+        if not t or t == "NAN":
+            continue
+        out[t] = roundtrip_cost_pct(parse_cap(cap), holding_days=holding_days)
+    return out

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -333,6 +333,7 @@ def enrich_features(
     info_fetch=None,
     price_fetch=None,
     accruals_fetch=None,
+    sector_map: dict | None = None,
 ) -> pd.DataFrame:
     """Build the merged per-ticker feature frame (indexed by ticker).
 
@@ -349,6 +350,11 @@ def enrich_features(
             :func:`_default_accruals_fetch` (throttled yfinance, skip-not-raise).
             Pass ``lambda tickers: {}`` to skip the network call in report runs
             that supply a pre-cached value or don't need the column.
+        sector_map: optional ``{TICKER_UPPER: sector}`` offline map (static index
+            map + persistent cache, see ``trade_modules.v3.sectors``). When given,
+            ``sector`` is resolved offline-first, falling back to live yfinance for
+            names the map does not cover. When None/empty, behaviour is unchanged
+            (live yfinance only).
 
     Returns:
         pd.DataFrame indexed by ticker with native + added + derived columns.
@@ -385,6 +391,12 @@ def enrich_features(
         added[feat] = pd.to_numeric(vals, errors="coerce")
     for key, feat in _INFO_STR.items():
         added[feat] = [info.get(t, {}).get(key) for t in tickers]
+    # BUILD ③: prefer the offline/cached sector map (static index > cache) when
+    # provided; fall back to the live yfinance .info sector for names it misses.
+    if sector_map:
+        added["sector"] = [
+            sector_map.get(str(t).upper()) or info.get(t, {}).get("sector") for t in tickers
+        ]
     # Truncate description to ~220 chars at a clean boundary; NaN/None → "".
     added["description"] = added["description"].apply(_truncate_description)
 

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -21,6 +21,7 @@ import pandas as pd
 
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.v3.fetch import robust_fetch_prices
+from trade_modules.v3.integrity import validate_panel
 from trade_modules.v3.universe import parse_cap
 
 # Approximate spot FX rates (local currency -> USD), for normalizing eToro's
@@ -364,6 +365,7 @@ def enrich_features(
 
     # --- (1) native factors from the etoro CSV ---
     raw = pd.read_csv(etoro_csv_path, na_values=["--"])
+    raw = validate_panel(raw, source=str(etoro_csv_path))
     raw = raw.drop_duplicates(subset="TKR", keep="first").set_index("TKR")
     native = pd.DataFrame(index=raw.index)
     native["name"] = raw["NAME"].astype("object") if "NAME" in raw.columns else pd.NA

--- a/trade_modules/v3/integrity.py
+++ b/trade_modules/v3/integrity.py
@@ -1,0 +1,133 @@
+"""BUILD ② (2026-07-18): fail-loud structural integrity gate for the etoro.csv panel.
+
+The v3 loaders (``universe.load_universe``, ``features.enrich_features``) previously
+did a bare ``pd.read_csv`` with no schema or dtype check, so a silently dropped
+column or a same-field-count column-shift (a company name comma-splitting a row)
+would degrade every downstream factor to NaN with no signal. This gate ASSERTS the
+panel's shape so corruption STOPS the pipeline instead of quietly poisoning the book.
+
+Two corruption modes, two catchers:
+  * an EXTRA-field comma-shift produces more fields than the header -> pandas' C
+    parser already raises ParserError at read time (loud, upstream of this gate);
+  * a SAME-field-count misalignment (an upstream column dropped, values shifted)
+    slips past pandas -> caught here: required columns must be present, and the
+    confirmed-numeric factor columns must actually coerce to numbers.
+
+Deliberately scoped to CORRUPTION, not COVERAGE:
+  * CAP/SZ/ERN are legitimately non-numeric (suffix/date/flag) and are NEVER
+    numeric-checked (CAP='39.2T');
+  * a sparse or entirely-empty column is missingness, left to the coverage gate —
+    only garbage IN a numeric column raises here.
+
+The panel is clean today (RFC-4180 quoted, 31 cols, every factor column 100%
+numeric); this is a forward guard, not a repair.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+class PanelIntegrityError(ValueError):
+    """Raised when the etoro.csv panel fails a structural integrity check."""
+
+
+# Columns v3 needs present to build the universe + the active factor set.
+PANEL_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "TKR",
+    "NAME",
+    "CAP",
+    "PRC",
+    "PET",
+    "ROE",
+    "FCF",
+    "52W",
+    "B",
+    "AM",
+    "EG",
+)
+
+# Confirmed plain-numeric factor columns (empirically 100% numeric on the clean
+# panel). CAP is excluded — it is suffixed ('39.2T'); TKR/NAME are strings.
+PANEL_REQUIRED_NUMERIC: tuple[str, ...] = ("PRC", "PET", "ROE", "FCF", "52W", "B", "AM", "EG")
+
+# A confirmed-numeric column whose PRESENT values coerce below this fraction is
+# corrupt (a column-shift injected strings). The clean panel is 1.000; corruption
+# collapses toward 0, so the margin is deliberately wide.
+NUMERIC_MIN_FRAC = 0.90
+
+# The ticker column is the row identity; near-total nulls = catastrophic corruption.
+TICKER_MIN_NONNULL_FRAC = 0.95
+
+
+def _numeric_fraction(s: pd.Series) -> tuple[int, float]:
+    """Return (#present values, fraction of them that coerce to a number).
+
+    Mirrors ``features._num`` cleaning (strip ``%`` and thousands commas). "Present"
+    = non-null and non-blank. Returns ``(0, 1.0)`` for an entirely-empty column so
+    missingness (coverage) never trips the corruption gate.
+    """
+    present = s.dropna()
+    present = present[present.astype(str).str.strip() != ""]
+    if len(present) == 0:
+        return 0, 1.0
+    cleaned = pd.to_numeric(
+        present.astype(str)
+        .str.replace("%", "", regex=False)
+        .str.replace(",", "", regex=False)
+        .str.strip(),
+        errors="coerce",
+    )
+    return len(present), float(cleaned.notna().mean())
+
+
+def validate_panel(
+    df: pd.DataFrame,
+    *,
+    source: str = "etoro.csv",
+    required_columns: tuple[str, ...] = PANEL_REQUIRED_COLUMNS,
+    required_numeric: tuple[str, ...] = PANEL_REQUIRED_NUMERIC,
+) -> pd.DataFrame:
+    """Fail-loud structural integrity gate. Returns ``df`` unchanged on success.
+
+    Args:
+        df: the raw panel as loaded by ``pd.read_csv`` (original column names).
+        source: path / label used in error messages.
+        required_columns: columns that must be present (``load_universe`` passes a
+            minimal ``('TKR','PRC','CAP')``; the feature path uses the full default).
+        required_numeric: confirmed-numeric columns whose present values must coerce.
+
+    Raises:
+        PanelIntegrityError: listing EVERY violation found in one pass.
+    """
+    if df is None or len(df) == 0:
+        raise PanelIntegrityError(f"{source}: panel is empty (0 rows)")
+
+    problems: list[str] = []
+
+    missing = [c for c in required_columns if c not in df.columns]
+    if missing:
+        problems.append(f"missing required columns: {missing}")
+
+    if "TKR" in df.columns:
+        t = df["TKR"].astype(str).str.strip()
+        nonnull_frac = float((t.ne("") & t.ne("nan") & t.ne("None")).mean())
+        if nonnull_frac < TICKER_MIN_NONNULL_FRAC:
+            problems.append(
+                f"TKR only {nonnull_frac:.1%} non-null (< {TICKER_MIN_NONNULL_FRAC:.0%}) — "
+                "likely a column shift"
+            )
+
+    for col in required_numeric:
+        if col not in df.columns:
+            continue  # already reported by the presence check
+        n, frac = _numeric_fraction(df[col])
+        if n > 0 and frac < NUMERIC_MIN_FRAC:
+            problems.append(
+                f"column {col!r} only {frac:.1%} numeric over {n} present values "
+                f"(< {NUMERIC_MIN_FRAC:.0%}) — a column shift likely injected non-numeric data"
+            )
+
+    if problems:
+        raise PanelIntegrityError(f"{source}: " + "; ".join(problems))
+    return df

--- a/trade_modules/v3/liquidity.py
+++ b/trade_modules/v3/liquidity.py
@@ -1,0 +1,79 @@
+"""BUILD ⑥a (2026-07-18): tiered, copier-aware ADV liquidity gate for v3.
+
+v3 previously gated liquidity with a single flat $1M floor applied inline in the
+report. After ④ expanded the scored universe ~25x (admitting many smaller / less-
+liquid names), the floor should scale with market-cap tier and — for a copied book —
+with a copier multiplier. This gate uses v3's own ``adv_usd`` (avg_volume x price x
+fx, already computed in features) so it costs NO extra network fetch, unlike
+``trade_modules.liquidity_filter`` whose ``get_adv`` fetches per ticker.
+
+Scope: the copier multiplier defaults to 1.0 (single-account = the tiered floor).
+Deriving a real multiplier from copier AUM is a proper capacity-model question,
+deferred; the parameter is the hook. Held names and unknown-ADV names are never
+dropped.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from trade_modules.liquidity_filter import TIER_MIN_ADV
+
+# Market-cap tier thresholds (USD). ``load_universe`` floors cap at $500M, so in
+# practice only SMALL..MEGA appear; MICRO is kept for completeness / held names.
+_CAP_TIERS: tuple[tuple[float, str], ...] = (
+    (2e11, "MEGA"),  # >= $200B
+    (1e10, "LARGE"),  # >= $10B
+    (2e9, "MID"),  # >= $2B
+    (3e8, "SMALL"),  # >= $300M
+)
+
+
+def cap_tier(cap_usd) -> str:
+    """Market-cap tier for a USD market cap. Unknown/NaN cap -> neutral ``MID``."""
+    try:
+        c = float(cap_usd)
+    except (TypeError, ValueError):
+        return "MID"
+    if math.isnan(c):
+        return "MID"
+    for threshold, name in _CAP_TIERS:
+        if c >= threshold:
+            return name
+    return "MICRO"
+
+
+def required_adv(cap_usd, *, copier_multiplier: float = 1.0) -> float:
+    """Minimum acceptable ADV (USD/day): the tier floor scaled by the copier
+    multiplier (clamped at >= 1.0 — copiers only ever raise the liquidity bar)."""
+    return TIER_MIN_ADV[cap_tier(cap_usd)] * max(1.0, float(copier_multiplier))
+
+
+def liquidity_gate(
+    scores: pd.DataFrame,
+    *,
+    copier_multiplier: float = 1.0,
+    held_col: str = "is_portfolio",
+    adv_col: str = "adv_usd",
+    cap_col: str = "cap",
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split ``scores`` into ``(kept, dropped)`` on the tiered ADV floor.
+
+    A row is DROPPED only when it is (a) not held, (b) has a KNOWN ADV, and (c) that
+    ADV is below its tier's (copier-scaled) floor. Held names, unknown-ADV names, and
+    (defensively) a frame lacking the ADV/cap columns are always kept.
+    """
+    if adv_col not in scores.columns or cap_col not in scores.columns:
+        return scores, scores.iloc[0:0]
+
+    adv = pd.to_numeric(scores[adv_col], errors="coerce")
+    held = (
+        scores[held_col].fillna(False).astype(bool)
+        if held_col in scores.columns
+        else pd.Series(False, index=scores.index)
+    )
+    floor = scores[cap_col].map(lambda c: required_adv(c, copier_multiplier=copier_multiplier))
+    drop = (~held) & adv.notna() & (adv < floor)
+    return scores[~drop].copy(), scores[drop].copy()

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -141,6 +141,46 @@ def _dedup_buy_candidates(cand_list: list[str], held: list[str], scored: pd.Data
     return out
 
 
+def _screen_buy_candidates(
+    cand_list: list[str],
+    scored: pd.DataFrame,
+    *,
+    max_short_interest: float | None,
+    min_current_ratio: float | None,
+    max_de: float | None,
+) -> tuple[list[str], list[str]]:
+    """FIX-NOW 2026-07-18 (D4/D8): drop squeeze-risky / distressed names from the BUY
+    pool. Applied to buys ONLY — never force-sells a holding.
+
+    A candidate is screened out when ANY active criterion trips:
+      * short_interest (% of float) > ``max_short_interest``  — squeeze/borrow risk;
+      * current_ratio < ``min_current_ratio``                 — distress (illiquid);
+      * de > ``max_de``                                       — distress (over-levered).
+    A criterion whose param is ``None`` is off; an absent column or NaN value never
+    excludes (missing data is not treated as distress). Returns (kept, screened_out).
+    """
+    if scored is None or not cand_list:
+        return cand_list, []
+
+    def _val(t: str, col: str) -> float:
+        if col not in scored.columns or t not in scored.index:
+            return float("nan")
+        try:
+            return float(scored.at[t, col])
+        except (TypeError, ValueError):
+            return float("nan")
+
+    kept: list[str] = []
+    out: list[str] = []
+    for t in cand_list:
+        si, cr, de = _val(t, "short_interest"), _val(t, "current_ratio"), _val(t, "de")
+        squeeze = max_short_interest is not None and pd.notna(si) and si > max_short_interest
+        illiquid = min_current_ratio is not None and pd.notna(cr) and cr < min_current_ratio
+        levered = max_de is not None and pd.notna(de) and de > max_de
+        (out if (squeeze or illiquid or levered) else kept).append(t)
+    return kept, out
+
+
 def _sector_labels(names: list[str], scored: pd.DataFrame) -> list[str]:
     """Uppercased sector label per name ("UNKNOWN" when missing)."""
     if scored is None or "sector" not in scored.columns:
@@ -170,6 +210,9 @@ def build_overlay(
     noncore_sell_floor: float = 0.0,
     protect_core: bool = False,
     core_floor: pd.Series | None = None,
+    max_short_interest: float | None = 20.0,
+    min_current_ratio: float | None = 1.0,
+    max_de: float | None = None,
 ) -> dict:
     """Build a minimal keep/sell/buy overlay on the live book, then risk-gate it.
 
@@ -269,12 +312,21 @@ def build_overlay(
 
     # BUY: strongest non-held eligible names clearing the buy percentile.
     bought: list[str] = []
+    screened_out: list[str] = []
     if not np.isnan(buy_threshold) and max_new > 0:
         cand = elig_conv[[t for t in elig_conv.index if t not in held_set]]
         cand = cand[cand >= buy_threshold].sort_values(ascending=False)
         # FIX A: never buy the same company twice, nor a dual listing of a name
         # already in the book (dedup the candidate pool + drop held companies).
         cand_list = _dedup_buy_candidates(list(cand.index), held, scored)
+        # FIX-NOW (D4/D8): drop squeeze-risky / distressed names from the buy pool.
+        cand_list, screened_out = _screen_buy_candidates(
+            cand_list,
+            scored,
+            max_short_interest=max_short_interest,
+            min_current_ratio=min_current_ratio,
+            max_de=max_de,
+        )
         bought = cand_list[: int(max_new)]
 
     # Pre-gate target: keeps anchored at current weight; buys funded from the freed
@@ -404,6 +456,7 @@ def build_overlay(
         "sold": sold,
         "kept": kept,
         "bought": bought,
+        "screened_out": screened_out,
         "gate": gate_diag,
         "core_floor_applied": core_floor_applied,
     }

--- a/trade_modules/v3/sectors.py
+++ b/trade_modules/v3/sectors.py
@@ -1,0 +1,105 @@
+"""BUILD ③ (2026-07-18): offline, cache-backed sector resolution for v3.
+
+v3 previously took ``sector`` ONLY from live yfinance ``.info["sector"]``. When
+yfinance throttled, ``sector`` went NaN, ``combine._sector_demean`` collapsed every
+NaN name into one ``__NA__`` bucket (global demean = a no-op), and the risk-gate
+sector cap became a single-bucket no-op with no diversification semantics.
+
+The v2 static index map (``market.csv`` + ``usindex.csv``, ~519 S&P-scale large-caps)
+covers only ~14% of our 3,345-name US universe, so it cannot carry sector-neutrality
+on its own. This module layers three tiers, highest trust first:
+
+    static index map  >  persistent cache  >  live yfinance (written back to cache)
+
+The write-back means each run backfills the cache from that run's live sectors, so
+coverage grows toward yfinance availability and — critically — a throttled run still
+gets stable sectors from the cache instead of silently degrading. Sectors are slow-
+changing, so caching carries no look-ahead risk. Taxonomy is yfinance's 11 GICS
+sectors, identical to the static CSVs — no taxonomy mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from trade_modules.pipeline_v2.sectors import load_sector_map
+
+# Repo-anchored so the static files resolve regardless of CWD (cron/VPS/tests).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STATIC_PATHS: tuple[str, ...] = (
+    str(_REPO_ROOT / "yahoofinance" / "input" / "market.csv"),
+    str(_REPO_ROOT / "yahoofinance" / "input" / "usindex.csv"),
+)
+DEFAULT_CACHE_PATH: str = str(Path("~/.weirdapps-trading/v3_sector_cache.json").expanduser())
+
+
+def merge_offline_map(static: dict, cache: dict) -> dict:
+    """Merge the static index map over the persistent cache — STATIC WINS.
+
+    Blank values are dropped; keys are upper-cased for case-insensitive lookup.
+    """
+    merged = {str(k).upper(): v for k, v in (cache or {}).items() if v}
+    merged.update({str(k).upper(): v for k, v in (static or {}).items() if v})
+    return merged
+
+
+def _read_cache(cache_path: str) -> dict:
+    """Read the persistent sector cache; ``{}`` on missing/corrupt/unreadable."""
+    try:
+        with open(Path(cache_path).expanduser(), encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k).upper(): str(v) for k, v in data.items() if v}
+
+
+def load_offline_sector_map(
+    static_paths: tuple[str, ...] = DEFAULT_STATIC_PATHS,
+    cache_path: str = DEFAULT_CACHE_PATH,
+) -> dict:
+    """Return the offline sector map (static index CSVs + persistent cache, static wins).
+
+    Keyed by upper-cased ticker. Safe to call with no data present -> ``{}``.
+    """
+    static = load_sector_map(list(static_paths))
+    cache = _read_cache(cache_path)
+    return merge_offline_map(static, cache)
+
+
+def update_sector_cache(
+    resolved,
+    *,
+    cache_path: str = DEFAULT_CACHE_PATH,
+    static_paths: tuple[str, ...] = DEFAULT_STATIC_PATHS,
+) -> int:
+    """Persist live-resolved sectors that the static map does NOT already cover.
+
+    ``resolved`` is any ``{ticker: sector}`` mapping (e.g. ``feats['sector']`` after
+    enrichment). Static-covered names are skipped (the static map is authoritative
+    and needs no caching). Returns the number of NEW cache entries written. Never
+    raises — a failed write returns 0.
+    """
+    static = load_sector_map(list(static_paths))
+    cache = _read_cache(cache_path)
+    added = 0
+    for ticker, sector in dict(resolved or {}).items():
+        if not sector:
+            continue
+        key = str(ticker).upper()
+        if key in static:
+            continue  # static is authoritative — do not cache
+        if cache.get(key) != str(sector):
+            cache[key] = str(sector)
+            added += 1
+    if added:
+        try:
+            path = Path(cache_path).expanduser()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(cache, fh, indent=0, sort_keys=True)
+        except OSError:
+            return 0
+    return added

--- a/trade_modules/v3/trial_register.py
+++ b/trade_modules/v3/trial_register.py
@@ -1,0 +1,69 @@
+"""FIX-NOW 2026-07-18 (D23 / spec §7): frozen acceptance gate + trial register.
+
+One auditable place that (a) freezes the DSR/PBO/IC thresholds so they cannot be
+quietly relaxed to pass a favoured signal, and (b) counts EVERY candidate signal
+under test so DSR deflation sees the true number of trials (undercounting inflates
+DSR). A factor earns conviction only by clearing THESE numbers on forward,
+net-of-cost, ≥2-regime data. Sources: Bailey-López de Prado (DSR/PBO), Harvey-Liu-Zhu
+(t>3), spec 2026-07-12 §7. Pure stdlib; no I/O.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+# Frozen acceptance gate (read-only mapping — mutation raises TypeError).
+ACCEPTANCE_THRESHOLDS = MappingProxyType(
+    {
+        "dsr_min": 0.95,  # Deflated Sharpe hurdle
+        "pbo_max": 0.05,  # Probability of Backtest Overfitting (CSCV)
+        "ic_mean_min": 0.02,  # mean incumbent-partialled cross-sectional IC
+        "ic_t_min": 3.0,  # Harvey-Liu-Zhu multiple-testing t-hurdle
+        "hit_rate_min": 0.55,
+        "bh_q": 0.10,  # Benjamini-Hochberg FDR level
+        "min_regimes": 2,  # must include a bear/stress regime
+        "net_ir_min": 0.30,  # net of 2x modelled EUR cost
+        "ablation_delta_ir_min": 0.10,  # Δ net OOS IR with vs without the signal
+    }
+)
+
+# Append-only register of every candidate signal/config under test. DSR deflates for
+# THIS count; candidates are registered BEFORE they accrue forward IC (spec line 165)
+# so the trial count is never undercounted after the fact.
+CANDIDATE_TRIALS = (
+    "reinstate_peg",
+    "gp_assets",
+    "operating_profitability_assets",
+    "accruals_pit",
+    "investment_cma",
+    "pead_sue",
+    "analyst_eps_revision",
+    "upside_orthogonalized_residual",
+    "core_lowdin_orthogonalization",
+    "growth_both_signs",
+    "lowvol_beta_only",
+    "lowvol_vol_only",
+    "ic_weighting_sizing_tier",
+    "fat_tail_cvar",
+)
+
+
+def trial_count() -> int:
+    """Number of registered candidate trials — the N used for DSR deflation."""
+    return len(CANDIDATE_TRIALS)
+
+
+def threshold(name: str) -> float:
+    """Read a frozen acceptance threshold (raises KeyError on an unknown gate)."""
+    return float(ACCEPTANCE_THRESHOLDS[name])
+
+
+def is_relaxation(name: str, proposed: float) -> bool:
+    """True if ``proposed`` would LOOSEN the frozen gate ``name``.
+
+    Guards against quietly relaxing the gate: ``*_min`` / ``*_regimes`` gates loosen
+    when LOWERED; ``*_max`` / ``*_q`` gates loosen when RAISED.
+    """
+    frozen = float(ACCEPTANCE_THRESHOLDS[name])
+    looser_when_lower = name.endswith("_min") or name.endswith("_regimes")
+    return proposed < frozen if looser_when_lower else proposed > frozen

--- a/trade_modules/v3/universe.py
+++ b/trade_modules/v3/universe.py
@@ -2,6 +2,8 @@ import re
 
 import pandas as pd
 
+from trade_modules.v3.integrity import validate_panel
+
 US_TICKER = re.compile(r"^[A-Z]+$")  # US/USD listing = no exchange suffix
 _SUFFIX = {"T": 1e12, "B": 1e9, "M": 1e6, "K": 1e3, "k": 1e3}
 
@@ -20,6 +22,12 @@ def load_universe(
     etoro_csv_path: str, min_price: float = 1.0, min_cap_usd: float = 5e8
 ) -> list[str]:
     df = pd.read_csv(etoro_csv_path, na_values=["--"])
+    df = validate_panel(
+        df,
+        source=str(etoro_csv_path),
+        required_columns=("TKR", "PRC", "CAP"),
+        required_numeric=("PRC",),
+    )
     tkr = df["TKR"].astype(str)
     mask_us = tkr.str.match(US_TICKER)
     price = pd.to_numeric(df["PRC"], errors="coerce")

--- a/trade_modules/v3/universe.py
+++ b/trade_modules/v3/universe.py
@@ -2,6 +2,7 @@ import re
 
 import pandas as pd
 
+from trade_modules.v3.constants import COVERAGE_FACTORS, MIN_FACTOR_COVERAGE
 from trade_modules.v3.integrity import validate_panel
 
 US_TICKER = re.compile(r"^[A-Z]+$")  # US/USD listing = no exchange suffix
@@ -18,9 +19,42 @@ def parse_cap(v) -> float:
     return float(m.group(1)) * _SUFFIX.get(m.group(2), 1.0)
 
 
+def _factor_coverage_count(
+    df: pd.DataFrame, factors: tuple[str, ...] = COVERAGE_FACTORS
+) -> pd.Series:
+    """Per-row count of ``factors`` whose value is numeric-present.
+
+    Mirrors ``features._num`` cleaning (strip ``%`` and thousands commas). Columns
+    absent from ``df`` count as not-present for every row.
+    """
+    total = pd.Series(0, index=df.index)
+    for col in factors:
+        if col not in df.columns:
+            continue
+        cleaned = pd.to_numeric(
+            df[col]
+            .astype(str)
+            .str.replace("%", "", regex=False)
+            .str.replace(",", "", regex=False)
+            .str.strip(),
+            errors="coerce",
+        )
+        total = total + cleaned.notna().astype(int)
+    return total
+
+
 def load_universe(
-    etoro_csv_path: str, min_price: float = 1.0, min_cap_usd: float = 5e8
+    etoro_csv_path: str,
+    min_price: float = 1.0,
+    min_cap_usd: float = 5e8,
+    min_factor_coverage: int = 0,
 ) -> list[str]:
+    """US, cap/price-filtered ticker list; optionally coverage-gated.
+
+    ``min_factor_coverage`` > 0 additionally keeps only names with at least that
+    many of the panel-native factors (``COVERAGE_FACTORS``) present — the BUILD ④
+    replacement for the analyst AND-gate. 0 (default) leaves the gate off.
+    """
     df = pd.read_csv(etoro_csv_path, na_values=["--"])
     df = validate_panel(
         df,
@@ -33,4 +67,26 @@ def load_universe(
     price = pd.to_numeric(df["PRC"], errors="coerce")
     cap = df["CAP"].map(parse_cap)
     keep = mask_us & (price > min_price) & (cap >= min_cap_usd)
+    if min_factor_coverage > 0:
+        keep = keep & (_factor_coverage_count(df) >= min_factor_coverage)
     return sorted(df.loc[keep, "TKR"].dropna().astype(str).unique().tolist())
+
+
+def assemble_scored_universe(
+    etoro_csv_path: str,
+    holdings,
+    candidates,
+    *,
+    min_factor_coverage: int = MIN_FACTOR_COVERAGE,
+) -> list[str]:
+    """Scored universe = coverage-gated broad set  ∪  holdings  ∪  candidates.
+
+    Coverage-gating (>= ``min_factor_coverage`` of the panel-native factors) is the
+    PRIMARY selector, replacing the analyst AND-gate. ``holdings`` (current positions)
+    and ``candidates`` (analyst buy names) are ALWAYS included even below the
+    threshold — a held name is never dropped for thin data. De-duped; holdings first,
+    then candidates, then the coverage-gated names.
+    """
+    covered = load_universe(etoro_csv_path, min_factor_coverage=min_factor_coverage)
+    ordered = [*(str(t) for t in holdings), *(str(t) for t in candidates), *covered]
+    return list(dict.fromkeys(ordered))

--- a/trade_modules/v3/validate_spine.py
+++ b/trade_modules/v3/validate_spine.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import pandas as pd
 
+from trade_modules.v3.constants import V3_SIGNAL_HORIZON
 from trade_modules.v3.labels import cross_sectional_ic, demean_by_date, ic_summary
 from trade_modules.validation.harness import evaluate
 from trade_modules.validation.ic_decay import compute_ic_decay
@@ -115,6 +116,7 @@ def run_gate(
     ic_min: float = 0.02,
     t_min: float = 3.0,
     hit_min: float = 0.55,
+    primary_horizon: int = V3_SIGNAL_HORIZON,
     regime: dict | None = None,
 ) -> dict:
     """Run the price-spine gate: cross-sectional IC check + harness DSR.
@@ -122,7 +124,10 @@ def run_gate(
     Args:
         scores:   Long-form DataFrame with columns [as_of, ticker, score].
         fwd:      Long-form DataFrame with columns [as_of, ticker, horizon, fwd_ret].
-        horizons: List of forecast horizons (primary = horizons[0]).
+        horizons: List of forecast horizons to grade (the measurement grid).
+        primary_horizon: The horizon at which the IC screen AND the harness DSR
+            are graded (default V3_SIGNAL_HORIZON = 21). Falls back to the nearest
+            member of ``horizons`` when the exact value is absent.
         n_trials: Number of tuned trials for DSR deflation.
         min_obs:  Minimum observations required for the harness to consider a family
                   material.
@@ -135,6 +140,7 @@ def run_gate(
         Dict with keys:
           - ic:               {horizon: ic_summary_dict}
           - ic_decay:         compute_ic_decay result
+          - primary_horizon:  the horizon graded (member of ``horizons``)
           - harness:          raw evaluate() VerdictReport
           - primary_ic_pass:  bool — IC gate on primary horizon
           - dsr_pass:         bool — harness overall passed
@@ -147,10 +153,15 @@ def run_gate(
         n_trials=n_trials,
         min_obs=min_obs,
         horizons=tuple(horizons),
+        primary_horizon=primary_horizon,
     )
     ic = {h: ic_summary(cross_sectional_ic(scores, fwd, h)) for h in horizons}
     decay = compute_ic_decay({h: ic[h]["mean_ic"] for h in horizons})
-    ph = horizons[0]
+    ph = (
+        primary_horizon
+        if primary_horizon in horizons
+        else min(horizons, key=lambda h: abs(h - primary_horizon))
+    )
     primary_ic_pass = bool(
         ic[ph]["mean_ic"] >= ic_min and ic[ph]["t_stat"] >= t_min and ic[ph]["hit_rate"] >= hit_min
     )
@@ -158,6 +169,7 @@ def run_gate(
     return {
         "ic": ic,
         "ic_decay": decay,
+        "primary_horizon": ph,
         "harness": report,
         "primary_ic_pass": primary_ic_pass,
         "dsr_pass": dsr_pass,

--- a/trade_modules/validation/harness.py
+++ b/trade_modules/validation/harness.py
@@ -455,6 +455,7 @@ def evaluate(
     min_obs: int = 30,
     config_perf: np.ndarray | None = None,
     signal_score_col: str = "conviction",
+    primary_horizon: int = 30,
 ) -> dict:
     """Pure orchestrator — the validation referee.
 
@@ -481,6 +482,10 @@ def evaluate(
             ``computed=False`` and the rest of the report is unaffected.  NOTE:
             the row PRODUCER must emit this column for the block to populate —
             producer wiring is out of scope for Phase 2B.
+        primary_horizon: the single horizon (in the row ``horizon`` units) at
+            which each family is graded — Sharpe / DSR and the cross-sectional IC.
+            Defaults to 30 for v2 back-compat; the v3 path passes
+            V3_SIGNAL_HORIZON (21). Nearest present horizon is used if absent.
 
     action_records schema note: the live action_log.jsonl uses ``committee_date``
     (not ``date``) and ``size`` (not ``weight_change``); ``size`` is null in all
@@ -489,8 +494,6 @@ def evaluate(
 
     Returns a VerdictReport dict.  Never crashes.
     """
-    primary_horizon = 30
-
     # -----------------------------------------------------------------------
     # Survivorship bias accounting (over ALL rows)
     # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the agreed v3 factor-model redesign (decision ledger: `~/Downloads/202607180418_v3_decisions_ledger.md`) in two TDD phases on top of the daily-signals baseline. **12 commits, v3 test suite 409 green**, every commit pre-commit-clean (ruff / ruff-format / mypy / gitleaks). This PR **subsumes** the earlier `feat/v3-fix-now` branch (its 5 commits are the first 5 here).

## FIX-NOW batch (#11–#15) — zero-estimation combiner corrections
- factor-set rebuild (strength→analyst_mom, value→P/E + EV/EBITDA, quality→ROE + FCF)
- equal-risk cluster weights (removed the Value+Quality cap-as-floor)
- true equal-vol cluster standardization
- squeeze-exclude gate + distress filter on buy candidates
- owner-core attribution (share of book variance) + frozen trial register (D21/D23)

## BUILD tier
**Tier 0 — honest measurement**
- **①** one declared signal horizon (`V3_SIGNAL_HORIZON = 21td`) unifying IC logger / spine gate / harness; fixed a real defect (IC screened at h=5 while the DSR resolved to h=21). Shared `harness.evaluate()` stays **v2-byte-identical** (default `primary_horizon=30`).
- **②** fail-loud CSV integrity gate (`v3/integrity.py`) — corruption (not coverage) stops the pipeline; empirically grounded on the live panel.

**Tier 1 — the central defect + sector reality**
- **③** offline cache-backed sector resolution (`v3/sectors.py`, static-index > cache > live) — makes sector-neutral demean + sector caps real (the static map alone covers only ~14% of the universe, so the persistent cache is the fix).
- **④ coverage-gate universe** (`v3/universe.py`) — replaces the analyst AND-gate that scored only **106 names (3.2%)** and anti-selected momentum (ρ = −0.72). Now scores **2,580 names (≥6/7 panel factors)**; holdings/candidates are always included.

**⑥ — realism (liquidity / cost / benchmark)**
- **⑥a** tiered, copier-aware ADV liquidity gate (`v3/liquidity.py`) using v3's own `adv_usd` (no extra fetch).
- **⑥b** transaction-cost model (`v3/costs.py`, spread-by-tier + eToro financing).
- **⑥c** EUR-denominated S&P 500 benchmark (`v3/benchmark.py`, D25).

## Honest limits / deferred
- Coverage-gating cannot yet be OOS-*proven* to beat the analyst gate (forward IC ~3 days old); justified by removing a known bias + coverage quality + literature-prior. Forward IC accrues vs the frozen gate.
- Cost is **not** wired into rank-IC (Spearman IC is ~cost-invariant); the net-IR gate + action-level cost suppression (which would change live trading) are deferred, sign-off-required.
- Deferred: 6 secondary/study scripts not yet wired for offline sectors; core-Löwdin; **⑤** price store (survivorship/versioning); **⑦** build-vs-buy PIT.

## Test
- v3 suite: **409 passed**. Shared-harness change verified v2-back-compatible (71 harness/validation/edgegate tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)