### PR TITLE
feat(v3): global coverage universe (drop US-only Phase-1 leftover)

### DIFF
--- a/tests/unit/trade_modules/test_v3_universe.py
+++ b/tests/unit/trade_modules/test_v3_universe.py
@@ -10,7 +10,7 @@ def test_parse_cap_suffixes():
     assert pd.isna(parse_cap("--"))
 
 
-def test_load_universe_filters(tmp_path):
+def test_load_universe_us_only_filter(tmp_path):
     csv = tmp_path / "etoro.csv"
     pd.DataFrame(
         {
@@ -19,8 +19,23 @@ def test_load_universe_filters(tmp_path):
             "CAP": ["3.5T", "10B", "100M", "40T", "2.5T"],
         }
     ).to_csv(csv, index=False)
+    u = load_universe(str(csv), min_price=1.0, min_cap_usd=5e8, us_only=True)
+    assert u == ["AAPL", "MSFT"]  # PENNY (price), SMALL (cap), 7203.T (non-US) excluded
+
+
+def test_load_universe_global_includes_non_us_fx_normalized(tmp_path):
+    csv = tmp_path / "etoro.csv"
+    pd.DataFrame(
+        {
+            "TKR": ["AAPL", "PENNY", "SMALL", "7203.T", "MSFT"],
+            "PRC": [200.0, 0.5, 50.0, 3000.0, 400.0],
+            "CAP": ["3.5T", "10B", "100M", "40T", "2.5T"],
+        }
+    ).to_csv(csv, index=False)
+    # Global default: 7203.T (¥40T≈$268B, ¥3000≈$20) clears the FX-normalized floors;
+    # PENNY ($0.50) and SMALL ($100M) still excluded. Legacy US behaviour is us_only=True.
     u = load_universe(str(csv), min_price=1.0, min_cap_usd=5e8)
-    assert u == ["AAPL", "MSFT"]  # PENNY (price), SMALL (cap), 7203.T (non-USD) excluded
+    assert set(u) == {"AAPL", "MSFT", "7203.T"}
 
 
 # ---------------------------------------------------------------------------

--- a/trade_modules/v3/universe.py
+++ b/trade_modules/v3/universe.py
@@ -48,12 +48,19 @@ def load_universe(
     min_price: float = 1.0,
     min_cap_usd: float = 5e8,
     min_factor_coverage: int = 0,
+    us_only: bool = False,
 ) -> list[str]:
-    """US, cap/price-filtered ticker list; optionally coverage-gated.
+    """Cap/price-filtered ticker list — GLOBAL by default (multi-currency book).
 
-    ``min_factor_coverage`` > 0 additionally keeps only names with at least that
-    many of the panel-native factors (``COVERAGE_FACTORS``) present — the BUILD ④
-    replacement for the analyst AND-gate. 0 (default) leaves the gate off.
+    eToro reports CAP and PRC in the listing's LOCAL currency, so cap and price are
+    FX-normalized to USD (``_usd_rate_for``) before the ``$500M`` / ``$1`` floors are
+    applied — otherwise a ¥ or HK$ value would be mis-compared against a USD floor.
+    For US listings the rate is 1.0, so their behaviour is unchanged.
+
+    Args:
+        us_only: restore the legacy US-listings-only filter (no exchange suffix).
+        min_factor_coverage: > 0 keeps only names with that many panel-native factors
+            present (``COVERAGE_FACTORS``) — the BUILD ④ coverage gate.
     """
     df = pd.read_csv(etoro_csv_path, na_values=["--"])
     df = validate_panel(
@@ -62,11 +69,17 @@ def load_universe(
         required_columns=("TKR", "PRC", "CAP"),
         required_numeric=("PRC",),
     )
+    # Lazy import: features imports universe (parse_cap), so importing it at module
+    # load would cycle; at call time features is already resolved.
+    from trade_modules.v3.features import _usd_rate_for
+
     tkr = df["TKR"].astype(str)
-    mask_us = tkr.str.match(US_TICKER)
-    price = pd.to_numeric(df["PRC"], errors="coerce")
-    cap = df["CAP"].map(parse_cap)
-    keep = mask_us & (price > min_price) & (cap >= min_cap_usd)
+    fx = tkr.map(_usd_rate_for)  # local currency -> USD (1.0 for US listings)
+    price_usd = pd.to_numeric(df["PRC"], errors="coerce") * fx
+    cap_usd = df["CAP"].map(parse_cap) * fx
+    keep = (price_usd > min_price) & (cap_usd >= min_cap_usd)
+    if us_only:
+        keep = keep & tkr.str.match(US_TICKER)
     if min_factor_coverage > 0:
         keep = keep & (_factor_coverage_count(df) >= min_factor_coverage)
     return sorted(df.loc[keep, "TKR"].dropna().astype(str).unique().tolist())


### PR DESCRIPTION
## Summary
The US-only universe filter (`US_TICKER = ^[A-Z]+$`) was a **Phase-1 price-spine validation scoping** (commit `067b6e5b`, "USD sub-universe") that leaked into the production universe. But the live book is **~21% non-US by NAV** and `buy.csv` candidates are **52% non-US** — so a US-only new-idea engine is wrong for this globally-diversified, EUR-home book.

- `load_universe`: **FX-normalize cap + price to USD** (`_usd_rate_for`) before the $500M / $1 floors, so they're single-currency across exchanges. `us_only` kept as an option; **default is now global**. US listings unchanged (rate 1.0).
- Global coverage ≥6/7 = **4,299 names** (2,580 US + 1,719 non-US). The two-stage enrichment still caps at 500, so runtime holds.
- Non-US sector resolves via live yfinance + the growing cache (③); region / USD-bloc caps already constrain geographic concentration.

## Test
Universe tests split into `us_only` + global cases; v3 suite **424 green**; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)