### PR TITLE
feat(v3): BUILD ⑤ versioned append-only price store (survivorship fix)

### DIFF
--- a/scripts/v3_price_store_update.py
+++ b/scripts/v3_price_store_update.py
@@ -1,0 +1,42 @@
+"""BUILD ⑤ (2026-07-19): grow the versioned append-only price store.
+
+Fetches the current US universe's EUR adjusted closes and appends them to
+``trade_modules.v3.price_store`` (``~/.weirdapps-trading/v3_price_store.parquet``).
+Run daily (VPS / network allowed) so the store accumulates history AND retains the
+bars of names that later leave the universe — the survivorship fix a backtest needs.
+
+    .venv/bin/python scripts/v3_price_store_update.py
+
+No module-level yahoofinance.core.config import (lazy imports in main()).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+ETORO_CSV = "yahoofinance/output/etoro.csv"
+
+
+def main() -> None:
+    from trade_modules.v3.price_store import append_bars, store_coverage  # noqa: PLC0415
+    from trade_modules.v3.prices import load_eur_close  # noqa: PLC0415
+    from trade_modules.v3.universe import load_universe  # noqa: PLC0415
+
+    tickers = load_universe(ETORO_CSV)
+    print(f"universe: {len(tickers)} names")
+
+    eur = load_eur_close(tickers, period="5y")
+    added = append_bars(eur)
+    cov = store_coverage()
+    print(
+        f"appended {added} new bars -> store now {cov['n_rows']:,} rows, "
+        f"{cov['n_tickers']:,} tickers, {cov['n_dates']:,} dates "
+        f"({cov['first']} .. {cov['last']})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/trade_modules/test_v3_price_store.py
+++ b/tests/unit/trade_modules/test_v3_price_store.py
@@ -1,0 +1,95 @@
+"""TDD — BUILD ⑤ (2026-07-19): versioned, append-only price store (survivorship fix).
+
+The v3 spine live-fetches prices every run with no disk backing, and delisted names
+simply vanish from the universe -> full survivorship bias. This store keeps every
+bar it has ever seen (delisting retention) and refreshes same-(date,ticker) closes
+to the newest fetch (split/div adjustment changes history retroactively).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.v3.price_store import append_bars, read_close, store_coverage
+
+
+def _wide(dates, data):
+    return pd.DataFrame(data, index=pd.to_datetime(dates))
+
+
+def test_append_then_read_roundtrips(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    px = _wide(["2026-01-01", "2026-01-02"], {"AAA": [10.0, 11.0], "BBB": [20.0, 21.0]})
+    assert append_bars(px, store_path=store) == 4  # 4 new (date,ticker) pairs
+    out = read_close(["AAA", "BBB"], store_path=store)
+    assert out.loc["2026-01-02", "AAA"] == 11.0
+    assert out.loc["2026-01-01", "BBB"] == 20.0
+
+
+def test_append_is_additive_across_dates_and_tickers(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    append_bars(_wide(["2026-01-01"], {"AAA": [10.0]}), store_path=store)
+    append_bars(_wide(["2026-01-02"], {"AAA": [11.0], "CCC": [30.0]}), store_path=store)
+    out = read_close(["AAA", "CCC"], store_path=store)
+    assert out.loc["2026-01-01", "AAA"] == 10.0  # old date retained
+    assert out.loc["2026-01-02", "CCC"] == 30.0  # new ticker added
+
+
+def test_delisting_retention(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    append_bars(_wide(["2026-01-01"], {"AAA": [10.0], "BBB": [20.0]}), store_path=store)
+    # Next run: BBB has left the universe (delisted) — only AAA fetched.
+    append_bars(_wide(["2026-01-02"], {"AAA": [11.0]}), store_path=store)
+    out = read_close(["AAA", "BBB"], store_path=store)
+    assert out.loc["2026-01-01", "BBB"] == 20.0  # delisted name's bar survives
+
+
+def test_newest_wins_on_same_key(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    append_bars(_wide(["2026-01-01"], {"AAA": [10.0]}), store_path=store)
+    n = append_bars(_wide(["2026-01-01"], {"AAA": [10.5]}), store_path=store)  # adjustment refresh
+    assert n == 0  # no NEW (date,ticker) pair
+    out = read_close(["AAA"], store_path=store)
+    assert out.loc["2026-01-01", "AAA"] == 10.5  # refreshed to newest
+
+
+def test_long_format_input_accepted(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    long = pd.DataFrame(
+        {"date": ["2026-01-01", "2026-01-01"], "ticker": ["AAA", "BBB"], "close": [10.0, 20.0]}
+    )
+    assert append_bars(long, store_path=store) == 2
+    assert read_close(["AAA"], store_path=store).loc["2026-01-01", "AAA"] == 10.0
+
+
+def test_read_missing_ticker_and_empty_store(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    assert read_close(["AAA"], store_path=store).empty  # store does not exist yet
+    append_bars(_wide(["2026-01-01"], {"AAA": [10.0]}), store_path=store)
+    assert read_close(["ZZZ"], store_path=store).empty  # ticker absent
+
+
+def test_append_empty_is_noop(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    assert append_bars(pd.DataFrame(), store_path=store) == 0
+    assert store_coverage(store_path=store)["n_rows"] == 0
+
+
+def test_store_coverage(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    append_bars(
+        _wide(["2026-01-01", "2026-01-02"], {"AAA": [10.0, 11.0], "BBB": [20.0, 21.0]}),
+        store_path=store,
+    )
+    cov = store_coverage(store_path=store)
+    assert cov["n_tickers"] == 2
+    assert cov["n_dates"] == 2
+    assert cov["n_rows"] == 4
+    assert cov["first"] == "2026-01-01" and cov["last"] == "2026-01-02"
+
+
+def test_nan_closes_dropped(tmp_path):
+    store = str(tmp_path / "s.parquet")
+    append_bars(_wide(["2026-01-01"], {"AAA": [10.0], "BBB": [float("nan")]}), store_path=store)
+    assert read_close(["BBB"], store_path=store).empty  # NaN close not stored
+    assert read_close(["AAA"], store_path=store).loc["2026-01-01", "AAA"] == 10.0

--- a/trade_modules/v3/price_store.py
+++ b/trade_modules/v3/price_store.py
@@ -1,0 +1,119 @@
+"""BUILD ⑤ (2026-07-19): versioned, append-only price store (survivorship fix).
+
+The v3 spine live-fetches prices every run with no disk backing, and a name that
+leaves ``etoro.csv`` simply vanishes -> full survivorship bias (BUY/HOLD biased up,
+SELL biased down). This store keeps every bar it has ever seen (delisting
+retention) so a backtest can price names that have since left the universe, and it
+refreshes same-``(date, ticker)`` closes to the newest fetch because split/dividend
+adjustment rewrites history retroactively.
+
+Storage: a single long-format parquet at ``~/.weirdapps-trading/v3_price_store.parquet``
+with columns ``date, ticker, close`` (adjusted close, EUR or USD per the caller).
+Append-only in that rows are never DROPPED; a conflicting ``(date, ticker)`` is
+UPDATED to the newest close.
+
+Deferred follow-ups (documented, not built here): git-history backward-seed of
+already-delisted tickers from ``etoro.csv`` history; wiring the store as the spine's
+read source; and the price-only sleeve re-validation (data-limited — Phase-1's naive
+spine showed no standalone edge).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+STORE_PATH: str = str(Path("~/.weirdapps-trading/v3_price_store.parquet").expanduser())
+_COLS = ["date", "ticker", "close"]
+
+
+def _to_long(prices: pd.DataFrame) -> pd.DataFrame:
+    """Normalise a wide (dates x tickers close) OR long (date, ticker, close) frame
+    to canonical long form with string dates and numeric closes; NaN closes dropped."""
+    if prices is None or len(prices) == 0:
+        return pd.DataFrame(columns=_COLS)
+    if set(_COLS).issubset(prices.columns):
+        out = prices[_COLS].copy()
+    else:  # wide: index = dates, columns = tickers
+        wide = prices.copy()
+        wide.index = pd.to_datetime(wide.index)
+        wide.index.name = "date"
+        out = wide.reset_index().melt(id_vars="date", var_name="ticker", value_name="close")
+    out["date"] = pd.to_datetime(out["date"]).dt.strftime("%Y-%m-%d")
+    out["ticker"] = out["ticker"].astype(str)
+    out["close"] = pd.to_numeric(out["close"], errors="coerce")
+    return out.dropna(subset=["close"])[_COLS]
+
+
+def _read_store(store_path: str) -> pd.DataFrame:
+    p = Path(store_path).expanduser()
+    if not p.exists():
+        return pd.DataFrame(columns=_COLS)
+    try:
+        return pd.read_parquet(p)[_COLS]
+    except Exception:  # noqa: BLE001 - a corrupt store must not crash the pipeline
+        return pd.DataFrame(columns=_COLS)
+
+
+def append_bars(prices: pd.DataFrame, *, store_path: str = STORE_PATH) -> int:
+    """Merge ``prices`` (wide or long) into the append-only store.
+
+    Existing ``(date, ticker)`` rows are refreshed to the newest close; no row is
+    ever dropped (delisting retention). Returns the number of NEW ``(date, ticker)``
+    pairs added (refreshes of existing pairs are not counted).
+    """
+    new = _to_long(prices)
+    if new.empty:
+        return 0
+    existing = _read_store(store_path)
+    existing_keys = (
+        set(zip(existing["date"], existing["ticker"], strict=False))
+        if not existing.empty
+        else set()
+    )
+    added = len({(d, t) for d, t in zip(new["date"], new["ticker"], strict=False)} - existing_keys)
+
+    combined = pd.concat([existing, new], ignore_index=True)
+    # Newest-wins on (date, ticker): `new` is concatenated last, so keep="last".
+    combined = combined.drop_duplicates(subset=["date", "ticker"], keep="last").sort_values(
+        ["date", "ticker"]
+    )
+    p = Path(store_path).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    combined.to_parquet(p, index=False)
+    return added
+
+
+def read_close(tickers, *, store_path: str = STORE_PATH, start=None, end=None) -> pd.DataFrame:
+    """Wide dates x tickers adjusted-close frame for ``tickers`` — delisted names
+    included (their bars persist). Empty frame if the store or the selection is empty."""
+    store = _read_store(store_path)
+    if store.empty:
+        return pd.DataFrame()
+    want = {str(t) for t in tickers}
+    sub = store[store["ticker"].isin(want)]
+    if start is not None:
+        sub = sub[sub["date"] >= str(start)]
+    if end is not None:
+        sub = sub[sub["date"] <= str(end)]
+    if sub.empty:
+        return pd.DataFrame()
+    wide = sub.pivot_table(index="date", columns="ticker", values="close", aggfunc="last")
+    wide.index = pd.to_datetime(wide.index)
+    return wide.sort_index()
+
+
+def store_coverage(store_path: str = STORE_PATH) -> dict:
+    """Diagnostics: row / ticker / date counts and the stored date range."""
+    store = _read_store(store_path)
+    if store.empty:
+        return {"n_rows": 0, "n_tickers": 0, "n_dates": 0, "first": None, "last": None}
+    dates = store["date"]
+    return {
+        "n_rows": int(len(store)),
+        "n_tickers": int(store["ticker"].nunique()),
+        "n_dates": int(dates.nunique()),
+        "first": str(dates.min()),
+        "last": str(dates.max()),
+    }


### PR DESCRIPTION
## Summary
BUILD tier ⑤. The v3 spine live-fetches prices with no disk backing and drops names that leave `etoro.csv` → full survivorship bias. Adds a **versioned, append-only price store** — purely additive (no existing production path changed).

- **`trade_modules/v3/price_store.py`** — `append_bars` (wide|long → long parquet; newest-wins on adjustment refresh; **never drops rows = delisting retention**), `read_close` (wide, delisted names included), `store_coverage`.
- **`scripts/v3_price_store_update.py`** — daily updater (universe → EUR closes → append) that grows the store and retains the bars of names that later delist.

## Deferred (documented in the module docstring)
git-history backward-seed of already-delisted tickers; wiring the store as the spine's read source; price-only sleeve re-validation (data-limited — Phase-1 naive spine showed no standalone edge).

## Test
9 new tests; full v3 suite **418 green**; pre-commit clean (ruff / ruff-format / mypy / gitleaks). Additive-only: no existing module imports the new code, so the broader suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)