### PR TITLE
feat(v3): per-parameter alpha backtest wiring (panel-history + per-cluster logging)

### DIFF
--- a/scripts/v3_factor_backtest.py
+++ b/scripts/v3_factor_backtest.py
@@ -1,0 +1,234 @@
+"""Panel-history per-factor alpha backtest.
+
+Reconstructs the etoro.csv panel from its git history (a de-facto point-in-time
+panel, committed daily), computes each factor's directional cross-sectional rank-z
+per weekly snapshot, and measures forward IC (Spearman, at V3_SIGNAL_HORIZON) per
+FACTOR and per CLUSTER — including the DISCARDED panel factors so the discard
+decisions can be validated. Forward returns come from EUR-adjusted prices.
+
+    .venv/bin/python scripts/v3_factor_backtest.py
+
+Writes ~/Downloads/<UTCstamp>_v3_factor_backtest.html + prints a ranked table.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from trade_modules.v3.combine import CLUSTERS, DIRECTION, _rank_z, _sector_demean  # noqa: E402
+from trade_modules.v3.factor_backtest import (  # noqa: E402
+    BACKTEST_PANEL_FACTORS,
+    factor_zscore,
+    forward_return_at,
+    is_active,
+)
+from trade_modules.validation.xsection_ic import cross_sectional_ic  # noqa: E402
+
+ETORO = "yahoofinance/output/etoro.csv"
+HORIZON = 21  # V3_SIGNAL_HORIZON (trading days)
+
+
+def git_snapshots(path: str, weekly: bool = True) -> list[tuple[str, str]]:
+    out = subprocess.run(
+        ["git", "log", "--format=%H|%cI", "--", path], capture_output=True, text=True
+    ).stdout
+    snaps = [(c, d[:10]) for c, d in (ln.split("|") for ln in out.splitlines() if "|" in ln)]
+    if weekly:  # keep one (the newest) commit per ISO week
+        seen: set = set()
+        keep = []
+        for c, d in snaps:  # newest-first
+            wk = datetime.fromisoformat(d).isocalendar()[:2]
+            if wk not in seen:
+                seen.add(wk)
+                keep.append((c, d))
+        snaps = keep
+    return list(reversed(snaps))  # oldest-first
+
+
+def load_panel_at(commit: str, path: str) -> pd.DataFrame | None:
+    txt = subprocess.run(["git", "show", f"{commit}:{path}"], capture_output=True, text=True).stdout
+    if not txt.strip():
+        return None
+    df = pd.read_csv(io.StringIO(txt), na_values=["--"])
+    if "TKR" not in df.columns:
+        return None
+    return df.dropna(subset=["TKR"]).drop_duplicates("TKR").set_index("TKR")
+
+
+def main() -> None:
+    from trade_modules.v3.prices import load_eur_close
+    from trade_modules.v3.sectors import load_offline_sector_map
+    from trade_modules.v3.universe import load_universe
+
+    snaps = git_snapshots(ETORO)
+    print(f"weekly snapshots: {len(snaps)}  ({snaps[0][1]} .. {snaps[-1][1]})")
+
+    universe = set(load_universe(ETORO, min_factor_coverage=6))  # global coverage names
+    print(f"backtest universe (global coverage ≥6/7): {len(universe)}")
+    px = load_eur_close(sorted(universe), period="1y")
+    print(f"priced (EUR): {px.shape[1]} names, {px.shape[0]} bars")
+    sector_map = load_offline_sector_map()
+    pidx = px.index
+
+    factors = dict(BACKTEST_PANEL_FACTORS)  # feature-name set (panel) + derived below
+    parts: dict[str, list[pd.DataFrame]] = {f: [] for f in set(factors.values())}
+    parts["mom_12_1"] = []
+    parts["realized_vol"] = []
+    cluster_parts: dict[str, list[pd.DataFrame]] = {c: [] for c in CLUSTERS}
+
+    n_used = 0
+    for commit, date in snaps:
+        panel = load_panel_at(commit, ETORO)
+        if panel is None:
+            continue
+        panel = panel[panel.index.astype(str).isin(universe)]
+        if panel.empty:
+            continue
+        mask = pidx <= pd.Timestamp(date)
+        if not mask.any():
+            continue
+        asof = pidx[mask].max()
+        fwd = forward_return_at(px, asof, HORIZON)
+        if fwd.empty:
+            continue
+        n_used += 1
+        sec = pd.Series({t: sector_map.get(str(t).upper()) for t in panel.index}, index=panel.index)
+
+        zcols: dict[str, pd.Series] = {}
+        for col, feat in BACKTEST_PANEL_FACTORS.items():
+            if col not in panel.columns:
+                continue
+            z = factor_zscore(panel[col], feat, sector=sec, sector_neutral=True)
+            zcols[feat] = z
+            part = pd.DataFrame({"date": date, "z": z, "fwd": fwd.reindex(z.index)}).dropna()
+            if len(part):
+                parts[feat].append(part.reset_index(names="ticker"))
+
+        # price-derived momentum (12-1) + realized vol, PIT from the price matrix
+        i = pidx.get_loc(asof)
+        if i >= 252:
+            mom = (px.iloc[i - 21] / px.iloc[i - 252]) - 1.0
+            vol = px.iloc[i - 252 : i + 1].pct_change(fill_method=None).std() * (252**0.5)
+            for feat, val in (("mom_12_1", mom), ("realized_vol", vol)):
+                z = _rank_z(val) * DIRECTION[feat]
+                z = _sector_demean(z, sec.reindex(z.index))
+                zcols[feat] = z
+                part = pd.DataFrame({"date": date, "z": z, "fwd": fwd.reindex(z.index)}).dropna()
+                if len(part):
+                    parts[feat].append(part.reset_index(names="ticker"))
+
+        # per-cluster z = mean of member factor-z present this snapshot
+        for cluster, members in CLUSTERS.items():
+            present = [zcols[m] for m in members if m in zcols]
+            if not present:
+                continue
+            cz = pd.concat(present, axis=1).mean(axis=1, skipna=True)
+            part = pd.DataFrame({"date": date, "z": cz, "fwd": fwd.reindex(cz.index)}).dropna()
+            if len(part):
+                cluster_parts[cluster].append(part.reset_index(names="ticker"))
+
+    print(f"snapshots used (with forward data): {n_used}")
+
+    def ic_rows(store: dict, kind: str) -> list[dict]:
+        rows = []
+        for name, plist in store.items():
+            if not plist:
+                continue
+            d = pd.concat(plist, ignore_index=True)
+            ic = cross_sectional_ic(d, "z", "fwd", date_col="date")
+            rows.append(
+                {
+                    "name": name,
+                    "kind": kind,
+                    "active": is_active(name) if kind == "factor" else True,
+                    "mean_ic": ic.get("mean_ic"),
+                    "t_stat": ic.get("t_stat"),
+                    "hit_rate": ic.get("hit_rate"),
+                    "n_dates": ic.get("n_dates"),
+                    "n_obs": len(d),
+                }
+            )
+        return rows
+
+    fac = sorted(ic_rows(parts, "factor"), key=lambda r: r["mean_ic"] or -9, reverse=True)
+    clu = sorted(ic_rows(cluster_parts, "cluster"), key=lambda r: r["mean_ic"] or -9, reverse=True)
+
+    _print(clu, "CLUSTERS")
+    _print(fac, "FACTORS")
+    out = _render(fac, clu, n_used, len(universe), px.shape[1], snaps)
+    print(f"\nreport -> {out}")
+
+
+def _print(rows: list[dict], title: str) -> None:
+    print(f"\n=== {title} (forward IC @ {HORIZON}td) ===")
+    print(f"{'name':16} {'act':>3} {'meanIC':>8} {'t':>6} {'hit':>6} {'dates':>5} {'obs':>7}")
+    for r in rows:
+        act = "" if r["kind"] == "cluster" else ("A" if r["active"] else "·")
+        print(
+            f"{r['name']:16} {act:>3} {(_f(r['mean_ic'])):>8} {_f(r['t_stat'], 2):>6} "
+            f"{_f(r['hit_rate'], 2):>6} {r['n_dates'] or 0:>5} {r['n_obs']:>7}"
+        )
+
+
+def _f(v, nd: int = 4) -> str:
+    return f"{v:.{nd}f}" if isinstance(v, (int, float)) and v == v else "n/a"
+
+
+def _render(fac, clu, n_snap, n_uni, n_px, snaps) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_factor_backtest.html")
+
+    def rowhtml(r):
+        good = (r["mean_ic"] or 0) > 0
+        strong = abs(r.get("t_stat") or 0) >= 2
+        act = "active" if r["active"] else "discarded"
+        badge = (
+            f'<span class="b {"act" if r["active"] else "disc"}">{act}</span>'
+            if r["kind"] == "factor"
+            else ""
+        )
+        col = "#0a7d33" if good else "#b91c1c"
+        tw = "700" if strong else "400"
+        return (
+            f"<tr><td><code>{r['name']}</code> {badge}</td>"
+            f"<td style='color:{col};font-weight:{tw}'>{_f(r['mean_ic'])}</td>"
+            f"<td style='font-weight:{tw}'>{_f(r['t_stat'], 2)}</td>"
+            f"<td>{_f(r['hit_rate'], 2)}</td><td>{r['n_dates'] or 0}</td><td>{r['n_obs']:,}</td></tr>"
+        )
+
+    ch = "\n".join(rowhtml(r) for r in clu)
+    fh = "\n".join(rowhtml(r) for r in fac)
+    html = f"""<!doctype html><html><head><meta charset="utf-8"><title>v3 Factor Backtest</title>
+<style>body{{font:14px -apple-system,Segoe UI,Arial,sans-serif;color:#1a1a1a;background:#fff;max-width:900px;margin:0 auto;padding:30px}}
+h1{{font-size:23px;margin:0 0 4px}}.sub{{color:#5b6470;font-size:13px;margin-bottom:20px}}
+h2{{font-size:17px;margin:26px 0 8px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}}
+table{{width:100%;border-collapse:collapse;font-size:13px}}th{{text-align:left;background:#f7f8fa;padding:7px 9px;border-bottom:1px solid #e6e8ec}}
+td{{padding:6px 9px;border-bottom:1px solid #eef0f2}}code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:12px}}
+.b{{font-size:10px;font-weight:700;padding:1px 6px;border-radius:20px;margin-left:4px}}.act{{color:#0a7d33;background:#e5f6ea}}.disc{{color:#6b7280;background:#eef0f2}}
+.note{{color:#5b6470;font-size:12.5px;margin:6px 0 2px}}</style></head><body>
+<h1>v3 Panel-History Factor Backtest</h1>
+<div class="sub">Forward IC (Spearman) at {HORIZON}td, over {n_snap} weekly point-in-time snapshots
+({snaps[0][1]} .. {snaps[-1][1]}) reconstructed from etoro.csv git history · universe {n_uni:,} global coverage names, {n_px:,} priced (EUR).</div>
+<p class="note"><b>How to read:</b> positive mean IC with |t|≥2 (bold) = evidence of alpha at this horizon on this (short) sample. <b>active</b> = in a live cluster; <b>discarded</b> = removed from scoring (shown to validate the discard). This is ~{n_snap} weekly dates — indicative, not the deflated-Sharpe gate.</p>
+<h2>Clusters</h2>
+<table><thead><tr><th>Cluster</th><th>mean IC</th><th>t-stat</th><th>hit</th><th>dates</th><th>obs</th></tr></thead><tbody>{ch}</tbody></table>
+<h2>Factors (active + discarded)</h2>
+<table><thead><tr><th>Factor</th><th>mean IC</th><th>t-stat</th><th>hit</th><th>dates</th><th>obs</th></tr></thead><tbody>{fh}</tbody></table>
+<p class="note">Excludes ev_ebitda + rev_growth (yfinance .info is current-only, not point-in-time reconstructable). mom_12_1 / realized_vol reconstructed from adjusted prices.</p>
+</body></html>"""
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(html)
+    return out
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_ic_logger.py
+++ b/scripts/v3_ic_logger.py
@@ -34,7 +34,11 @@ BUY_CSV = "yahoofinance/output/buy.csv"
 ETORO_CSV = "yahoofinance/output/etoro.csv"
 
 DEFAULT_LOG = "~/.weirdapps-trading/v3_ic_log.csv"
-LOG_COLUMNS = ["date", "ticker", "conviction", "sector", "close"]
+# Per-cluster z's are logged alongside the composite conviction so forward IC can be
+# measured PER CLUSTER from the live log, not just for the composite. Older logs that
+# predate this lack the columns -> they read back as NaN (handled downstream).
+_CLUSTER_Z = ("value_z", "quality_z", "momentum_z", "growth_z", "lowvol_z", "strength_z")
+LOG_COLUMNS = ["date", "ticker", "conviction", "sector", "close", *_CLUSTER_Z]
 
 
 # ---------------------------------------------------------------------------
@@ -83,15 +87,17 @@ def append_snapshot(
         conv_val = row.get("conviction", np.nan)
         sect_val = row.get("sector", "")
 
-        rows.append(
-            {
-                "date": date,
-                "ticker": str(ticker),
-                "conviction": float(conv_val) if pd.notna(conv_val) else np.nan,
-                "sector": str(sect_val) if pd.notna(sect_val) else "",
-                "close": float(close_val) if pd.notna(close_val) else np.nan,
-            }
-        )
+        rec = {
+            "date": date,
+            "ticker": str(ticker),
+            "conviction": float(conv_val) if pd.notna(conv_val) else np.nan,
+            "sector": str(sect_val) if pd.notna(sect_val) else "",
+            "close": float(close_val) if pd.notna(close_val) else np.nan,
+        }
+        for cz in _CLUSTER_Z:  # per-cluster z for per-cluster forward IC
+            v = row.get(cz, np.nan)
+            rec[cz] = float(v) if pd.notna(v) else np.nan
+        rows.append(rec)
 
     if not rows:
         return 0
@@ -104,8 +110,13 @@ def append_snapshot(
     return len(rows)
 
 
-def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
-    """Build (signal_date, ticker, conviction, forward_return) panel.
+def forward_return_panel(
+    log_df: pd.DataFrame, horizon: int, signal_col: str = "conviction"
+) -> pd.DataFrame:
+    """Build (signal_date, ticker, <signal_col>, forward_return) panel.
+
+    ``signal_col`` selects which logged column is the signal (default the composite
+    ``conviction``; pass e.g. ``"value_z"`` to measure a single cluster's IC).
 
     For each unique date at sorted position ``i`` in the log, the forward date
     is the date at position ``i + horizon`` (log-row steps, not calendar days).
@@ -124,7 +135,7 @@ def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
         ``[signal_date, ticker, conviction, forward_return]``.
         Empty when there are fewer than ``horizon + 1`` distinct dates.
     """
-    empty = pd.DataFrame(columns=["signal_date", "ticker", "conviction", "forward_return"])
+    empty = pd.DataFrame(columns=["signal_date", "ticker", signal_col, "forward_return"])
     if log_df is None or log_df.empty:
         return empty
 
@@ -138,10 +149,8 @@ def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
     # Build a (date, ticker) -> close pivot for fast lookups.
     pivot = log.pivot_table(index="date", columns="ticker", values="close", aggfunc="first")
 
-    # Build (date, ticker) -> conviction lookup.
-    conv_pivot = log.pivot_table(
-        index="date", columns="ticker", values="conviction", aggfunc="first"
-    )
+    # Build (date, ticker) -> signal lookup (conviction, or a cluster-z).
+    conv_pivot = log.pivot_table(index="date", columns="ticker", values=signal_col, aggfunc="first")
 
     records = []
     for i, signal_date in enumerate(dates):
@@ -166,7 +175,7 @@ def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
                 {
                     "signal_date": signal_date,
                     "ticker": ticker,
-                    "conviction": conviction,
+                    signal_col: conviction,
                     "forward_return": close_fut / close_sig - 1.0,
                 }
             )
@@ -179,6 +188,7 @@ def forward_return_panel(log_df: pd.DataFrame, horizon: int) -> pd.DataFrame:
 def ic_from_log(
     log_df: pd.DataFrame,
     horizons: tuple[int, ...] = V3_IC_HORIZONS,
+    signal_col: str = "conviction",
 ) -> dict:
     """Compute cross-sectional IC for each horizon from the IC log.
 
@@ -220,7 +230,7 @@ def ic_from_log(
             }
             continue
 
-        panel = forward_return_panel(log_df, h)
+        panel = forward_return_panel(log_df, h, signal_col=signal_col)
         if panel.empty or len(panel) == 0:
             results[h] = {
                 "insufficient_history": True,
@@ -232,7 +242,7 @@ def ic_from_log(
 
         ic = cross_sectional_ic(
             panel,
-            signal_col="conviction",
+            signal_col=signal_col,
             forward_col="forward_return",
             date_col="signal_date",
         )

--- a/tests/unit/trade_modules/test_v3_factor_backtest.py
+++ b/tests/unit/trade_modules/test_v3_factor_backtest.py
@@ -1,0 +1,59 @@
+"""TDD — panel-history per-factor backtest helpers (which parameters have alpha)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.v3.factor_backtest import (
+    BACKTEST_PANEL_FACTORS,
+    factor_zscore,
+    forward_return_at,
+    is_active,
+    summarize_ic,
+)
+
+
+def test_factor_zscore_respects_direction():
+    idx = ["a", "b", "c", "d"]
+    # low P/E is good (direction -1): the cheapest name gets the HIGHEST z.
+    zp = factor_zscore(pd.Series([10, 20, 30, 40], index=idx), "pe_trailing", sector_neutral=False)
+    assert zp["a"] > zp["d"]
+    # high ROE is good (direction +1): the highest ROE gets the highest z.
+    zr = factor_zscore(pd.Series([10, 20, 30, 40], index=idx), "roe", sector_neutral=False)
+    assert zr["d"] > zr["a"]
+
+
+def test_forward_return_at():
+    idx = pd.date_range("2026-01-01", periods=5, freq="B")
+    px = pd.DataFrame({"AAA": [100, 101, 102, 103, 110], "BBB": [50, 50, 50, 50, 45]}, index=idx)
+    fr = forward_return_at(px, idx[0], horizon=4)
+    assert round(fr["AAA"], 4) == 0.10  # 100 -> 110
+    assert round(fr["BBB"], 4) == -0.10  # 50 -> 45
+
+
+def test_forward_return_at_missing_or_out_of_range():
+    idx = pd.date_range("2026-01-01", periods=3, freq="B")
+    px = pd.DataFrame({"AAA": [100, 101, 102]}, index=idx)
+    assert forward_return_at(px, idx[0], horizon=9).empty  # horizon runs past data
+    assert forward_return_at(px, "2099-01-01", horizon=1).empty  # as_of absent
+
+
+def test_summarize_ic():
+    s = summarize_ic(pd.Series([0.1, 0.2, 0.3]))
+    assert s["n"] == 3
+    assert round(s["mean_ic"], 4) == 0.2
+    assert s["hit_rate"] == 1.0
+    assert s["t_stat"] > 0
+
+
+def test_is_active_flags_discarded_factors():
+    assert is_active("pe_trailing") is True  # in the value cluster
+    assert is_active("roe") is True
+    assert is_active("upside") is False  # discarded
+    assert is_active("buy_pct") is False  # discarded
+
+
+def test_backtest_factor_set_covers_active_and_discarded():
+    feats = set(BACKTEST_PANEL_FACTORS.values())
+    assert {"pe_trailing", "roe", "analyst_mom"} <= feats  # active
+    assert {"upside", "buy_pct", "pe_forward"} <= feats  # discarded, tested for alpha

--- a/tests/unit/trade_modules/test_v3_ic_logger.py
+++ b/tests/unit/trade_modules/test_v3_ic_logger.py
@@ -187,11 +187,23 @@ class TestAppendSnapshot:
         assert len(df) == 2 * len(scored)
 
     def test_log_schema_correct(self, tmp_path):
-        """CSV must have exactly the five schema columns."""
+        """CSV must have the base schema + the per-cluster z columns (backtest wiring)."""
         log_path = tmp_path / "log.csv"
         append_snapshot(str(log_path), "2026-07-01", _scored_frame())
         df = pd.read_csv(log_path)
-        assert set(df.columns) == {"date", "ticker", "conviction", "sector", "close"}
+        assert set(df.columns) == {
+            "date",
+            "ticker",
+            "conviction",
+            "sector",
+            "close",
+            "value_z",
+            "quality_z",
+            "momentum_z",
+            "growth_z",
+            "lowvol_z",
+            "strength_z",
+        }
 
     def test_close_sourced_from_price_column(self, tmp_path):
         log_path = tmp_path / "log.csv"
@@ -316,3 +328,61 @@ class TestIcFromLog:
         results = ic_from_log(empty, horizons=(1, 5))
         for h in (1, 5):
             assert results[h].get("insufficient_history") is True
+
+
+# ---------------------------------------------------------------------------
+# Per-cluster logging + signal_col IC (backtest wiring, part B)
+# ---------------------------------------------------------------------------
+
+
+def test_append_snapshot_captures_cluster_z(tmp_path):
+    log_path = tmp_path / "log.csv"
+    scored = pd.DataFrame(
+        {
+            "conviction": [0.5, -0.2],
+            "sector": ["Tech", "Fin"],
+            "price": [100.0, 200.0],
+            "value_z": [1.1, -0.3],
+            "quality_z": [0.4, 0.2],
+            "momentum_z": [0.0, 1.0],
+            "growth_z": [0.1, 0.1],
+            "lowvol_z": [-0.5, 0.5],
+            "strength_z": [0.2, -0.2],
+        },
+        index=["AAA", "BBB"],
+    )
+    append_snapshot(str(log_path), "2026-07-01", scored)
+    df = pd.read_csv(log_path).set_index("ticker")
+    for cz in ("value_z", "quality_z", "momentum_z", "growth_z", "lowvol_z", "strength_z"):
+        assert cz in df.columns
+    assert df.loc["AAA", "value_z"] == 1.1
+    assert df.loc["BBB", "lowvol_z"] == 0.5
+
+
+def test_ic_from_log_measures_per_cluster_signal():
+    # A log where value_z predicts the next-step forward return.
+    rng = np.random.default_rng(3)
+    n_dates, n_t = 24, 30
+    dates = [f"2026-01-{d + 1:02d}" for d in range(n_dates)]
+    tk = [f"T{i:02d}" for i in range(n_t)]
+    vz = rng.standard_normal((n_dates, n_t))
+    prices = np.ones((n_dates, n_t)) * 100.0
+    for d in range(1, n_dates):
+        prices[d] = prices[d - 1] * (1 + vz[d - 1] * 0.05 + rng.standard_normal(n_t) * 0.002)
+    rows = []
+    for di, dt in enumerate(dates):
+        for ti, t in enumerate(tk):
+            rows.append(
+                {
+                    "date": dt,
+                    "ticker": t,
+                    "conviction": 0.0,
+                    "sector": "X",
+                    "close": float(prices[di, ti]),
+                    "value_z": float(vz[di, ti]),
+                }
+            )
+    log = pd.DataFrame(rows)
+    res = ic_from_log(log, horizons=(1,), signal_col="value_z")
+    assert "insufficient_history" not in res[1]
+    assert res[1]["mean_ic"] > 0.1  # value_z predicts -> positive cluster IC

--- a/trade_modules/v3/factor_backtest.py
+++ b/trade_modules/v3/factor_backtest.py
@@ -1,0 +1,100 @@
+"""Panel-history per-factor alpha backtest — which parameters actually have alpha.
+
+The etoro.csv panel is git-committed daily, so its history is a de-facto point-in-time
+panel (~months). For each historical snapshot we compute each factor's directional
+cross-sectional rank-z (the SAME transform the live combiner uses) and its forward
+return, then measure per-factor / per-cluster forward IC + incremental (spanning) IC.
+
+This covers the panel-native factors (PIT from the CSV) plus price-derived momentum /
+realized-vol (PIT from adjusted prices). It deliberately INCLUDES the discarded panel
+factors (upside, buy_pct, pe_forward, …) so their discard decisions can be validated.
+It excludes the yfinance-.info factors (ev_ebitda, rev_growth) — those are current-only,
+not reconstructable point-in-time.
+
+Pure helpers here; the git-history + price I/O + orchestration live in
+``scripts/v3_factor_backtest.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from trade_modules.v3.combine import CLUSTERS, DIRECTION, _rank_z, _sector_demean
+from trade_modules.v3.features import _num
+
+# Panel columns backtestable point-in-time -> feature name (for the DIRECTION sign).
+# Active (scored) + discarded panel factors, so the discards can be tested too.
+BACKTEST_PANEL_FACTORS: dict[str, str] = {
+    # active, panel-native (also in the live clusters)
+    "PET": "pe_trailing",
+    "ROE": "roe",
+    "FCF": "fcf",
+    "52W": "pct_52w_high",
+    "B": "beta",
+    "AM": "analyst_mom",
+    "EG": "earn_growth",
+    # discarded from scoring — tested here to CHECK the discard was right
+    "PEF": "pe_forward",
+    "P/S": "ps_sector",
+    "PEG": "peg",
+    "DE": "de",
+    "PP": "price_perf",
+    "DV": "div_yield",
+    "SI": "short_interest",
+    "UP%": "upside",
+    "%B": "buy_pct",
+}
+
+# Which feature names are ACTIVE (in a live cluster) vs discarded.
+_ACTIVE_FEATURES = {m for members in CLUSTERS.values() for m in members}
+
+
+def factor_zscore(
+    raw: pd.Series, feature_name: str, sector: pd.Series | None = None, sector_neutral: bool = True
+) -> pd.Series:
+    """Directional cross-sectional rank-z of ONE raw factor column (one snapshot).
+
+    Mirrors the live combiner: clean → van-der-Waerden rank-z → multiply by the
+    factor's DIRECTION (+1 keep / -1 low-is-good) → optional within-sector demean.
+    """
+    z = _rank_z(_num(pd.Series(raw))) * DIRECTION.get(feature_name, 1)
+    if sector_neutral and sector is not None:
+        z = _sector_demean(z, pd.Series(sector).reindex(z.index))
+    return z
+
+
+def forward_return_at(prices: pd.DataFrame, as_of, horizon: int) -> pd.Series:
+    """Per-ticker forward return from ``as_of`` over ``horizon`` trading bars.
+
+    ``prices`` is a dates×tickers adjusted-close frame. Returns a Series indexed by
+    ticker (NaN where the as_of or the +horizon bar is missing). Empty if as_of is
+    not in the index or the horizon bar runs past the data.
+    """
+    idx = prices.index
+    if as_of not in idx:
+        return pd.Series(dtype=float)
+    i = idx.get_loc(as_of)
+    j = i + horizon
+    if j >= len(idx):
+        return pd.Series(dtype=float)
+    base = prices.iloc[i]
+    fut = prices.iloc[j]
+    fr = (fut / base) - 1.0
+    return fr.replace([np.inf, -np.inf], np.nan)
+
+
+def summarize_ic(ic_by_date: pd.Series) -> dict:
+    """Summary stats of a per-date IC series: n, mean, std, t-stat, hit-rate."""
+    ic = pd.to_numeric(pd.Series(ic_by_date), errors="coerce").dropna()
+    n = int(len(ic))
+    mean = float(ic.mean()) if n else float("nan")
+    sd = float(ic.std(ddof=1)) if n > 1 else float("nan")
+    t = mean / (sd / np.sqrt(n)) if (n > 1 and sd and sd > 0) else float("nan")
+    hit = float((ic > 0).mean()) if n else float("nan")
+    return {"n": n, "mean_ic": mean, "ic_std": sd, "t_stat": t, "hit_rate": hit}
+
+
+def is_active(feature_name: str) -> bool:
+    """True if the feature is in a live scoring cluster (else it is a discarded factor)."""
+    return feature_name in _ACTIVE_FEATURES


### PR DESCRIPTION
## Summary
Wires up **per-parameter alpha measurement** — the thing that lets us backtest which factors/clusters actually have alpha. Previously only the composite conviction was logged and the committed panel history was unused.

**A — panel-history factor backtest** (`trade_modules/v3/factor_backtest.py` + `scripts/v3_factor_backtest.py`): reconstructs etoro.csv from git history (PIT, committed daily), computes each factor's directional rank-z per weekly snapshot, and measures forward IC (@21td) **per factor and per cluster** — including DISCARDED panel factors, to validate the discards. Renders an HTML report.

**B — per-cluster live logging** (`scripts/v3_ic_logger.py`): `append_snapshot` now persists the six cluster-z; `forward_return_panel` + `ic_from_log` gain a `signal_col` param so forward IC is computable for any column (e.g. `value_z`).

## First backtest result (indicative — 16 weekly snapshots, Feb–Jul 2026, one risk-on regime)
Active clusters show NEGATIVE forward IC on this window (lowvol/quality most negative), while discarded upside/buy_pct are mildly positive — consistent with a mega-cap-tech, high-beta melt-up where value/quality/low-vol lag. This is NOT the deflated-Sharpe gate (n≈16); it validates *why* weights are frozen and gated on multi-year data.

## Test
9 new tests; v3 suite **432 green**; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)