### PR TITLE
feat(v3): PIT fundamentals store + derivations + Sharadar ingestion (Phase 1)

### DIFF
--- a/scripts/v3_daily_update.py
+++ b/scripts/v3_daily_update.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -50,8 +51,15 @@ def _pages(table: str, q: dict):
         if cur:
             qq["qopts.cursor_id"] = cur
         url = f"{BASE}/{table}.json?{urllib.parse.urlencode(qq)}"
-        with urllib.request.urlopen(url, timeout=90) as r:  # noqa: S310 (fixed https host)
-            p = json.loads(r.read().decode())
+        for attempt in range(5):  # retry transient socket timeouts / 5xx
+            try:
+                with urllib.request.urlopen(url, timeout=120) as r:  # noqa: S310 (fixed host)
+                    p = json.loads(r.read().decode())
+                break
+            except Exception:  # noqa: BLE001
+                if attempt == 4:
+                    raise
+                time.sleep(5 * (attempt + 1))
         dt = p["datatable"]
         yield dt["data"], [c["name"] for c in dt["columns"]]
         cur = p.get("meta", {}).get("next_cursor_id")
@@ -106,9 +114,15 @@ def main() -> None:
     ap.add_argument("--since", default="2015-01-01")
     args = ap.parse_args()
     uni = build_universe(args.since)
+    # Resume: skip tickers already in the store (a prior run may have timed out).
+    done: set = set()
+    if Path(STORE).exists():
+        done = set(pd.read_parquet(STORE, columns=["ticker"])["ticker"].astype(str).unique())
+    todo = [t for t in uni if t not in done]
+    print(f"resume: {len(done)} tickers already stored, {len(todo)} to fetch")
     total = 0
-    for i in range(0, len(uni), 200):
-        chunk = uni[i : i + 200]
+    for i in range(0, len(todo), 200):
+        chunk = todo[i : i + 200]
         frames = []
         for data, cols in _pages(
             "DAILY",

--- a/scripts/v3_daily_update.py
+++ b/scripts/v3_daily_update.py
@@ -1,0 +1,131 @@
+"""Ingest Sharadar DAILY (survivorship-clean daily marketcap + pb/pe/ps) into a
+month-end store — the survivorship fix that SEP-sample can't give us.
+
+DAILY is in the SF1 bundle AND covers delisted names (verified: BBBY has full
+2016-2026 DAILY history; SEP does not). We build the true US common-stock universe
+INCLUDING delisted names from the TICKERS table, pull DAILY month-end marketcap
+(a survivorship-clean return proxy) plus the point-in-time pb/pe/ps valuation
+ratios, and store them append-only. This removes the survivorship bias from the
+fundamentals backtest (my SF1 store was scoped to eToro's CURRENT universe, missing
+the ~2,915 delisted names).
+
+Caveat: monthly marketcap growth ≈ price return only while share count is stable;
+it is contaminated by issuance/buybacks (mainly affecting the asset-growth factor).
+Exact prices need SEP-full (a separate subscription) — flagged, not required here.
+
+Auth: NDL_API_KEY.  Usage: .venv/bin/python scripts/v3_daily_update.py --since 2015-01-01
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pandas as pd
+
+STORE = str(Path("~/.weirdapps-trading/v3_daily_monthly.parquet").expanduser())
+UNIVERSE_FILE = str(Path("~/.weirdapps-trading/v3_us_universe.txt").expanduser())
+BASE = "https://data.nasdaq.com/api/v3/datatables/SHARADAR"
+VALUE_COLS = ["marketcap", "pb", "pe", "ps"]
+_COLS = ["date", "ticker", *VALUE_COLS]
+
+
+def _key() -> str:
+    for v in ("NDL_API_KEY", "NASDAQ_DATA_LINK_API_KEY", "QUANDL_API_KEY"):
+        if os.environ.get(v):
+            return os.environ[v]
+    print("ERROR: no NDL_API_KEY", file=sys.stderr)
+    sys.exit(2)
+
+
+def _pages(table: str, q: dict):
+    key, cur = _key(), None
+    while True:
+        qq = {**q, "api_key": key}
+        if cur:
+            qq["qopts.cursor_id"] = cur
+        url = f"{BASE}/{table}.json?{urllib.parse.urlencode(qq)}"
+        with urllib.request.urlopen(url, timeout=90) as r:  # noqa: S310 (fixed https host)
+            p = json.loads(r.read().decode())
+        dt = p["datatable"]
+        yield dt["data"], [c["name"] for c in dt["columns"]]
+        cur = p.get("meta", {}).get("next_cursor_id")
+        if not cur:
+            break
+
+
+def build_universe(since: str) -> list[str]:
+    """US Domestic Common Stock active in [since, now], INCLUDING delisted names."""
+    rows = []
+    q = {"table": "SF1", "qopts.columns": "ticker,category,isdelisted,lastpricedate"}
+    for data, _cols in _pages("TICKERS", q):
+        rows += data
+    uni = sorted({r[0] for r in rows if r[1] == "Domestic Common Stock" and (r[3] or "") >= since})
+    Path(UNIVERSE_FILE).parent.mkdir(parents=True, exist_ok=True)
+    Path(UNIVERSE_FILE).write_text("\n".join(uni))
+    print(f"universe: {len(uni)} US common stocks (incl. delisted) -> {UNIVERSE_FILE}")
+    return uni
+
+
+def _to_month_end(daily: pd.DataFrame) -> pd.DataFrame:
+    if daily.empty:
+        return pd.DataFrame(columns=_COLS)
+    d = daily.copy()
+    d["date"] = pd.to_datetime(d["date"], errors="coerce")
+    for c in VALUE_COLS:
+        d[c] = pd.to_numeric(d.get(c), errors="coerce")
+    d = d.dropna(subset=["date"])
+    me = d.set_index("date").groupby("ticker")[VALUE_COLS].resample("ME").last().reset_index()
+    me["date"] = me["date"].dt.strftime("%Y-%m-%d")
+    return me[_COLS]
+
+
+def _append(new: pd.DataFrame) -> int:
+    if new.empty:
+        return 0
+    p = Path(STORE)
+    existing = pd.read_parquet(p) if p.exists() else pd.DataFrame(columns=_COLS)
+    keys = set(zip(existing["ticker"], existing["date"], strict=False)) if len(existing) else set()
+    added = len({(t, d) for t, d in zip(new["ticker"], new["date"], strict=False)} - keys)
+    combined = new if existing.empty else pd.concat([existing, new], ignore_index=True)
+    combined = combined.drop_duplicates(["ticker", "date"], keep="last").sort_values(
+        ["ticker", "date"]
+    )
+    p.parent.mkdir(parents=True, exist_ok=True)
+    combined.to_parquet(p, index=False)
+    return added
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Ingest Sharadar DAILY -> month-end store.")
+    ap.add_argument("--since", default="2015-01-01")
+    args = ap.parse_args()
+    uni = build_universe(args.since)
+    total = 0
+    for i in range(0, len(uni), 200):
+        chunk = uni[i : i + 200]
+        frames = []
+        for data, cols in _pages(
+            "DAILY",
+            {
+                "ticker": ",".join(chunk),
+                "date.gte": args.since,
+                "qopts.columns": "ticker,date," + ",".join(VALUE_COLS),
+            },
+        ):
+            if data:
+                frames.append(pd.DataFrame(data, columns=cols))
+        daily = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        added = _append(_to_month_end(daily))
+        total += added
+        print(f"  chunk {i // 200 + 1}/{(len(uni) - 1) // 200 + 1}: {len(daily)} daily -> +{added}")
+    print(f"done: +{total} month-end rows -> {STORE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_fundamentals_backtest.py
+++ b/scripts/v3_fundamentals_backtest.py
@@ -1,0 +1,231 @@
+"""Phase 3 — multi-year backtest of the PIT fundamental factors (the real unlock).
+
+Uses the point-in-time Sharadar fundamentals store (datekey-lagged, no look-ahead)
++ a long EUR price history to measure the forward IC of the data-blocked durable
+premia — book_to_price, asset_growth (CMA), gp_assets (Novy-Marx), accruals (Sloan)
+— over ~10-20 years / multiple regimes, instead of the 5-month etoro.csv panel. This
+is the sample the DSR / multi-regime gate actually needs.
+
+Monthly cross-sections: each month-end T, read fundamentals as of T (and ~T-1yr for
+asset growth), form each factor's directional sector-demeaned rank-z, and correlate
+with the forward 1-month return (raw + beta-neutral). Reports IC raw -> beta-neutral
+with HAC (Newey-West) t-stats, a Fama-MacBeth simultaneous panel, and per-sector IC.
+
+    .venv/bin/python scripts/v3_fundamentals_backtest.py [--period 10y] [--max-tickers N]
+
+Reuses the tested helpers from factor_backtest / fundamentals / combine. Prices are
+yfinance (survivors only -> a survivorship caveat, flagged); delisted-name pricing is
+the documented next data step (Sharadar SEP).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from trade_modules.v3.combine import _rank_z, _sector_demean  # noqa: E402
+from trade_modules.v3.factor_backtest import (  # noqa: E402
+    beta_neutralize,
+    fama_macbeth,
+    hac_tstat,
+)
+from trade_modules.v3.fundamentals import factor_panel  # noqa: E402
+from trade_modules.v3.fundamentals_store import STORE_PATH, read_asof  # noqa: E402
+from trade_modules.validation.xsection_ic import cross_sectional_ic  # noqa: E402
+
+# Factor -> directional sign (+1 high-good / -1 low-good), matching the literature.
+FACTORS = {"book_to_price": +1, "asset_growth": -1, "gp_assets": +1, "accruals": -1}
+HAC_LAGS = 12  # ~1yr of monthly autocorrelation for the overlap-robust t-stat
+BETA_WIN = 36  # trailing months for the rolling market beta
+
+
+def _store_tickers() -> list[str]:
+    """Store tickers ranked by latest market cap (so --max-tickers takes the largest)."""
+    df = pd.read_parquet(STORE_PATH)
+    latest_mc = df.sort_values("datekey").groupby("ticker")["marketcap"].last()
+    return [str(t) for t in latest_mc.sort_values(ascending=False).index]
+
+
+def _rolling_beta(mret: pd.DataFrame) -> pd.DataFrame:
+    """Trailing-``BETA_WIN`` month beta of each name vs the equal-weight market."""
+    mkt = mret.mean(axis=1)
+    cov = mret.rolling(BETA_WIN).cov(mkt)
+    var = mkt.rolling(BETA_WIN).var()
+    return cov.div(var, axis=0)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Multi-year PIT fundamentals backtest.")
+    ap.add_argument("--period", default="10y", help="yfinance price history period (e.g. 10y, max)")
+    ap.add_argument("--horizon-months", type=int, default=1)
+    ap.add_argument("--max-tickers", type=int, default=0, help="cap universe (0 = all)")
+    args = ap.parse_args()
+
+    from trade_modules.v3.prices import load_eur_close
+    from trade_modules.v3.sectors import load_offline_sector_map
+
+    tickers = _store_tickers()
+    if args.max_tickers:
+        tickers = tickers[: args.max_tickers]
+    print(f"store tickers: {len(tickers)}")
+    px = load_eur_close(tickers, period=args.period)
+    if px.empty:
+        print("no prices — is the store populated / network up?")
+        return
+    monthly = px.resample("ME").last()
+    fwd_mat = monthly.shift(-args.horizon_months) / monthly - 1.0
+    mret = monthly.pct_change(fill_method=None)
+    beta = _rolling_beta(mret)
+    sector_map = load_offline_sector_map()
+    print(f"priced (EUR): {monthly.shape[1]} names, {monthly.shape[0]} months")
+
+    parts: dict[str, list[pd.DataFrame]] = {f: [] for f in FACTORS}
+    fm_parts: list[pd.DataFrame] = []
+    dates = monthly.index[BETA_WIN:]  # need the beta window warmed up
+    n_used = 0
+    for T in dates:
+        fwd = fwd_mat.loc[T].dropna()
+        if fwd.empty:
+            continue
+        tkey = T.strftime("%Y-%m-%d")
+        pkey = (T - pd.Timedelta(days=365)).strftime("%Y-%m-%d")
+        fasof = read_asof(tickers, tkey)
+        if fasof.empty:
+            continue
+        fp = factor_panel(fasof, read_asof(tickers, pkey), monthly.loc[T])
+        n_used += 1
+        sec = pd.Series({t: sector_map.get(str(t).upper()) for t in fp.index}, index=fp.index)
+        beta_T = beta.loc[T] if T in beta.index else None
+        fwd_n = beta_neutralize(fwd, beta_T) if beta_T is not None else fwd
+
+        fm_row = {}
+        for fname, sign in FACTORS.items():
+            z = _sector_demean(_rank_z(fp[fname]) * sign, sec.reindex(fp.index))
+            part = pd.DataFrame(
+                {"date": tkey, "z": z, "fwd": fwd.reindex(z.index), "fwd_n": fwd_n.reindex(z.index)}
+            ).dropna(subset=["z", "fwd"])
+            if len(part):
+                parts[fname].append(part.reset_index(names="ticker"))
+            fm_row[fname] = z
+        fmdf = pd.DataFrame(fm_row)
+        fmdf["fwd"] = fwd.reindex(fmdf.index)
+        fmdf["date"] = tkey
+        fm_parts.append(fmdf.reset_index(names="ticker"))
+
+    print(f"monthly cross-sections used: {n_used}  ({dates[0].date()} .. {dates[-1].date()})")
+
+    rows = []
+    for fname in FACTORS:
+        if not parts[fname]:
+            continue
+        d = pd.concat(parts[fname], ignore_index=True)
+        raw = cross_sectional_ic(d, "z", "fwd", date_col="date")
+        neu = cross_sectional_ic(d.dropna(subset=["fwd_n"]), "z", "fwd_n", date_col="date")
+        neu_s = pd.Series(neu.get("ic_by_date") or {}, dtype=float).sort_index()
+        rows.append(
+            {
+                "name": fname,
+                "ic_raw": raw.get("mean_ic"),
+                "ic_neu": neu.get("mean_ic"),
+                "t_hac": hac_tstat(neu_s, HAC_LAGS) if len(neu_s) > 1 else float("nan"),
+                "hit": neu.get("hit_rate"),
+                "n_dates": neu.get("n_dates"),
+                "n_obs": len(d),
+            }
+        )
+    rows.sort(key=lambda r: r["ic_neu"] if isinstance(r["ic_neu"], float) else -9)
+
+    fm = {}
+    if fm_parts:
+        fmp = pd.concat(fm_parts, ignore_index=True)
+        fm = fama_macbeth(fmp, "fwd", list(FACTORS), date_col="date", lags=HAC_LAGS)
+
+    _print(rows, fm, n_used)
+    out = _render(rows, fm, n_used, dates, monthly.shape[1], args.period)
+    print(f"\nreport -> {out}")
+
+
+def _f(v, nd: int = 4) -> str:
+    return f"{v:.{nd}f}" if isinstance(v, (int, float)) and v == v else "n/a"
+
+
+def _print(rows, fm, n_used) -> None:
+    print(f"\n=== PIT FUNDAMENTALS forward IC (raw -> beta-neutral, HAC t; {n_used} months) ===")
+    print(f"{'factor':16} {'IC_raw':>8} {'IC_neu':>8} {'tHAC':>7} {'hit':>5} {'dates':>5}")
+    for r in rows:
+        print(
+            f"{r['name']:16} {_f(r['ic_raw']):>8} {_f(r['ic_neu']):>8} "
+            f"{_f(r['t_hac'], 2):>7} {_f(r['hit'], 2):>5} {r['n_dates'] or 0:>5}"
+        )
+    if fm:
+        print("\n--- Fama-MacBeth (simultaneous, HAC t) ---")
+        for k, v in fm.items():
+            print(f"{k:16} coef {_f(v['coef']):>9}  tHAC {_f(v['t'], 2):>6}  dates {v['n_dates']}")
+
+
+def _render(rows, fm, n_used, dates, n_px, period) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_fundamentals_backtest.html")
+
+    def frow(r):
+        good = (r["ic_neu"] or 0) > 0
+        strong = abs(r.get("t_hac") or 0) >= 2
+        col = "#0a7d33" if good else "#b91c1c"
+        tw = "700" if strong else "400"
+        return (
+            f"<tr><td><code>{r['name']}</code></td>"
+            f"<td>{_f(r['ic_raw'])}</td>"
+            f"<td style='color:{col};font-weight:{tw}'>{_f(r['ic_neu'])}</td>"
+            f"<td style='font-weight:{tw}'>{_f(r['t_hac'], 2)}</td>"
+            f"<td>{_f(r['hit'], 2)}</td><td>{r['n_dates'] or 0}</td><td>{r['n_obs']:,}</td></tr>"
+        )
+
+    fmrows = ""
+    for k, v in (fm or {}).items():
+        c = "#0a7d33" if (v["coef"] or 0) > 0 else "#b91c1c"
+        tw = "700" if abs(v.get("t") or 0) >= 2 else "400"
+        fmrows += (
+            f"<tr><td><code>{k}</code></td><td style='color:{c}'>{_f(v['coef'])}</td>"
+            f"<td style='font-weight:{tw}'>{_f(v['t'], 2)}</td><td>{v['n_dates']}</td></tr>"
+        )
+    fm_block = (
+        "<h2>Fama-MacBeth — simultaneous premia (HAC t)</h2>"
+        "<table><thead><tr><th>Factor</th><th>mean coef</th><th>t (HAC)</th><th>dates</th></tr>"
+        f"</thead><tbody>{fmrows}</tbody></table>"
+        if fm
+        else ""
+    )
+    body = "\n".join(frow(r) for r in rows)
+    html = f"""<!doctype html><html><head><meta charset="utf-8"><title>v3 PIT Fundamentals Backtest</title>
+<style>body{{font:14px -apple-system,Segoe UI,Arial,sans-serif;color:#1a1a1a;background:#fff;max-width:900px;margin:0 auto;padding:30px}}
+h1{{font-size:23px;margin:0 0 4px}}.sub{{color:#5b6470;font-size:13px;margin-bottom:16px}}
+h2{{font-size:17px;margin:24px 0 8px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}}
+table{{width:100%;border-collapse:collapse;font-size:13px}}th{{text-align:left;background:#f7f8fa;padding:7px 9px;border-bottom:1px solid #e6e8ec}}
+td{{padding:6px 9px;border-bottom:1px solid #eef0f2}}code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:12px}}
+.note{{color:#5b6470;font-size:12.5px;margin:6px 0}}</style></head><body>
+<h1>v3 PIT Fundamentals Backtest — the data-blocked durable premia</h1>
+<div class="sub">Monthly forward IC over {n_used} point-in-time cross-sections
+({dates[0].date()} .. {dates[-1].date()}, ~{period} price history, {n_px:,} priced) from the
+Sharadar SF1 store (datekey-lagged, no look-ahead). Book-to-price, asset-growth (CMA),
+GP/assets (Novy-Marx), accruals (Sloan).</div>
+<p class="note"><b>The unlock:</b> unlike the 5-month etoro.csv panel, this spans multiple
+regimes, so the HAC t-stats and Fama-MacBeth premia are the first read the DSR / ≥2-regime
+gate can actually use. <b>t (HAC)</b> = Newey-West ({HAC_LAGS} lags). Survivorship caveat:
+prices are yfinance survivors; delisted-name pricing (Sharadar SEP) is the next data step.</p>
+<table><thead><tr><th>Factor</th><th>IC raw</th><th>IC β-neutral</th><th>t (HAC)</th><th>hit</th><th>dates</th><th>obs</th></tr></thead><tbody>{body}</tbody></table>
+{fm_block}
+</body></html>"""
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(html)
+    return out
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_fundamentals_backtest.py
+++ b/scripts/v3_fundamentals_backtest.py
@@ -44,6 +44,7 @@ DAILY_STORE = str(Path("~/.weirdapps-trading/v3_daily_monthly.parquet").expandus
 SF1_STORE = str(Path("~/.weirdapps-trading/v3_fundamentals_store.parquet").expanduser())
 HAC_LAGS = 12
 BETA_WIN = 24
+MCAP_FLOOR = 100.0  # $100M (Sharadar marketcap is in $M): drop micro-cap return noise
 # factor -> directional sign (+1 high-good / -1 low-good)
 SIGNS = {
     "book_to_price": +1,
@@ -93,8 +94,17 @@ def main() -> None:
     )
     print(f"SF1 store: {sf1['ticker'].nunique()} names")
 
-    fwd_mat = mc.shift(-1) / mc - 1.0
-    mret = mc.pct_change(fill_method=None)
+    # Clean price proxy = marketcap / shares-outstanding: dividing out shares removes
+    # the issuance/buyback contamination in a raw marketcap return. Shares come from
+    # SF1 sharesbas as-of each month (updates at each filing, constant between).
+    shares = pd.DataFrame(index=mc.index, columns=mc.columns, dtype=float)
+    for T in mc.index:
+        f = _asof(sf1, T.strftime("%Y-%m-%d"))
+        if not f.empty:
+            shares.loc[T] = pd.to_numeric(f["sharesbas"], errors="coerce").reindex(mc.columns)
+    price = mc / shares.replace(0.0, np.nan)
+    fwd_mat = price.shift(-1) / price - 1.0
+    mret = price.pct_change(fill_method=None)
     mkt = mret.mean(axis=1)
     beta_mat = mret.rolling(BETA_WIN).cov(mkt).div(mkt.rolling(BETA_WIN).var(), axis=0)
     sue_tbl = _sue_table(sf1)
@@ -104,7 +114,9 @@ def main() -> None:
     dates = mc.index[12:-1]
     n_used = 0
     for T in dates:
-        fwd = fwd_mat.loc[T].dropna()
+        mcap_T = mc.loc[T]
+        keep = mcap_T[mcap_T > MCAP_FLOOR].index  # liquid-enough cross-section
+        fwd = fwd_mat.loc[T].reindex(keep).dropna()
         if len(fwd) < 20:
             continue
         tkey = T.strftime("%Y-%m-%d")

--- a/scripts/v3_fundamentals_backtest.py
+++ b/scripts/v3_fundamentals_backtest.py
@@ -1,154 +1,187 @@
-"""Phase 3 — multi-year backtest of the PIT fundamental factors (the real unlock).
+"""Phase 3 — SURVIVORSHIP-CLEAN multi-year backtest of the PIT fundamental factors.
 
-Uses the point-in-time Sharadar fundamentals store (datekey-lagged, no look-ahead)
-+ a long EUR price history to measure the forward IC of the data-blocked durable
-premia — book_to_price, asset_growth (CMA), gp_assets (Novy-Marx), accruals (Sloan)
-— over ~10-20 years / multiple regimes, instead of the 5-month etoro.csv panel. This
-is the sample the DSR / multi-regime gate actually needs.
+Sources (all delisted-inclusive, point-in-time):
+- DAILY store (``v3_daily_monthly.parquet``): month-end marketcap (return proxy +
+  size) and pb / pe / ps (PIT valuation ratios), for the full US common-stock
+  universe INCLUDING the ~2,915 delisted names — this removes the survivorship bias.
+- SF1 store (``v3_fundamentals_store.parquet``): assets/equity/gp/netinc/ncfo/eps.
 
-Monthly cross-sections: each month-end T, read fundamentals as of T (and ~T-1yr for
-asset growth), form each factor's directional sector-demeaned rank-z, and correlate
-with the forward 1-month return (raw + beta-neutral). Reports IC raw -> beta-neutral
-with HAC (Newey-West) t-stats, a Fama-MacBeth simultaneous panel, and per-sector IC.
+Factors (directional sign): book_to_price=1/pb, earnings_yield=1/pe, sales_yield=1/ps
+(value); gp_assets (Novy-Marx quality); asset_growth (CMA, −); accruals (Sloan, −);
+sue (PEAD, seasonal-random-walk). Forward return = month-over-month marketcap growth.
+Reports forward IC raw→beta-neutral with HAC (Newey-West) t + Fama-MacBeth.
 
-    .venv/bin/python scripts/v3_fundamentals_backtest.py [--period 10y] [--max-tickers N]
+    .venv/bin/python scripts/v3_fundamentals_backtest.py
 
-Reuses the tested helpers from factor_backtest / fundamentals / combine. Prices are
-yfinance (survivors only -> a survivorship caveat, flagged); delisted-name pricing is
-the documented next data step (Sharadar SEP).
+Caveat: marketcap growth ≈ price return only while shares are stable (issuance/buyback
+noise, mainly the asset-growth factor). Exact prices need SEP-full. Global rank-z
+(no sector demean here — the offline sector map is thin; per-sector value was covered
+by the etoro-panel backtest).
 """
 
 from __future__ import annotations
 
-import argparse
 import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from trade_modules.v3.combine import _rank_z, _sector_demean  # noqa: E402
+from trade_modules.v3.combine import _rank_z  # noqa: E402
 from trade_modules.v3.factor_backtest import (  # noqa: E402
     beta_neutralize,
     fama_macbeth,
     hac_tstat,
 )
 from trade_modules.v3.fundamentals import factor_panel  # noqa: E402
-from trade_modules.v3.fundamentals_store import STORE_PATH, read_asof  # noqa: E402
 from trade_modules.validation.xsection_ic import cross_sectional_ic  # noqa: E402
 
-# Factor -> directional sign (+1 high-good / -1 low-good), matching the literature.
-FACTORS = {"book_to_price": +1, "asset_growth": -1, "gp_assets": +1, "accruals": -1}
-HAC_LAGS = 12  # ~1yr of monthly autocorrelation for the overlap-robust t-stat
-BETA_WIN = 36  # trailing months for the rolling market beta
+DAILY_STORE = str(Path("~/.weirdapps-trading/v3_daily_monthly.parquet").expanduser())
+SF1_STORE = str(Path("~/.weirdapps-trading/v3_fundamentals_store.parquet").expanduser())
+HAC_LAGS = 12
+BETA_WIN = 24
+# factor -> directional sign (+1 high-good / -1 low-good)
+SIGNS = {
+    "book_to_price": +1,
+    "earnings_yield": +1,
+    "sales_yield": +1,
+    "gp_assets": +1,
+    "asset_growth": -1,
+    "accruals": -1,
+    "sue": +1,
+}
 
 
-def _store_tickers() -> list[str]:
-    """Store tickers ranked by latest market cap (so --max-tickers takes the largest)."""
-    df = pd.read_parquet(STORE_PATH)
-    latest_mc = df.sort_values("datekey").groupby("ticker")["marketcap"].last()
-    return [str(t) for t in latest_mc.sort_values(ascending=False).index]
+def _matrix(daily: pd.DataFrame, col: str) -> pd.DataFrame:
+    m = daily.pivot_table(index="date", columns="ticker", values=col, aggfunc="last")
+    m.index = pd.to_datetime(m.index)
+    return m.sort_index()
 
 
-def _rolling_beta(mret: pd.DataFrame) -> pd.DataFrame:
-    """Trailing-``BETA_WIN`` month beta of each name vs the equal-weight market."""
-    mkt = mret.mean(axis=1)
-    cov = mret.rolling(BETA_WIN).cov(mkt)
-    var = mkt.rolling(BETA_WIN).var()
-    return cov.div(var, axis=0)
+def _asof(df: pd.DataFrame, as_of: str) -> pd.DataFrame:
+    sub = df[df["datekey"] <= as_of]
+    return sub.sort_values("datekey").groupby("ticker").last() if not sub.empty else pd.DataFrame()
+
+
+def _sue_table(sf1: pd.DataFrame) -> pd.DataFrame:
+    """Per (ticker, datekey) seasonal-random-walk SUE from the EPS history."""
+    out = []
+    for tkr, g in sf1.sort_values("datekey").groupby("ticker"):
+        eps = pd.to_numeric(g["eps"], errors="coerce")
+        d4 = eps.diff(4)
+        sue = d4 / d4.expanding(min_periods=2).std()
+        out.append(
+            pd.DataFrame({"ticker": tkr, "datekey": g["datekey"].to_numpy(), "sue": sue.to_numpy()})
+        )
+    return pd.concat(out, ignore_index=True).dropna(subset=["sue"]) if out else pd.DataFrame()
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Multi-year PIT fundamentals backtest.")
-    ap.add_argument("--period", default="10y", help="yfinance price history period (e.g. 10y, max)")
-    ap.add_argument("--horizon-months", type=int, default=1)
-    ap.add_argument("--max-tickers", type=int, default=0, help="cap universe (0 = all)")
-    args = ap.parse_args()
-
-    from trade_modules.v3.prices import load_eur_close
-    from trade_modules.v3.sectors import load_offline_sector_map
-
-    tickers = _store_tickers()
-    if args.max_tickers:
-        tickers = tickers[: args.max_tickers]
-    print(f"store tickers: {len(tickers)}")
-    px = load_eur_close(tickers, period=args.period)
-    if px.empty:
-        print("no prices — is the store populated / network up?")
+    if not Path(DAILY_STORE).exists():
+        print(f"no DAILY store at {DAILY_STORE} — run v3_daily_update.py first")
         return
-    monthly = px.resample("ME").last()
-    fwd_mat = monthly.shift(-args.horizon_months) / monthly - 1.0
-    mret = monthly.pct_change(fill_method=None)
-    beta = _rolling_beta(mret)
-    sector_map = load_offline_sector_map()
-    print(f"priced (EUR): {monthly.shape[1]} names, {monthly.shape[0]} months")
+    daily = pd.read_parquet(DAILY_STORE)
+    sf1 = pd.read_parquet(SF1_STORE)
+    mc = _matrix(daily, "marketcap")
+    pb, pe, ps = _matrix(daily, "pb"), _matrix(daily, "pe"), _matrix(daily, "ps")
+    print(
+        f"DAILY store: {mc.shape[1]} names, {mc.shape[0]} months ({mc.index[0].date()}..{mc.index[-1].date()})"
+    )
+    print(f"SF1 store: {sf1['ticker'].nunique()} names")
 
-    parts: dict[str, list[pd.DataFrame]] = {f: [] for f in FACTORS}
+    fwd_mat = mc.shift(-1) / mc - 1.0
+    mret = mc.pct_change(fill_method=None)
+    mkt = mret.mean(axis=1)
+    beta_mat = mret.rolling(BETA_WIN).cov(mkt).div(mkt.rolling(BETA_WIN).var(), axis=0)
+    sue_tbl = _sue_table(sf1)
+
+    parts: dict[str, list[pd.DataFrame]] = {f: [] for f in SIGNS}
     fm_parts: list[pd.DataFrame] = []
-    dates = monthly.index[BETA_WIN:]  # need the beta window warmed up
+    dates = mc.index[12:-1]
     n_used = 0
     for T in dates:
         fwd = fwd_mat.loc[T].dropna()
-        if fwd.empty:
+        if len(fwd) < 20:
             continue
         tkey = T.strftime("%Y-%m-%d")
         pkey = (T - pd.Timedelta(days=365)).strftime("%Y-%m-%d")
-        fasof = read_asof(tickers, tkey)
+        fasof = _asof(sf1, tkey)
         if fasof.empty:
             continue
-        fp = factor_panel(fasof, read_asof(tickers, pkey), monthly.loc[T])
         n_used += 1
-        sec = pd.Series({t: sector_map.get(str(t).upper()) for t in fp.index}, index=fp.index)
-        beta_T = beta.loc[T] if T in beta.index else None
-        fwd_n = beta_neutralize(fwd, beta_T) if beta_T is not None else fwd
+        # value factors straight from DAILY PIT ratios (guard ratio > 0)
+        vals: dict[str, pd.Series] = {}
+        for name, ratio in (("book_to_price", pb), ("earnings_yield", pe), ("sales_yield", ps)):
+            r = ratio.loc[T]
+            vals[name] = (1.0 / r).where(r > 0)
+        # SF1 balance-sheet / cash-flow factors
+        fp = factor_panel(fasof, _asof(sf1, pkey), mc.loc[T])
+        for name in ("gp_assets", "asset_growth", "accruals"):
+            vals[name] = fp[name]
+        sue_asof = _asof(sue_tbl, tkey) if not sue_tbl.empty else pd.DataFrame()
+        vals["sue"] = sue_asof["sue"] if "sue" in sue_asof.columns else pd.Series(dtype=float)
 
-        fm_row = {}
-        for fname, sign in FACTORS.items():
-            z = _sector_demean(_rank_z(fp[fname]) * sign, sec.reindex(fp.index))
+        beta_T = beta_mat.loc[T] if T in beta_mat.index else None
+        fwd_n = (
+            beta_neutralize(fwd, beta_T)
+            if beta_T is not None
+            else pd.Series(np.nan, index=fwd.index)
+        )
+
+        fm_row: dict[str, pd.Series] = {}
+        for name, sign in SIGNS.items():
+            z = _rank_z(vals[name]) * sign
             part = pd.DataFrame(
                 {"date": tkey, "z": z, "fwd": fwd.reindex(z.index), "fwd_n": fwd_n.reindex(z.index)}
             ).dropna(subset=["z", "fwd"])
             if len(part):
-                parts[fname].append(part.reset_index(names="ticker"))
-            fm_row[fname] = z
+                parts[name].append(part.reset_index(names="ticker"))
+            fm_row[name] = z
         fmdf = pd.DataFrame(fm_row)
         fmdf["fwd"] = fwd.reindex(fmdf.index)
         fmdf["date"] = tkey
         fm_parts.append(fmdf.reset_index(names="ticker"))
 
-    print(f"monthly cross-sections used: {n_used}  ({dates[0].date()} .. {dates[-1].date()})")
+    print(f"monthly cross-sections used: {n_used}  ({dates[0].date()}..{dates[-1].date()})")
 
     rows = []
-    for fname in FACTORS:
-        if not parts[fname]:
+    for name in SIGNS:
+        if not parts[name]:
             continue
-        d = pd.concat(parts[fname], ignore_index=True)
+        d = pd.concat(parts[name], ignore_index=True)
         raw = cross_sectional_ic(d, "z", "fwd", date_col="date")
         neu = cross_sectional_ic(d.dropna(subset=["fwd_n"]), "z", "fwd_n", date_col="date")
+        raw_s = pd.Series(raw.get("ic_by_date") or {}, dtype=float).sort_index()
         neu_s = pd.Series(neu.get("ic_by_date") or {}, dtype=float).sort_index()
         rows.append(
             {
-                "name": fname,
+                "name": name,
                 "ic_raw": raw.get("mean_ic"),
+                "t_raw": hac_tstat(raw_s, HAC_LAGS) if len(raw_s) > 1 else float("nan"),
                 "ic_neu": neu.get("mean_ic"),
-                "t_hac": hac_tstat(neu_s, HAC_LAGS) if len(neu_s) > 1 else float("nan"),
+                "t_neu": hac_tstat(neu_s, HAC_LAGS) if len(neu_s) > 1 else float("nan"),
                 "hit": neu.get("hit_rate"),
-                "n_dates": neu.get("n_dates"),
+                "n_dates": raw.get("n_dates"),
                 "n_obs": len(d),
             }
         )
-    rows.sort(key=lambda r: r["ic_neu"] if isinstance(r["ic_neu"], float) else -9)
+    rows.sort(
+        key=lambda r: (
+            r["ic_neu"] if isinstance(r["ic_neu"], float) and r["ic_neu"] == r["ic_neu"] else -9
+        )
+    )
 
     fm = {}
     if fm_parts:
         fmp = pd.concat(fm_parts, ignore_index=True)
-        fm = fama_macbeth(fmp, "fwd", list(FACTORS), date_col="date", lags=HAC_LAGS)
+        fm = fama_macbeth(fmp, "fwd", list(SIGNS), date_col="date", lags=HAC_LAGS)
 
-    _print(rows, fm, n_used)
-    out = _render(rows, fm, n_used, dates, monthly.shape[1], args.period)
+    _print(rows, fm, n_used, mc)
+    out = _render(rows, fm, n_used, dates, mc.shape[1])
     print(f"\nreport -> {out}")
 
 
@@ -156,34 +189,35 @@ def _f(v, nd: int = 4) -> str:
     return f"{v:.{nd}f}" if isinstance(v, (int, float)) and v == v else "n/a"
 
 
-def _print(rows, fm, n_used) -> None:
-    print(f"\n=== PIT FUNDAMENTALS forward IC (raw -> beta-neutral, HAC t; {n_used} months) ===")
-    print(f"{'factor':16} {'IC_raw':>8} {'IC_neu':>8} {'tHAC':>7} {'hit':>5} {'dates':>5}")
+def _print(rows, fm, n_used, mc) -> None:
+    print(f"\n=== SURVIVORSHIP-CLEAN PIT FUNDAMENTALS forward IC ({n_used} months, HAC t) ===")
+    print(
+        f"{'factor':16} {'IC_raw':>8} {'tR_HAC':>7} {'IC_neu':>8} {'tN_HAC':>7} {'hit':>5} {'dates':>5}"
+    )
     for r in rows:
         print(
-            f"{r['name']:16} {_f(r['ic_raw']):>8} {_f(r['ic_neu']):>8} "
-            f"{_f(r['t_hac'], 2):>7} {_f(r['hit'], 2):>5} {r['n_dates'] or 0:>5}"
+            f"{r['name']:16} {_f(r['ic_raw']):>8} {_f(r['t_raw'], 2):>7} {_f(r['ic_neu']):>8} "
+            f"{_f(r['t_neu'], 2):>7} {_f(r['hit'], 2):>5} {r['n_dates'] or 0:>5}"
         )
     if fm:
-        print("\n--- Fama-MacBeth (simultaneous, HAC t) ---")
+        print("\n--- Fama-MacBeth (all factors jointly, HAC t) ---")
         for k, v in fm.items():
-            print(f"{k:16} coef {_f(v['coef']):>9}  tHAC {_f(v['t'], 2):>6}  dates {v['n_dates']}")
+            print(f"{k:16} coef {_f(v['coef']):>9}  tHAC {_f(v['t'], 2):>6}")
 
 
-def _render(rows, fm, n_used, dates, n_px, period) -> str:
+def _render(rows, fm, n_used, dates, n_px) -> str:
     stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
     out = os.path.expanduser(f"~/Downloads/{stamp}_v3_fundamentals_backtest.html")
 
     def frow(r):
         good = (r["ic_neu"] or 0) > 0
-        strong = abs(r.get("t_hac") or 0) >= 2
+        strong = abs(r.get("t_neu") or 0) >= 2
         col = "#0a7d33" if good else "#b91c1c"
         tw = "700" if strong else "400"
         return (
-            f"<tr><td><code>{r['name']}</code></td>"
-            f"<td>{_f(r['ic_raw'])}</td>"
-            f"<td style='color:{col};font-weight:{tw}'>{_f(r['ic_neu'])}</td>"
-            f"<td style='font-weight:{tw}'>{_f(r['t_hac'], 2)}</td>"
+            f"<tr><td><code>{r['name']}</code></td><td>{_f(r['ic_raw'])}</td>"
+            f"<td>{_f(r['t_raw'], 2)}</td><td style='color:{col};font-weight:{tw}'>{_f(r['ic_neu'])}</td>"
+            f"<td style='font-weight:{tw}'>{_f(r['t_neu'], 2)}</td>"
             f"<td>{_f(r['hit'], 2)}</td><td>{r['n_dates'] or 0}</td><td>{r['n_obs']:,}</td></tr>"
         )
 
@@ -191,35 +225,28 @@ def _render(rows, fm, n_used, dates, n_px, period) -> str:
     for k, v in (fm or {}).items():
         c = "#0a7d33" if (v["coef"] or 0) > 0 else "#b91c1c"
         tw = "700" if abs(v.get("t") or 0) >= 2 else "400"
-        fmrows += (
-            f"<tr><td><code>{k}</code></td><td style='color:{c}'>{_f(v['coef'])}</td>"
-            f"<td style='font-weight:{tw}'>{_f(v['t'], 2)}</td><td>{v['n_dates']}</td></tr>"
-        )
+        fmrows += f"<tr><td><code>{k}</code></td><td style='color:{c}'>{_f(v['coef'])}</td><td style='font-weight:{tw}'>{_f(v['t'], 2)}</td></tr>"
     fm_block = (
-        "<h2>Fama-MacBeth — simultaneous premia (HAC t)</h2>"
-        "<table><thead><tr><th>Factor</th><th>mean coef</th><th>t (HAC)</th><th>dates</th></tr>"
-        f"</thead><tbody>{fmrows}</tbody></table>"
+        "<h2>Fama-MacBeth — all factors jointly (HAC t)</h2><table><thead><tr><th>Factor</th>"
+        f"<th>mean coef</th><th>t (HAC)</th></tr></thead><tbody>{fmrows}</tbody></table>"
         if fm
         else ""
     )
     body = "\n".join(frow(r) for r in rows)
-    html = f"""<!doctype html><html><head><meta charset="utf-8"><title>v3 PIT Fundamentals Backtest</title>
+    html = f"""<!doctype html><html><head><meta charset="utf-8"><title>v3 Survivorship-Clean Fundamentals Backtest</title>
 <style>body{{font:14px -apple-system,Segoe UI,Arial,sans-serif;color:#1a1a1a;background:#fff;max-width:900px;margin:0 auto;padding:30px}}
-h1{{font-size:23px;margin:0 0 4px}}.sub{{color:#5b6470;font-size:13px;margin-bottom:16px}}
-h2{{font-size:17px;margin:24px 0 8px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}}
+h1{{font-size:22px;margin:0 0 4px}}.sub{{color:#5b6470;font-size:13px;margin-bottom:14px}}
+h2{{font-size:17px;margin:22px 0 8px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}}
 table{{width:100%;border-collapse:collapse;font-size:13px}}th{{text-align:left;background:#f7f8fa;padding:7px 9px;border-bottom:1px solid #e6e8ec}}
 td{{padding:6px 9px;border-bottom:1px solid #eef0f2}}code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:12px}}
 .note{{color:#5b6470;font-size:12.5px;margin:6px 0}}</style></head><body>
-<h1>v3 PIT Fundamentals Backtest — the data-blocked durable premia</h1>
-<div class="sub">Monthly forward IC over {n_used} point-in-time cross-sections
-({dates[0].date()} .. {dates[-1].date()}, ~{period} price history, {n_px:,} priced) from the
-Sharadar SF1 store (datekey-lagged, no look-ahead). Book-to-price, asset-growth (CMA),
-GP/assets (Novy-Marx), accruals (Sloan).</div>
-<p class="note"><b>The unlock:</b> unlike the 5-month etoro.csv panel, this spans multiple
-regimes, so the HAC t-stats and Fama-MacBeth premia are the first read the DSR / ≥2-regime
-gate can actually use. <b>t (HAC)</b> = Newey-West ({HAC_LAGS} lags). Survivorship caveat:
-prices are yfinance survivors; delisted-name pricing (Sharadar SEP) is the next data step.</p>
-<table><thead><tr><th>Factor</th><th>IC raw</th><th>IC β-neutral</th><th>t (HAC)</th><th>hit</th><th>dates</th><th>obs</th></tr></thead><tbody>{body}</tbody></table>
+<h1>v3 Survivorship-Clean PIT Fundamentals Backtest</h1>
+<div class="sub">{n_used} monthly cross-sections ({dates[0].date()}..{dates[-1].date()}), {n_px:,} US common
+stocks <b>including delisted</b> (Sharadar DAILY, marketcap return proxy) × the SF1 point-in-time store.</div>
+<p class="note"><b>t (HAC)</b> = Newey-West ({HAC_LAGS} lags). β-neutral strips the market/beta component.
+Survivorship removed (delisted names included). Residual caveat: marketcap growth ≈ price return only
+while share count is stable (issuance/buyback noise — mainly asset_growth). Global rank-z.</p>
+<table><thead><tr><th>Factor</th><th>IC raw</th><th>t raw</th><th>IC β-neutral</th><th>t β-neut</th><th>hit</th><th>dates</th><th>obs</th></tr></thead><tbody>{body}</tbody></table>
 {fm_block}
 </body></html>"""
     with open(out, "w", encoding="utf-8") as fh:

--- a/scripts/v3_fundamentals_update.py
+++ b/scripts/v3_fundamentals_update.py
@@ -1,0 +1,135 @@
+"""Ingest Sharadar SF1 (Core US Fundamentals) into the PIT fundamentals store.
+
+Point-in-time by construction: we keep Sharadar's ``datekey`` (the date each filing
+became public) and store as-reported quarterly figures (``dimension=ARQ``), so
+``fundamentals_store.read_asof(T)`` never sees a report filed after T.
+
+Auth: set the Nasdaq Data Link API key in the environment (NOT the repo):
+    export NDL_API_KEY=...            # or NASDAQ_DATA_LINK_API_KEY / QUANDL_API_KEY
+(get it at https://data.nasdaq.com/account/profile ; needs a Sharadar SF1 subscription).
+
+Usage:
+    .venv/bin/python scripts/v3_fundamentals_update.py --from-universe [--since 2005-01-01]
+    .venv/bin/python scripts/v3_fundamentals_update.py --tickers AAPL,MSFT,JPM
+
+Scoped/incremental pulls use the paginated datatables API (implemented here). A
+one-shot FULL-history load of the whole SF1 table is better done via the bulk
+export endpoint (``qopts.export=true`` -> zip); wire that when we run the first
+full backfill and have decided the ticker scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from trade_modules.v3.fundamentals_store import (  # noqa: E402
+    NUM_FIELDS,
+    append_records,
+    store_coverage,
+)
+
+ETORO_CSV = "yahoofinance/output/etoro.csv"
+BASE = "https://data.nasdaq.com/api/v3/datatables/SHARADAR/SF1.json"
+# Sharadar SF1 columns we keep (names already match NUM_FIELDS + keys).
+_COLUMNS = ["ticker", "datekey", "reportperiod", *NUM_FIELDS]
+
+
+def _api_key() -> str | None:
+    for var in ("NDL_API_KEY", "NASDAQ_DATA_LINK_API_KEY", "QUANDL_API_KEY"):
+        key = os.environ.get(var)
+        if key:
+            return key
+    return None
+
+
+def _universe_tickers() -> list[str]:
+    try:
+        df = pd.read_csv(ETORO_CSV, na_values=["--"])
+        return sorted(df["TKR"].dropna().astype(str).unique())
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: could not read {ETORO_CSV}: {exc}", file=sys.stderr)
+        return []
+
+
+def _fetch_page(key: str, params: dict) -> tuple[list[list], list[str], str | None]:
+    """One datatables page -> (rows, column_names, next_cursor)."""
+    q = {**params, "api_key": key, "qopts.columns": ",".join(_COLUMNS), "dimension": "ARQ"}
+    url = f"{BASE}?{urllib.parse.urlencode(q)}"
+    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310 (fixed https host)
+        payload = json.loads(resp.read().decode())
+    dt = payload.get("datatable", {})
+    cols = [c["name"] for c in dt.get("columns", [])]
+    nxt = payload.get("meta", {}).get("next_cursor_id")
+    return dt.get("data", []), cols, nxt
+
+
+def _fetch(key: str, tickers: list[str], since: str | None) -> pd.DataFrame:
+    """Fetch all pages for a ticker batch (Sharadar caps tickers per request, so batch)."""
+    frames: list[pd.DataFrame] = []
+    for i in range(0, len(tickers), 100):  # batch tickers to stay within request limits
+        batch = ",".join(tickers[i : i + 100])
+        params: dict = {"ticker": batch}
+        if since:
+            params["datekey.gte"] = since
+        cursor: str | None = None
+        while True:
+            page_params = dict(params)
+            if cursor:
+                page_params["qopts.cursor_id"] = cursor
+            rows, cols, cursor = _fetch_page(key, page_params)
+            if rows:
+                frames.append(pd.DataFrame(rows, columns=cols))
+            if not cursor:
+                break
+    return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=_COLUMNS)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Ingest Sharadar SF1 into the PIT fundamentals store.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--tickers", help="comma-separated tickers")
+    g.add_argument("--from-universe", action="store_true", help="use the etoro.csv universe")
+    ap.add_argument("--since", help="only filings with datekey >= this (YYYY-MM-DD)")
+    args = ap.parse_args()
+
+    key = _api_key()
+    if not key:
+        print(
+            "ERROR: no Nasdaq Data Link API key. Set NDL_API_KEY (get it at "
+            "https://data.nasdaq.com/account/profile, needs a Sharadar SF1 subscription).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    tickers = (
+        [t.strip() for t in args.tickers.split(",") if t.strip()]
+        if args.tickers
+        else _universe_tickers()
+    )
+    if not tickers:
+        print("ERROR: no tickers to fetch.", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"fetching SF1 (ARQ) for {len(tickers)} tickers"
+        + (f" since {args.since}" if args.since else "")
+    )
+    df = _fetch(key, tickers, args.since)
+    print(f"fetched {len(df)} filing rows")
+    added = append_records(df)
+    cov = store_coverage()
+    print(f"appended {added} new (ticker,datekey) rows -> store now: {cov}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_fundamentals_update.py
+++ b/scripts/v3_fundamentals_update.py
@@ -99,6 +99,7 @@ def main() -> None:
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--tickers", help="comma-separated tickers")
     g.add_argument("--from-universe", action="store_true", help="use the etoro.csv universe")
+    g.add_argument("--from-file", help="read tickers from a file (one per line)")
     ap.add_argument("--since", help="only filings with datekey >= this (YYYY-MM-DD)")
     args = ap.parse_args()
 
@@ -111,11 +112,12 @@ def main() -> None:
         )
         sys.exit(2)
 
-    tickers = (
-        [t.strip() for t in args.tickers.split(",") if t.strip()]
-        if args.tickers
-        else _universe_tickers()
-    )
+    if args.tickers:
+        tickers = [t.strip() for t in args.tickers.split(",") if t.strip()]
+    elif args.from_file:
+        tickers = [ln.strip() for ln in Path(args.from_file).read_text().splitlines() if ln.strip()]
+    else:
+        tickers = _universe_tickers()
     if not tickers:
         print("ERROR: no tickers to fetch.", file=sys.stderr)
         sys.exit(1)

--- a/scripts/v3_sep_prices_update.py
+++ b/scripts/v3_sep_prices_update.py
@@ -1,0 +1,120 @@
+"""Ingest Sharadar SEP (survivorship-clean equity prices, incl. delisted) into a
+month-end price store for the PIT fundamentals backtest.
+
+SEP carries delisted tickers, which yfinance drops — the source of the survivorship
+bias flagged in the first fundamentals backtest. We pull daily adjusted close
+(``closeadj``, split+dividend adjusted), resample per ticker to month-end, and append
+to a dedicated append-only store (``v3/price_store`` machinery) so a name that later
+delisted still prices historically.
+
+Auth: NDL_API_KEY (Sharadar SF1+SEP bundle). Usage:
+    .venv/bin/python scripts/v3_sep_prices_update.py --from-universe --since 2015-01-01
+    .venv/bin/python scripts/v3_sep_prices_update.py --tickers AAPL,MSFT --since 2015-01-01
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from trade_modules.v3.price_store import append_bars, store_coverage  # noqa: E402
+
+SEP_STORE = str(Path("~/.weirdapps-trading/v3_sep_monthly.parquet").expanduser())
+BASE = "https://data.nasdaq.com/api/v3/datatables/SHARADAR/SEP.json"
+ETORO_CSV = "yahoofinance/output/etoro.csv"
+
+
+def _api_key() -> str | None:
+    for var in ("NDL_API_KEY", "NASDAQ_DATA_LINK_API_KEY", "QUANDL_API_KEY"):
+        if os.environ.get(var):
+            return os.environ[var]
+    return None
+
+
+def _universe_tickers() -> list[str]:
+    df = pd.read_csv(ETORO_CSV, na_values=["--"])
+    return sorted(df["TKR"].dropna().astype(str).unique())
+
+
+def _fetch_daily(key: str, tickers: list[str], since: str) -> pd.DataFrame:
+    """Daily (ticker, date, closeadj) for a ticker batch, all pages."""
+    frames: list[pd.DataFrame] = []
+    for i in range(0, len(tickers), 100):
+        batch = ",".join(tickers[i : i + 100])
+        cursor: str | None = None
+        while True:
+            q = {
+                "ticker": batch,
+                "date.gte": since,
+                "qopts.columns": "ticker,date,closeadj",
+                "api_key": key,
+            }
+            if cursor:
+                q["qopts.cursor_id"] = cursor
+            url = f"{BASE}?{urllib.parse.urlencode(q)}"
+            with urllib.request.urlopen(url, timeout=90) as resp:  # noqa: S310 (fixed https host)
+                payload = json.loads(resp.read().decode())
+            dt = payload.get("datatable", {})
+            rows, cols = dt.get("data", []), [c["name"] for c in dt.get("columns", [])]
+            if rows:
+                frames.append(pd.DataFrame(rows, columns=cols))
+            cursor = payload.get("meta", {}).get("next_cursor_id")
+            if not cursor:
+                break
+    return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+
+def _to_month_end(daily: pd.DataFrame) -> pd.DataFrame:
+    """Long daily (ticker, date, closeadj) -> long month-end (date, ticker, close)."""
+    if daily.empty:
+        return pd.DataFrame(columns=["date", "ticker", "close"])
+    d = daily.copy()
+    d["date"] = pd.to_datetime(d["date"], errors="coerce")
+    d["close"] = pd.to_numeric(d["closeadj"], errors="coerce")
+    d = d.dropna(subset=["date", "close"])
+    me = d.set_index("date").groupby("ticker")["close"].resample("ME").last().reset_index()
+    me["date"] = me["date"].dt.strftime("%Y-%m-%d")
+    return me[["date", "ticker", "close"]]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Ingest Sharadar SEP -> month-end price store.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--tickers")
+    g.add_argument("--from-universe", action="store_true")
+    ap.add_argument("--since", default="2015-01-01")
+    args = ap.parse_args()
+
+    key = _api_key()
+    if not key:
+        print("ERROR: no NDL_API_KEY (needs the Sharadar SEP bundle).", file=sys.stderr)
+        sys.exit(2)
+    tickers = (
+        [t.strip() for t in args.tickers.split(",") if t.strip()]
+        if args.tickers
+        else _universe_tickers()
+    )
+    print(f"SEP: fetching daily closeadj for {len(tickers)} tickers since {args.since}")
+    total_added = 0
+    # Process in ticker chunks so month-end resampling stays bounded in memory.
+    for i in range(0, len(tickers), 200):
+        chunk = tickers[i : i + 200]
+        daily = _fetch_daily(key, chunk, args.since)
+        me = _to_month_end(daily)
+        added = append_bars(me, store_path=SEP_STORE) if not me.empty else 0
+        total_added += added
+        print(f"  chunk {i // 200 + 1}: {len(daily)} daily -> +{added} month-end rows")
+    print(f"done: +{total_added} rows -> {store_coverage(SEP_STORE)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/trade_modules/test_v3_fundamentals.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals.py
@@ -72,3 +72,21 @@ def test_factor_panel_matches_scalar_derivations():
     assert fp.loc["A", "gp_assets"] == pytest.approx(0.15)
     assert fp.loc["A", "accruals"] == pytest.approx(0.04)
     assert math.isnan(fp.loc["B", "book_to_price"])  # negative equity -> NaN
+
+
+def test_factor_panel_handles_empty_prior():
+    # Early months have no prior-year filing -> fprior is empty; must not crash.
+    fasof = pd.DataFrame(
+        {
+            "equity": [40.0],
+            "assets": [200.0],
+            "gp": [30.0],
+            "netinc": [20.0],
+            "ncfo": [12.0],
+            "sharesbas": [10.0],
+        },
+        index=["A"],
+    )
+    fp = factor_panel(fasof, pd.DataFrame(), pd.Series({"A": 10.0}))
+    assert math.isnan(fp.loc["A", "asset_growth"])  # no prior -> NaN
+    assert fp.loc["A", "gp_assets"] == pytest.approx(0.15)  # others still compute

--- a/tests/unit/trade_modules/test_v3_fundamentals.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals.py
@@ -1,0 +1,51 @@
+"""TDD — PIT fundamental factor derivations (the data-blocked durable premia)."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from trade_modules.v3.fundamentals import (
+    accruals,
+    asset_growth,
+    book_to_price,
+    gross_profit_to_assets,
+    srw_sue,
+)
+
+
+def test_book_to_price():
+    assert book_to_price(40.0, 100.0) == pytest.approx(0.40)  # cheap on book
+    assert math.isnan(book_to_price(-5.0, 100.0))  # negative book -> meaningless
+    assert math.isnan(book_to_price(40.0, 0.0))  # no market cap
+
+
+def test_asset_growth_is_yoy():
+    assert asset_growth(110.0, 100.0) == pytest.approx(0.10)  # +10% (CMA: low is good)
+    assert asset_growth(90.0, 100.0) == pytest.approx(-0.10)  # conservative investment
+    assert math.isnan(asset_growth(110.0, 0.0))
+
+
+def test_gross_profit_to_assets():
+    assert gross_profit_to_assets(30.0, 120.0) == pytest.approx(0.25)  # Novy-Marx quality
+    assert math.isnan(gross_profit_to_assets(30.0, 0.0))
+
+
+def test_accruals():
+    # (net income - operating cash flow) / assets; high accruals = low earnings quality.
+    assert accruals(20.0, 12.0, 200.0) == pytest.approx(0.04)
+    assert accruals(10.0, 25.0, 300.0) == pytest.approx(-0.05)  # cash-backed earnings
+    assert math.isnan(accruals(20.0, 12.0, 0.0))
+
+
+def test_srw_sue_positive_on_accelerating_eps():
+    # Seasonal-random-walk SUE = (eps_t - eps_{t-4}) / std(seasonal diffs). Needs the
+    # EPS history; the last jump (1.6 vs 1.2 = +0.4) is large vs prior +0.2 steps.
+    eps = pd.Series([1.0, 1.1, 1.2, 1.3, 1.2, 1.3, 1.4, 1.6])
+    assert srw_sue(eps) > 0
+
+
+def test_srw_sue_needs_enough_history():
+    assert math.isnan(srw_sue(pd.Series([1.0, 1.1, 1.2])))  # < 5 quarters -> NaN

--- a/tests/unit/trade_modules/test_v3_fundamentals.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals.py
@@ -11,6 +11,7 @@ from trade_modules.v3.fundamentals import (
     accruals,
     asset_growth,
     book_to_price,
+    factor_panel,
     gross_profit_to_assets,
     srw_sue,
 )
@@ -49,3 +50,25 @@ def test_srw_sue_positive_on_accelerating_eps():
 
 def test_srw_sue_needs_enough_history():
     assert math.isnan(srw_sue(pd.Series([1.0, 1.1, 1.2])))  # < 5 quarters -> NaN
+
+
+def test_factor_panel_matches_scalar_derivations():
+    fasof = pd.DataFrame(
+        {
+            "equity": [40.0, -5.0],
+            "assets": [200.0, 100.0],
+            "gp": [30.0, 20.0],
+            "netinc": [20.0, 5.0],
+            "ncfo": [12.0, 8.0],
+            "sharesbas": [10.0, 10.0],
+        },
+        index=["A", "B"],
+    )
+    fprior = pd.DataFrame({"assets": [180.0, 120.0]}, index=["A", "B"])
+    price = pd.Series({"A": 10.0, "B": 5.0})
+    fp = factor_panel(fasof, fprior, price)
+    assert fp.loc["A", "book_to_price"] == pytest.approx(0.40)  # 40 / (10*10)
+    assert fp.loc["A", "asset_growth"] == pytest.approx(200 / 180 - 1)
+    assert fp.loc["A", "gp_assets"] == pytest.approx(0.15)
+    assert fp.loc["A", "accruals"] == pytest.approx(0.04)
+    assert math.isnan(fp.loc["B", "book_to_price"])  # negative equity -> NaN

--- a/tests/unit/trade_modules/test_v3_fundamentals_store.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals_store.py
@@ -1,0 +1,116 @@
+"""TDD — PIT fundamentals store (Sharadar SF1). The core primitive is a strict
+point-in-time read: as of date T, only filings with datekey <= T are visible."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from trade_modules.v3.fundamentals_store import (
+    append_records,
+    read_asof,
+    read_history,
+    store_coverage,
+)
+
+
+def _rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            # AAA: Q1 filed 03-15, Q2 filed 06-14 (a filing becomes visible on its datekey)
+            {
+                "ticker": "AAA",
+                "datekey": "2026-03-15",
+                "reportperiod": "2026-03-31",
+                "assets": 100.0,
+                "equity": 40.0,
+            },
+            {
+                "ticker": "AAA",
+                "datekey": "2026-06-14",
+                "reportperiod": "2026-06-30",
+                "assets": 110.0,
+                "equity": 44.0,
+            },
+            {
+                "ticker": "BBB",
+                "datekey": "2026-05-01",
+                "reportperiod": "2026-03-31",
+                "assets": 200.0,
+                "equity": 80.0,
+            },
+        ]
+    )
+
+
+def test_read_asof_is_point_in_time(tmp_path):
+    store = str(tmp_path / "f.parquet")
+    append_records(_rows(), store_path=store)
+    # As of 05-01, AAA's Q2 (datekey 06-14) is NOT yet public -> must see Q1 only.
+    asof = read_asof(["AAA", "BBB"], "2026-05-01", store_path=store)
+    assert asof.loc["AAA", "assets"] == 100.0  # no look-ahead
+    assert asof.loc["BBB", "assets"] == 200.0
+    # As of 06-30, AAA's Q2 is public.
+    asof2 = read_asof(["AAA"], "2026-06-30", store_path=store)
+    assert asof2.loc["AAA", "assets"] == 110.0
+
+
+def test_read_asof_excludes_ticker_with_no_visible_filing(tmp_path):
+    store = str(tmp_path / "f.parquet")
+    append_records(_rows(), store_path=store)
+    # Before any BBB filing (datekey 05-01), BBB has nothing visible.
+    asof = read_asof(["AAA", "BBB"], "2026-04-01", store_path=store)
+    assert "AAA" in asof.index
+    assert "BBB" not in asof.index
+
+
+def test_append_only_and_newest_wins_on_restatement(tmp_path):
+    store = str(tmp_path / "f.parquet")
+    append_records(_rows(), store_path=store)
+    # A restated refresh of the SAME (ticker, datekey) updates the value...
+    append_records(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": "AAA",
+                    "datekey": "2026-03-15",
+                    "reportperiod": "2026-03-31",
+                    "assets": 101.0,
+                }
+            ]
+        ),
+        store_path=store,
+    )
+    # ...and a delisted name's rows persist (append-only, never dropped).
+    append_records(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": "ZZZ",
+                    "datekey": "2026-01-10",
+                    "reportperiod": "2025-12-31",
+                    "assets": 50.0,
+                }
+            ]
+        ),
+        store_path=store,
+    )
+    asof = read_asof(["AAA"], "2026-04-01", store_path=store)
+    assert asof.loc["AAA", "assets"] == 101.0  # newest-wins on same (ticker, datekey)
+    cov = store_coverage(store)
+    assert cov["n_tickers"] == 3  # AAA, BBB, ZZZ all retained
+
+
+def test_read_history_returns_visible_rows_sorted(tmp_path):
+    store = str(tmp_path / "f.parquet")
+    append_records(_rows(), store_path=store)
+    hist = read_history(["AAA"], "2026-12-31", store_path=store)
+    assert list(hist["datekey"]) == ["2026-03-15", "2026-06-14"]  # both, oldest-first
+    # bounded by as_of
+    hist2 = read_history(["AAA"], "2026-05-01", store_path=store)
+    assert list(hist2["datekey"]) == ["2026-03-15"]
+
+
+def test_empty_store_is_safe(tmp_path):
+    store = str(tmp_path / "none.parquet")
+    assert read_asof(["AAA"], "2026-05-01", store_path=store).empty
+    assert store_coverage(store)["n_rows"] == 0

--- a/trade_modules/v3/fundamentals.py
+++ b/trade_modules/v3/fundamentals.py
@@ -1,0 +1,85 @@
+"""PIT fundamental factor derivations — the data-blocked durable premia we cannot
+build from the current panel (need Sharadar SF1 balance-sheet / cash-flow history).
+
+Pure, unit-tested; no I/O. Each takes already-point-in-time values (from
+``fundamentals_store.read_asof`` / ``read_history``, i.e. datekey <= as_of) and
+returns the raw factor value. Directional signs are applied later in the combiner
+(book_to_price + / asset_growth − / gp_assets + / accruals − / sue +).
+
+References: Fama-French (book-to-market; CMA investment), Hou-Xue-Zhang (q-factor
+investment), Novy-Marx (gross-profitability/assets), Sloan (accruals), Foster-
+Olsen-Shevlin / Bernard-Thomas (PEAD, seasonal-random-walk SUE).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+
+def _num(x) -> float:
+    try:
+        v = float(x)
+    except (TypeError, ValueError):
+        return math.nan
+    return v if math.isfinite(v) else math.nan
+
+
+def book_to_price(equity, market_cap) -> float:
+    """Book-to-price = shareholders' equity / market cap (high = cheap on book).
+
+    The Fama-French value anchor and the right valuation metric for financials.
+    NaN when book is non-positive (meaningless — e.g. buyback-heavy / intangible
+    firms) or market cap is missing/zero.
+    """
+    e, m = _num(equity), _num(market_cap)
+    if math.isnan(e) or math.isnan(m) or e <= 0 or m <= 0:
+        return math.nan
+    return e / m
+
+
+def asset_growth(assets_now, assets_year_ago) -> float:
+    """Year-over-year total-asset growth (the CMA / investment factor; low is good)."""
+    a, a0 = _num(assets_now), _num(assets_year_ago)
+    if math.isnan(a) or math.isnan(a0) or a0 == 0:
+        return math.nan
+    return a / a0 - 1.0
+
+
+def gross_profit_to_assets(gross_profit, assets) -> float:
+    """Gross profitability / total assets (Novy-Marx quality; high is good)."""
+    g, a = _num(gross_profit), _num(assets)
+    if math.isnan(g) or math.isnan(a) or a == 0:
+        return math.nan
+    return g / a
+
+
+def accruals(net_income, operating_cash_flow, assets) -> float:
+    """Balance-sheet accruals = (net income − operating cash flow) / assets.
+
+    High accruals = earnings not backed by cash = lower earnings quality (Sloan);
+    scored negative in the combiner.
+    """
+    ni, cf, a = _num(net_income), _num(operating_cash_flow), _num(assets)
+    if math.isnan(ni) or math.isnan(cf) or math.isnan(a) or a == 0:
+        return math.nan
+    return (ni - cf) / a
+
+
+def srw_sue(eps_history) -> float:
+    """Seasonal-random-walk standardized unexpected earnings (PEAD signal).
+
+    ``eps_history`` is a ticker's chronological quarterly EPS (oldest→newest). SUE =
+    the latest year-over-year EPS change divided by the volatility of those seasonal
+    changes: ``(eps_t − eps_{t-4}) / std(Δ4 eps)``. Needs ≥5 quarters (≥2 seasonal
+    diffs); NaN otherwise or on zero dispersion. Uses only actuals — no consensus feed.
+    """
+    e = pd.to_numeric(pd.Series(eps_history), errors="coerce").dropna()
+    diffs = e.diff(4).dropna()
+    if len(diffs) < 2:
+        return math.nan
+    sd = float(diffs.std(ddof=1))
+    if not sd or math.isnan(sd) or sd == 0:
+        return math.nan
+    return float(diffs.iloc[-1] / sd)

--- a/trade_modules/v3/fundamentals.py
+++ b/trade_modules/v3/fundamentals.py
@@ -83,3 +83,33 @@ def srw_sue(eps_history) -> float:
     if not sd or math.isnan(sd) or sd == 0:
         return math.nan
     return float(diffs.iloc[-1] / sd)
+
+
+def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) -> pd.DataFrame:
+    """Vectorized cross-section of the balance-sheet / cash-flow PIT factors.
+
+    ``fasof`` = point-in-time fundamentals as of date T (from ``read_asof(T)``);
+    ``fprior`` = fundamentals as of ~T−1yr (for asset growth); ``price`` = the price
+    at T per ticker (to form market cap = price × sharesbas). All aligned to
+    ``fasof.index``. Returns the four raw factors (book_to_price, asset_growth,
+    gp_assets, accruals) — SUE is series-based and handled separately.
+    """
+    idx = fasof.index
+
+    def col(df: pd.DataFrame, name: str) -> pd.Series:
+        return pd.to_numeric(df.reindex(idx).get(name), errors="coerce")
+
+    eq, assets, gp = col(fasof, "equity"), col(fasof, "assets"), col(fasof, "gp")
+    ni, cf, shares = col(fasof, "netinc"), col(fasof, "ncfo"), col(fasof, "sharesbas")
+    assets_prior = col(fprior, "assets")
+    px = pd.to_numeric(pd.Series(price).reindex(idx), errors="coerce")
+
+    mktcap = px * shares
+    return pd.DataFrame(
+        {
+            "book_to_price": (eq / mktcap).where((eq > 0) & (mktcap > 0)),
+            "asset_growth": (assets / assets_prior - 1.0).where(assets_prior > 0),
+            "gp_assets": (gp / assets).where(assets != 0),
+            "accruals": ((ni - cf) / assets).where(assets != 0),
+        }
+    )

--- a/trade_modules/v3/fundamentals.py
+++ b/trade_modules/v3/fundamentals.py
@@ -97,7 +97,11 @@ def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) ->
     idx = fasof.index
 
     def col(df: pd.DataFrame, name: str) -> pd.Series:
-        return pd.to_numeric(df.reindex(idx).get(name), errors="coerce")
+        # Always return a Series aligned to idx, even when df is empty / lacks the
+        # column (e.g. no prior-year filing) — otherwise .where() gets a scalar.
+        reixed = df.reindex(idx)
+        s = reixed[name] if name in reixed.columns else pd.Series(index=idx, dtype=float)
+        return pd.to_numeric(s, errors="coerce")
 
     eq, assets, gp = col(fasof, "equity"), col(fasof, "assets"), col(fasof, "gp")
     ni, cf, shares = col(fasof, "netinc"), col(fasof, "ncfo"), col(fasof, "sharesbas")

--- a/trade_modules/v3/fundamentals_store.py
+++ b/trade_modules/v3/fundamentals_store.py
@@ -1,0 +1,122 @@
+"""PIT fundamentals store (Sharadar SF1) — the point-in-time backbone for the
+data-blocked durable premia (P/B, asset-growth/CMA, GP-assets, accruals, SUE/PEAD).
+
+Mirrors ``v3/price_store.py``: a single append-only long parquet keyed by
+``(ticker, datekey)``, where ``datekey`` is the date a filing became PUBLIC. The
+core primitive is :func:`read_asof` — as of date T it returns, per ticker, the most
+recent filing with ``datekey <= T`` only, so a factor computed "as of T" can never
+see a report that had not yet been filed (no look-ahead). Rows are never dropped
+(delisting / restatement history retained); a conflicting ``(ticker, datekey)`` is
+refreshed to the newest values (restatements).
+
+Storage: ``~/.weirdapps-trading/v3_fundamentals_store.parquet``. Fields are the
+minimal set the derivations in ``v3/fundamentals.py`` need; extend NUM_FIELDS as
+more factors are added. Ingestion (network) lives in ``scripts/v3_fundamentals_update.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+STORE_PATH: str = str(Path("~/.weirdapps-trading/v3_fundamentals_store.parquet").expanduser())
+
+KEYS = ["ticker", "datekey", "reportperiod"]
+# Numeric as-reported fields we derive factors from (Sharadar SF1 names, ARQ dimension).
+NUM_FIELDS = ["assets", "equity", "gp", "netinc", "ncfo", "revenue", "eps"]
+STORE_COLS = KEYS + NUM_FIELDS
+
+
+def _normalise(records: pd.DataFrame) -> pd.DataFrame:
+    """Coerce an incoming frame to the canonical schema (missing fields -> NaN)."""
+    if records is None or len(records) == 0:
+        return pd.DataFrame(columns=STORE_COLS)
+    out = records.reindex(columns=STORE_COLS).copy()
+    out["ticker"] = out["ticker"].astype(str)
+    out["datekey"] = pd.to_datetime(out["datekey"], errors="coerce").dt.strftime("%Y-%m-%d")
+    out["reportperiod"] = out["reportperiod"].astype("object")
+    for f in NUM_FIELDS:
+        out[f] = pd.to_numeric(out[f], errors="coerce")
+    return out.dropna(subset=["ticker", "datekey"])[STORE_COLS]
+
+
+def _read_store(store_path: str) -> pd.DataFrame:
+    p = Path(store_path).expanduser()
+    if not p.exists():
+        return pd.DataFrame(columns=STORE_COLS)
+    try:
+        return pd.read_parquet(p).reindex(columns=STORE_COLS)
+    except Exception:  # noqa: BLE001 - a corrupt store must not crash the pipeline
+        return pd.DataFrame(columns=STORE_COLS)
+
+
+def append_records(records: pd.DataFrame, *, store_path: str = STORE_PATH) -> int:
+    """Merge ``records`` into the append-only store.
+
+    Existing ``(ticker, datekey)`` rows are refreshed to the newest values (a
+    restatement filed under the same datekey); no row is ever dropped. Returns the
+    number of NEW ``(ticker, datekey)`` pairs added.
+    """
+    new = _normalise(records)
+    if new.empty:
+        return 0
+    existing = _read_store(store_path)
+    existing_keys = (
+        set(zip(existing["ticker"], existing["datekey"], strict=False))
+        if not existing.empty
+        else set()
+    )
+    added = len(
+        {(t, d) for t, d in zip(new["ticker"], new["datekey"], strict=False)} - existing_keys
+    )
+    combined = pd.concat([existing, new], ignore_index=True)
+    combined = combined.drop_duplicates(subset=["ticker", "datekey"], keep="last").sort_values(
+        ["ticker", "datekey"]
+    )
+    p = Path(store_path).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    combined.to_parquet(p, index=False)
+    return added
+
+
+def read_asof(tickers, as_of, *, store_path: str = STORE_PATH) -> pd.DataFrame:
+    """Point-in-time cross-section: per ticker, the latest filing with datekey <= as_of.
+
+    Returns a frame indexed by ticker (columns = NUM_FIELDS + datekey + reportperiod).
+    Tickers with no visible filing as of ``as_of`` are omitted. Empty if the store is.
+    """
+    store = _read_store(store_path)
+    if store.empty:
+        return pd.DataFrame()
+    want = {str(t) for t in tickers}
+    sub = store[store["ticker"].isin(want) & (store["datekey"] <= str(as_of))]
+    if sub.empty:
+        return pd.DataFrame()
+    latest = sub.sort_values("datekey").groupby("ticker", as_index=True).last()
+    return latest[NUM_FIELDS + ["datekey", "reportperiod"]]
+
+
+def read_history(tickers, as_of, *, store_path: str = STORE_PATH) -> pd.DataFrame:
+    """All filings visible as of ``as_of`` for ``tickers``, oldest-first — for
+    series-based factors (e.g. seasonal-random-walk SUE needs the EPS history)."""
+    store = _read_store(store_path)
+    if store.empty:
+        return pd.DataFrame(columns=STORE_COLS)
+    want = {str(t) for t in tickers}
+    sub = store[store["ticker"].isin(want) & (store["datekey"] <= str(as_of))]
+    return sub.sort_values(["ticker", "datekey"]).reset_index(drop=True)
+
+
+def store_coverage(store_path: str = STORE_PATH) -> dict:
+    """Diagnostics: row / ticker counts and the stored datekey range."""
+    store = _read_store(store_path)
+    if store.empty:
+        return {"n_rows": 0, "n_tickers": 0, "first": None, "last": None}
+    dk = store["datekey"]
+    return {
+        "n_rows": int(len(store)),
+        "n_tickers": int(store["ticker"].nunique()),
+        "first": str(dk.min()),
+        "last": str(dk.max()),
+    }

--- a/trade_modules/v3/fundamentals_store.py
+++ b/trade_modules/v3/fundamentals_store.py
@@ -24,7 +24,18 @@ STORE_PATH: str = str(Path("~/.weirdapps-trading/v3_fundamentals_store.parquet")
 
 KEYS = ["ticker", "datekey", "reportperiod"]
 # Numeric as-reported fields we derive factors from (Sharadar SF1 names, ARQ dimension).
-NUM_FIELDS = ["assets", "equity", "gp", "netinc", "ncfo", "revenue", "eps"]
+# sharesbas + marketcap let us build book-to-price at ANY date (equity / (price*shares)).
+NUM_FIELDS = [
+    "assets",
+    "equity",
+    "gp",
+    "netinc",
+    "ncfo",
+    "revenue",
+    "eps",
+    "sharesbas",
+    "marketcap",
+]
 STORE_COLS = KEYS + NUM_FIELDS
 
 

--- a/trade_modules/v3/fundamentals_store.py
+++ b/trade_modules/v3/fundamentals_store.py
@@ -70,7 +70,8 @@ def append_records(records: pd.DataFrame, *, store_path: str = STORE_PATH) -> in
     added = len(
         {(t, d) for t, d in zip(new["ticker"], new["datekey"], strict=False)} - existing_keys
     )
-    combined = pd.concat([existing, new], ignore_index=True)
+    # Skip concat when the store is empty to avoid a pandas all-NA FutureWarning.
+    combined = new if existing.empty else pd.concat([existing, new], ignore_index=True)
     combined = combined.drop_duplicates(subset=["ticker", "datekey"], keep="last").sort_values(
         ["ticker", "datekey"]
     )


### PR DESCRIPTION
Phase 1 of the #1 alpha lever (owner decision: **A / US-first Sharadar**). Network-free, TDD; not wired into scoring yet.

**Why this is the top lever:** point-in-time fundamentals unlock the data-blocked durable premia (P/B, asset-growth/CMA, GP-assets, accruals, PEAD) AND — because Sharadar carries ~20y of PIT history — let the multi-year / multi-regime validation clock run **now**, instead of waiting years on the 5-month etoro.csv panel.

## What's here
- `v3/fundamentals_store.py` — append-only parquet keyed by (ticker, **datekey** = filing date). `read_asof(T)` returns only filings with datekey ≤ T (strict PIT, no look-ahead); `read_history` for series factors; delisting/restatement retention. Mirrors the price store.
- `v3/fundamentals.py` — pure derivations: book_to_price, asset_growth (CMA), gross_profit_to_assets (Novy-Marx), accruals (Sloan), srw_sue (PEAD, seasonal-random-walk, actuals-only — no consensus feed needed).
- `scripts/v3_fundamentals_update.py` — Sharadar SF1 (ARQ) ingestion via Nasdaq Data Link (stdlib urllib, paginated). Key from `NDL_API_KEY` env, never the repo; fails clean with instructions when absent.

## Tests
11 (RED→GREEN). Next: Phase 3 backtest over Sharadar history (HAC + Fama-MacBeth, finally multi-regime), then Phase 4 promote only what clears the frozen gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)