### PR TITLE
feat(v3): two-stage scoring — bound enrichment cost for production runtime

### DIFF
--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -258,27 +258,29 @@ def _read_tickers(path: str) -> list[str]:
 def main() -> None:
     # Lazy imports: avoid module-level yahoofinance.core.config import.
     from trade_modules.v3.combine import compute_scores  # noqa: PLC0415
+    from trade_modules.v3.constants import MIN_FACTOR_COVERAGE  # noqa: PLC0415
+    from trade_modules.v3.enrichment import select_enrichment_set  # noqa: PLC0415
     from trade_modules.v3.features import enrich_features  # noqa: PLC0415
     from trade_modules.v3.sectors import (  # noqa: PLC0415
         load_offline_sector_map,
         update_sector_cache,
     )
-    from trade_modules.v3.universe import assemble_scored_universe  # noqa: PLC0415
+    from trade_modules.v3.universe import load_universe  # noqa: PLC0415
 
-    # --- Universe assembly (mirrors v3_full_report.py exactly) ---
+    # --- Universe: two-stage scoring (pre-rank full coverage universe, enrich top slice) ---
     port = _read_tickers(PORTFOLIO_CSV)
     buy = _read_tickers(BUY_CSV)
     port_set = set(port)
-    # BUILD ④: coverage-gated broad universe ∪ holdings ∪ analyst candidates,
-    # replacing the analyst AND-gate (which scored only ~3% of the universe).
-    universe = assemble_scored_universe(ETORO_CSV, port, buy)
+    sector_map = load_offline_sector_map()
+    cap = int(os.environ.get("V3_ENRICH_CAP", "500"))
+    pool = load_universe(ETORO_CSV, min_factor_coverage=MIN_FACTOR_COVERAGE)
+    universe = select_enrichment_set(ETORO_CSV, port, buy, cap=cap, sector_map=sector_map)
     print(
-        f"universe: {len(universe)} tickers (coverage-gated ∪ {len(port_set)} held "
-        f"∪ {len(set(buy) - port_set)} analyst candidates)"
+        f"universe: pre-ranked {len(pool)} coverage names -> enriching {len(universe)} "
+        f"({len(port_set)} held + {len(set(buy) - port_set)} analyst candidates + top coverage)"
     )
 
     # --- Feature enrichment + scoring ---
-    sector_map = load_offline_sector_map()
     feats = enrich_features(
         universe,
         ETORO_CSV,

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -87,6 +87,7 @@ _REGION_CAP = float(os.environ.get("V3_REGION_CAP", "0.65"))
 _COPIER_MULT = float(
     os.environ.get("V3_COPIER_MULT", "1.0")
 )  # scales the tier ADV floor for a copied book
+_ENRICH_CAP = int(os.environ.get("V3_ENRICH_CAP", "500"))  # max names to fully enrich (two-stage)
 # Polymarket deployment dial. The signal is a shadow / ZERO-conviction cross-repo
 # input, so the book-moving tilt is OFF by default (V3_PM_MAX_TILT=0 -> advisory
 # only: the signal is fetched + shown in the report but does not move deployment).
@@ -452,23 +453,27 @@ def write_preview(out: str = PREVIEW_OUT) -> str:
 
 
 def main() -> None:
-    # --- Universe assembly: coverage-gated ∪ holdings ∪ analyst candidates (BUILD ④) ---
-    from trade_modules.v3.universe import assemble_scored_universe
+    # --- Universe: two-stage scoring (BUILD ④ + production runtime) ---
+    from trade_modules.v3.constants import MIN_FACTOR_COVERAGE
+    from trade_modules.v3.enrichment import select_enrichment_set
+    from trade_modules.v3.sectors import load_offline_sector_map, update_sector_cache
+    from trade_modules.v3.universe import load_universe
 
     port = _read_tickers(PORTFOLIO_CSV)
     buy = _read_tickers(BUY_CSV)
     port_set = set(port)
-    # Coverage-gated broad universe replaces the analyst AND-gate (which scored ~3%).
-    universe = assemble_scored_universe(ETORO_CSV, port, buy)
+    sector_map = load_offline_sector_map()
+    # Pre-rank the FULL coverage-gated universe network-free, then fully enrich only
+    # holdings + candidates + top coverage names — bounds the ~4s/name yfinance .info
+    # cost (a full ~2,580-name enrich would be ~3h).
+    pool = load_universe(ETORO_CSV, min_factor_coverage=MIN_FACTOR_COVERAGE)
+    universe = select_enrichment_set(ETORO_CSV, port, buy, cap=_ENRICH_CAP, sector_map=sector_map)
     print(
-        f"universe: {len(universe)} tickers (coverage-gated ∪ {len(port_set)} held "
-        f"∪ {len(set(buy) - port_set)} analyst candidates)"
+        f"universe: pre-ranked {len(pool)} coverage names -> enriching {len(universe)} "
+        f"({len(port_set)} held + {len(set(buy) - port_set)} analyst candidates + top coverage)"
     )
 
     # --- Feature enrichment + scoring with BALANCED cluster weights ---
-    from trade_modules.v3.sectors import load_offline_sector_map, update_sector_cache
-
-    sector_map = load_offline_sector_map()
     feats = enrich_features(
         universe,
         ETORO_CSV,

--- a/tests/unit/trade_modules/test_v3_enrichment.py
+++ b/tests/unit/trade_modules/test_v3_enrichment.py
@@ -1,0 +1,117 @@
+"""TDD — two-stage scoring (2026-07-19): bound the yfinance enrichment cost.
+
+panel_prescore ranks the full coverage universe network-free; select_enrichment_set
+returns holdings + candidates + top coverage names, bounded by cap — so a run enriches
+~old-report scale instead of ~2,580 names (~3h).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.v3.enrichment import panel_prescore, select_enrichment_set
+
+# Strong -> weak on the panel factors (low PE / high ROE,FCF,52W,AM,EG / low beta = good).
+_ROWS = [
+    {
+        "TKR": "AAA",
+        "PRC": "10",
+        "CAP": "1B",
+        "PET": "8",
+        "ROE": "30",
+        "FCF": "12",
+        "52W": "95",
+        "B": "0.7",
+        "AM": "8",
+        "EG": "20",
+    },
+    {
+        "TKR": "BBB",
+        "PRC": "10",
+        "CAP": "1B",
+        "PET": "15",
+        "ROE": "12",
+        "FCF": "3",
+        "52W": "60",
+        "B": "1.0",
+        "AM": "0",
+        "EG": "5",
+    },
+    {
+        "TKR": "DDD",
+        "PRC": "10",
+        "CAP": "1B",
+        "PET": "20",
+        "ROE": "8",
+        "FCF": "1",
+        "52W": "50",
+        "B": "1.2",
+        "AM": "-2",
+        "EG": "2",
+    },
+    {
+        "TKR": "CCC",
+        "PRC": "10",
+        "CAP": "1B",
+        "PET": "40",
+        "ROE": "2",
+        "FCF": "-5",
+        "52W": "20",
+        "B": "1.6",
+        "AM": "-8",
+        "EG": "-10",
+    },
+]
+
+
+def _panel(tmp_path):
+    cols = ["TKR", "NAME", "CAP", "PRC", "PET", "ROE", "FCF", "52W", "B", "AM", "EG"]
+    rows = [{**r, "NAME": r["TKR"] + " Corp"} for r in _ROWS]
+    df = pd.DataFrame(rows)
+    for c in cols:
+        if c not in df.columns:
+            df[c] = ""
+    p = tmp_path / "etoro.csv"
+    df[cols].to_csv(p, index=False)
+    return str(p)
+
+
+def test_panel_prescore_ranks_strong_above_weak(tmp_path):
+    csv = _panel(tmp_path)
+    from trade_modules.v3.universe import load_universe
+
+    uni = load_universe(csv, min_factor_coverage=6)
+    ps = panel_prescore(csv, uni)
+    assert ps["AAA"] > ps["CCC"]  # strong panel factors outrank weak
+    assert ps["AAA"] > ps["DDD"]
+    assert ps.notna().sum() >= 3  # network-free, still produces a usable ranking
+
+
+def test_select_enrichment_set_always_includes_holdings(tmp_path):
+    csv = _panel(tmp_path)
+    # CCC is the weakest name but is HELD -> must be enriched regardless of pre-score.
+    out = select_enrichment_set(csv, holdings=["CCC"], candidates=[], cap=2, sector_map=None)
+    assert "CCC" in out  # held name never dropped
+    assert "AAA" in out  # top pre-score fills the remaining slot
+    assert len(out) <= 2
+
+
+def test_select_enrichment_set_respects_cap_and_fills_with_top(tmp_path):
+    csv = _panel(tmp_path)
+    out = select_enrichment_set(csv, holdings=[], candidates=[], cap=2, sector_map=None)
+    assert len(out) == 2
+    assert out[0] == "AAA"  # highest pre-score first
+    assert "CCC" not in out  # weakest excluded when over cap
+
+
+def test_select_enrichment_set_candidates_included(tmp_path):
+    csv = _panel(tmp_path)
+    out = select_enrichment_set(csv, holdings=[], candidates=["DDD"], cap=3, sector_map=None)
+    assert "DDD" in out  # analyst candidate kept through the transition
+    assert len(out) <= 3
+
+
+def test_select_enrichment_set_dedup(tmp_path):
+    csv = _panel(tmp_path)
+    out = select_enrichment_set(csv, holdings=["AAA"], candidates=["AAA"], cap=4, sector_map=None)
+    assert out.count("AAA") == 1  # de-duped across holdings/candidates/top

--- a/trade_modules/v3/enrichment.py
+++ b/trade_modules/v3/enrichment.py
@@ -1,0 +1,82 @@
+"""BUILD (2026-07-19): two-stage scoring — bound the yfinance enrichment cost.
+
+④ expanded the scored universe ~25x (~2,580 names), but ``enrich_features`` fetches
+per-ticker yfinance ``.info`` (~4s each) -> a full-universe run is ~3 hours and
+throttle-prone: not production-viable.
+
+Two-stage fix:
+  1. ``panel_prescore`` — score the FULL coverage-gated universe on the panel-native
+     factors only (PET/ROE/FCF/52W/B/AM/EG + offline sector), NO network (~0.3s).
+     Conviction itself is eligibility-gated (needs price history), so we rank by the
+     weighted cluster-z mean, which is populated for every name.
+  2. ``select_enrichment_set`` — full-enrich (yfinance .info + prices) only holdings +
+     analyst candidates + the top coverage names by pre-score, bounded by ``cap``.
+
+This keeps ④'s selection BREADTH (the pre-rank sees all 2,580, so momentum names the
+old analyst gate excluded can surface) while restoring old-report runtime.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from trade_modules.v3.combine import CLUSTER_WEIGHTS, CLUSTERS, compute_scores
+from trade_modules.v3.constants import MIN_FACTOR_COVERAGE
+from trade_modules.v3.features import enrich_features
+from trade_modules.v3.universe import load_universe
+
+
+def panel_prescore(etoro_csv_path, universe, sector_map=None) -> pd.Series:
+    """Cheap, network-free panel-only conviction proxy for ranking.
+
+    Enriches ``universe`` with NO-OP info/price/accruals fetchers (panel-native
+    factors + offline sector only), then returns the per-ticker weighted mean of the
+    six cluster-z columns (``CLUSTER_WEIGHTS``, renormalized per-row over the clusters
+    present). Higher = stronger on the panel factors. NaN where no cluster is present.
+    """
+    feats = enrich_features(
+        universe,
+        etoro_csv_path,
+        info_fetch=lambda _ts: {},
+        price_fetch=lambda _ts, period="2y", **_k: pd.DataFrame(),
+        accruals_fetch=lambda _ts: {},
+        sector_map=sector_map,
+    )
+    scored = compute_scores(feats, sector_neutral=True)
+    cluster_names = list(CLUSTERS.keys())
+    zmat = scored[cluster_names]
+    w = pd.Series(CLUSTER_WEIGHTS)[cluster_names]
+    wmat = pd.DataFrame(
+        np.tile(w.to_numpy(), (len(zmat), 1)), index=zmat.index, columns=cluster_names
+    ).where(zmat.notna())
+    wsum = wmat.sum(axis=1)
+    return (zmat * wmat).sum(axis=1) / wsum.where(wsum > 0)
+
+
+def select_enrichment_set(
+    etoro_csv_path,
+    holdings,
+    candidates,
+    *,
+    cap: int = 500,
+    sector_map=None,
+    min_factor_coverage: int = MIN_FACTOR_COVERAGE,
+) -> list[str]:
+    """Bounded set to fully enrich: holdings + candidates + top coverage names.
+
+    ``holdings`` and ``candidates`` are ALWAYS included (held names are never dropped;
+    analyst candidates kept through the transition). Remaining budget up to ``cap`` is
+    filled with the highest panel-pre-score names from the coverage-gated universe.
+    De-duped; holdings/candidates first, then top coverage names.
+    """
+    universe = load_universe(etoro_csv_path, min_factor_coverage=min_factor_coverage)
+    always = list(dict.fromkeys([str(t) for t in holdings] + [str(t) for t in candidates]))
+    always_up = {t.upper() for t in always}
+
+    prescore = panel_prescore(etoro_csv_path, universe, sector_map=sector_map)
+    ranked = [str(t) for t in prescore.dropna().sort_values(ascending=False).index]
+    top = [t for t in ranked if t.upper() not in always_up]
+
+    slots = max(0, int(cap) - len(always))
+    return list(dict.fromkeys(always + top[:slots]))


### PR DESCRIPTION
## Summary
Production-readiness fix. ④ expanded the scored universe ~25× (~2,580 names), but `enrich_features` fetches per-ticker yfinance `.info` (~4s each) → a full-universe run is **~3 hours** and throttle-prone.

**Two-stage scoring:**
- `trade_modules/v3/enrichment.py` — `panel_prescore` (network-free weighted cluster-z rank over the FULL coverage-gated universe, ~0.3s) + `select_enrichment_set` (holdings + candidates + top coverage names by pre-score, capped at `V3_ENRICH_CAP=500`).
- Wired `v3_overlay_report` + `v3_ic_logger`: pre-rank all coverage names, then fully enrich only the bounded top slice.

Preserves ④'s selection breadth (the pre-rank sees all 2,580, so momentum names the analyst gate excluded can still surface) while restoring ~old-report runtime.

## Test
5 new tests; v3 suite **423 green**; pre-commit clean. Both scorers import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)