### PR TITLE
feat(v3): best-bet factor prior + adaptive weight-proposal mechanism

### DIFF
--- a/scripts/v3_pipeline_map.py
+++ b/scripts/v3_pipeline_map.py
@@ -60,6 +60,9 @@ LABEL = {
     "op_margin": "Operating margin",
     "accruals": "Accruals",
     "target_dispersion": "Target dispersion",
+    "gp_assets": "Gross profit / assets",
+    "sue": "Earnings surprise (SUE)",
+    "asset_growth": "Asset growth (CMA)",
 }
 _DIRTXT = {1: "high = good", -1: "low = good"}
 
@@ -70,6 +73,7 @@ CLUSTER_LABEL = {
     "growth_z": "Growth",
     "lowvol_z": "Low volatility",
     "strength_z": "Strength",
+    "pead_z": "PEAD (earnings surprise)",
 }
 
 # Curated non-scored classification (documented FIX-NOW / redesign decisions).
@@ -88,10 +92,11 @@ MONITORED = {  # shadow-logged + backtested, ZERO conviction
 DISCARDED = {
     "pe_forward": "near-duplicate of trailing P/E (ρ 0.75) — removed",
     "target_dispersion": "live-fetched, non-point-in-time — removed",
-    "accruals": "needs a point-in-time balance sheet — BUILD / shadow",
-    "roa": "retired for the interim quality set (ROE + FCF)",
-    "gross_margin": "per-sales margin; the Novy-Marx anchor is GP/assets — BUILD",
+    "roa": "retired for the interim quality set (ROE + FCF + GP/assets)",
+    "gross_margin": "per-sales margin; superseded by GP/assets (now scored)",
     "op_margin": "per-sales margin; operating-profitability/assets — BUILD",
+    "asset_growth": "CMA / investment — NO alpha on survivorship-clean data (FM ~0) → excluded",
+    "accruals": "Sloan accruals — NO alpha on survivorship-clean data → excluded",
 }
 
 

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -239,10 +239,10 @@ def test_derive_cluster_weights_equal_spread_when_rest_ic_nonpositive():
     """Freed weight spreads equally when non-VQ clusters all have IC ≤ 0 (else branch).
 
     Triggers the ``else`` branch at combine.py ~line 118: VQ IC is high enough
-    to push sum above the 0.55 cap, and the three remaining clusters (momentum,
-    lowvol, strength) have IC ≤ 0 so their raw weights are all zero.  The freed
-    weight (1 - 0.55 = 0.45) must be spread equally across the three clusters,
-    giving each 0.15, and the VQ pair is still exactly at the 0.55 cap.
+    to push sum above the 0.55 cap, and the four remaining clusters (momentum,
+    lowvol, strength, pead) have IC ≤ 0 so their raw weights are all zero.  The freed
+    weight (1 - 0.55 = 0.45) must be spread equally across the four clusters,
+    giving each 0.1125, and the VQ pair is still exactly at the 0.55 cap.
     """
     from trade_modules.v3.combine import derive_cluster_weights
 
@@ -258,8 +258,8 @@ def test_derive_cluster_weights_equal_spread_when_rest_ic_nonpositive():
     assert abs(sum(w.values()) - 1.0) < 1e-9, f"weights sum {sum(w.values())} != 1.0"
     assert abs(w["value_z"] + w["quality_z"] - 0.55) < 1e-9, "VQ cap not exactly 0.55"
 
-    expected_each = (1.0 - 0.55) / 3  # 0.45 / 3 = 0.15
-    for c in ("momentum_z", "lowvol_z", "strength_z"):
+    expected_each = (1.0 - 0.55) / 4  # rest = momentum, lowvol, strength, pead
+    for c in ("momentum_z", "lowvol_z", "strength_z", "pead_z"):
         assert abs(w[c] - expected_each) < 1e-9, (
             f"{c}: got {w[c]:.6f}, expected {expected_each:.6f}"
         )
@@ -341,6 +341,7 @@ def test_growth_cluster_registered_direction_positive():
         "growth_z",
         "lowvol_z",
         "strength_z",
+        "pead_z",
     ]
 
 
@@ -511,27 +512,29 @@ def test_fixnow_value_drops_raw_pb_anchors_ev_ebitda():
         assert "pb" not in members, "raw P/B must not be scored in any cluster"
 
 
-def test_fixnow_quality_interim_is_roe_fcf():
-    """Interim quality = ROE + FCF (panel-available). Per-sales margins + roa retired
-    (GP/assets is the right anchor but unbuildable now → BUILD); current_ratio + de move
-    to a distress filter; accruals is shadow-only (non-PIT) (D8)."""
-    from trade_modules.v3.combine import CLUSTERS
+def test_quality_is_roe_fcf_gp_assets():
+    """Quality = ROE + FCF + GP/assets (Novy-Marx anchor added 2026-07-19 once the
+    Sharadar SF1 PIT data was in). Per-sales margins + roa stay retired; current_ratio
+    + de are a distress filter; accruals shadow-only (no clean alpha)."""
+    from trade_modules.v3.combine import CLUSTERS, DIRECTION
 
-    assert CLUSTERS["quality_z"] == ["roe", "fcf"]
+    assert CLUSTERS["quality_z"] == ["roe", "fcf", "gp_assets"]
+    assert DIRECTION["gp_assets"] == +1
     for dead in ("roa", "gross_margin", "op_margin", "current_ratio", "de", "accruals"):
         for members in CLUSTERS.values():
-            assert dead not in members, f"{dead} must not be scored in quality (interim)"
+            assert dead not in members, f"{dead} must not be scored in quality"
 
 
-def test_fixnow_equal_weight_core_no_vq_floor():
-    """Default weights: core (value/quality/momentum/lowvol) equal — no discretionary
-    tilt; growth = satellite (reduced, >0); strength = small cap; NO Value+Quality
-    cap-as-floor (VQ well below 0.55); weights sum to 1 (D14, D6b, D11, D7)."""
+def test_best_bet_prior_weights_2026_07_19():
+    """BEST-BET prior (grounded in the survivorship-clean backtest + literature):
+    quality-led (GP/assets), value+momentum held as durable core, PEAD added, low-vol
+    trimmed to a risk-diversifier, growth trimmed. VQ below the 0.55 cap; sum = 1."""
     from trade_modules.v3.combine import CLUSTER_WEIGHTS as w
 
-    assert w["value_z"] == w["quality_z"] == w["momentum_z"] == w["lowvol_z"]
-    assert 0.0 < w["growth_z"] < w["value_z"], "growth is a reduced satellite (>0)"
-    assert 0.0 < w["strength_z"] < w["growth_z"], "strength is a small cap"
+    assert w["quality_z"] == max(w.values()), "quality is the evidence leader"
+    assert w["pead_z"] > 0, "PEAD participates (best clean signal + robust literature)"
+    assert w["lowvol_z"] < w["value_z"], "low-vol trimmed to a risk-diversifier"
+    assert w["lowvol_z"] <= 0.10 + 1e-9, "low-vol capped low (its alpha was a beta artifact)"
     assert (w["value_z"] + w["quality_z"]) < 0.55, "no Value+Quality cap-as-floor"
     assert abs(sum(w.values()) - 1.0) < 1e-9
 

--- a/tests/unit/trade_modules/test_v3_fundamentals.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals.py
@@ -13,6 +13,7 @@ from trade_modules.v3.fundamentals import (
     book_to_price,
     factor_panel,
     gross_profit_to_assets,
+    live_fundamentals_factors,
     srw_sue,
 )
 
@@ -90,3 +91,28 @@ def test_factor_panel_handles_empty_prior():
     fp = factor_panel(fasof, pd.DataFrame(), pd.Series({"A": 10.0}))
     assert math.isnan(fp.loc["A", "asset_growth"])  # no prior -> NaN
     assert fp.loc["A", "gp_assets"] == pytest.approx(0.15)  # others still compute
+
+
+def test_live_fundamentals_factors(tmp_path):
+    from trade_modules.v3.fundamentals_store import append_records
+
+    store = str(tmp_path / "f.parquet")
+    rows = [
+        {"ticker": "AAA", "datekey": dk, "reportperiod": dk, "assets": 200.0, "gp": 30.0, "eps": e}
+        for dk, e in [
+            ("2024-03-15", 1.0),
+            ("2024-06-15", 1.1),
+            ("2024-09-15", 1.2),
+            ("2024-12-15", 1.3),
+            ("2025-03-15", 1.2),
+            ("2025-06-15", 1.4),
+            ("2025-09-15", 1.5),
+            ("2025-12-15", 1.8),
+        ]
+    ]
+    append_records(pd.DataFrame(rows), store_path=store)
+    out = live_fundamentals_factors(["AAA", "ZZZ"], store_path=store)
+    assert out.loc["AAA", "gp_assets"] == pytest.approx(0.15)  # 30 / 200
+    assert not math.isnan(out.loc["AAA", "sue"])  # >=6 quarters -> SUE computable
+    assert math.isnan(out.loc["ZZZ", "gp_assets"])  # not in store -> NaN (graceful)
+    assert math.isnan(out.loc["ZZZ", "sue"])

--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -159,7 +159,16 @@ def test_render_email_is_outlook_safe():
         assert forbidden not in html, forbidden
     assert "&amp;amp;" not in html  # no HTML-entity double-escaping
     # sections + all six factor clusters present
-    for token in ("Factor Snapshot", "Value", "Quality", "Growth", "Momentum", "Analyst", "Risk"):
+    for token in (
+        "Factor Snapshot",
+        "Value",
+        "Quality",
+        "PEAD",
+        "Growth",
+        "Momentum",
+        "Strength",
+        "Risk",
+    ):
         assert token in html, token
     # USD-bloc breach surfaced (0.68 > 0.65 cap)
     assert "BREACH" in html

--- a/tests/unit/trade_modules/test_v3_weight_proposal.py
+++ b/tests/unit/trade_modules/test_v3_weight_proposal.py
@@ -1,0 +1,62 @@
+"""TDD — adaptive weight-proposal mechanism (Bayesian shrinkage prior->IC)."""
+
+from __future__ import annotations
+
+import pytest
+
+from trade_modules.v3.weight_proposal import proposal_table, propose_weights
+
+# Guardrail-valid prior (each ≤ cap 0.30, core ≥ floor 0.10), like the real CLUSTER_WEIGHTS.
+PRIOR = {"value_z": 0.30, "quality_z": 0.25, "momentum_z": 0.25, "lowvol_z": 0.20}
+
+
+def test_no_data_returns_prior():
+    p = propose_weights(PRIOR, ic={}, n={})
+    for c in PRIOR:
+        assert p[c] == pytest.approx(PRIOR[c])
+
+
+def test_real_cluster_weights_roundtrip_at_zero_data():
+    # The deployed best-bet prior must be guardrail-valid: at n=0 the mechanism returns
+    # it unchanged (so deploying it == the mechanism's current proposal).
+    from trade_modules.v3.combine import CLUSTER_WEIGHTS
+
+    p = propose_weights(dict(CLUSTER_WEIGHTS), ic={}, n={})
+    for c in CLUSTER_WEIGHTS:
+        assert p[c] == pytest.approx(CLUSTER_WEIGHTS[c])
+
+
+def test_sums_to_one_and_nonneg():
+    p = propose_weights(PRIOR, ic={"momentum_z": 0.05}, n={"momentum_z": 100})
+    assert abs(sum(p.values()) - 1.0) < 1e-9
+    assert all(v >= 0 for v in p.values())
+
+
+def test_promoted_factor_with_high_ic_rises_above_prior():
+    ic = {"momentum_z": 0.10, "value_z": 0.0, "quality_z": 0.0}
+    n = dict.fromkeys(PRIOR, 1000)  # high confidence
+    p = propose_weights(PRIOR, ic, n, promoted={"momentum_z"})
+    assert p["momentum_z"] > PRIOR["momentum_z"]
+
+
+def test_dsr_gate_limits_unpromoted_gain():
+    # momentum prior (0.2) sits below the cap so the gate (min with prior) actually bites.
+    prior = {"value_z": 0.40, "quality_z": 0.40, "momentum_z": 0.20}
+    ic = {"momentum_z": 0.10}
+    n = dict.fromkeys(prior, 1000)
+    gated = propose_weights(prior, ic, n, promoted=set())
+    promoted = propose_weights(prior, ic, n, promoted={"momentum_z"})
+    assert promoted["momentum_z"] > gated["momentum_z"]
+
+
+def test_floors_never_zero_the_durable_core():
+    ic = {"momentum_z": 0.5}  # momentum dominates the IC
+    n = dict.fromkeys(PRIOR, 1000)
+    p = propose_weights(PRIOR, ic, n, promoted={"momentum_z"})
+    assert p["value_z"] > 0 and p["quality_z"] > 0  # durable core never zeroed
+
+
+def test_proposal_table_sorted_by_abs_delta():
+    t = proposal_table({"a": 0.5, "b": 0.3, "c": 0.2}, {"a": 0.7, "b": 0.2, "c": 0.1})
+    assert t[0]["cluster"] == "a"  # largest |delta| (+0.2 vs -0.1, -0.1)
+    assert t[0]["delta"] == pytest.approx(0.2)

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -31,6 +31,7 @@ DIRECTION = {
     "gross_margin": +1,
     "op_margin": +1,
     "fcf": +1,
+    "gp_assets": +1,  # gross profitability / assets (Novy-Marx) — added 2026-07-19
     "current_ratio": +1,
     "de": -1,
     "accruals": -1,  # high accruals = lower earnings quality = BAD
@@ -50,6 +51,9 @@ DIRECTION = {
     "buy_pct": +1,
     "short_interest": -1,
     "target_dispersion": -1,
+    # earnings surprise / PEAD + investment (2026-07-19)
+    "sue": +1,  # standardized unexpected earnings (post-earnings drift; high is good)
+    "asset_growth": -1,  # CMA / investment (low is good) — monitored, not scored
 }
 
 # Scoring clusters -> member metrics.
@@ -62,12 +66,11 @@ CLUSTERS = {
     # mega-cap-tech universe — shorts the R&D/brand compounders). Anchor on
     # EV/EBITDA + trailing earnings yield. Intangibles-adjusted book -> BUILD.
     "value_z": ["pe_trailing", "ev_ebitda"],
-    # FIX-NOW 2026-07-18 (D8): interim quality = ROE + FCF (panel-available).
-    # GP/assets + operating-profitability/assets are the Novy-Marx anchors but need
-    # Total Assets / Gross Profit -> BUILD. de + current_ratio -> distress filter
-    # (financial strength, not profitability). accruals -> shadow (non-PIT, needs a
-    # point-in-time balance sheet). roa / per-sales margins retired for the interim.
-    "quality_z": ["roe", "fcf"],
+    # quality = ROE + FCF + GP/assets. GP/assets (Novy-Marx) added 2026-07-19 once the
+    # Sharadar SF1 PIT data was in — it was the best survivorship-clean raw IC (t 3.5)
+    # AND the documented profitability anchor. de + current_ratio stay a distress
+    # filter; accruals shadow-only (no clean alpha).
+    "quality_z": ["roe", "fcf", "gp_assets"],
     # price_perf pruned 2026-07-14: rho 0.95 with mom_12_1 (same price move counted
     # twice). Kept the academic 12-1 skip-month + 52w-high proximity (distinct).
     "momentum_z": ["mom_12_1", "pct_52w_high"],
@@ -78,6 +81,10 @@ CLUSTERS = {
     # short_interest (→ squeeze-exclude gate) and target_dispersion (non-PIT,
     # discarded) are removed from scoring. Raw columns stay in the feature frame.
     "strength_z": ["analyst_mom"],
+    # PEAD / earnings surprise (2026-07-19): the most consistent survivorship-clean
+    # signal (beta-neutral IC t 2.06, hit 68%) + robust literature (Bernard-Thomas).
+    # SUE = seasonal-random-walk standardized unexpected earnings, from SF1 actuals.
+    "pead_z": ["sue"],
 }
 
 # ---------------------------------------------------------------------------
@@ -128,13 +135,21 @@ _VALUE_CANDIDATES = sorted({m for r in VALUE_GROUP_RECIPES.values() for m in r})
 # the ic_weights path stays available for the later sizing tier. (True equal-VOL
 # standardization of the cluster z's is a fast-follow refinement; this sets the
 # equal-risk nominal shares and removes the 0.55 VQ floor.)
+# BEST-BET PRIOR 2026-07-19 (grounded in our survivorship-clean backtest + literature,
+# Bayesian-anchored). Quality-led (GP/assets = best clean IC + Novy-Marx); value +
+# momentum held as durable decades-premia (regime-weak now, not chased-dropped); PEAD
+# added (best clean signal + robust); low-vol trimmed 0.21->0.10 (our clean data showed
+# its standalone alpha was a beta artifact -> risk-diversifier only); growth trimmed
+# (short-leg-of-value). CMA + accruals EXCLUDED (no clean alpha). The adaptive shrinkage
+# mechanism (v3/weight_proposal.py) proposes drift toward measured forward IC as data accrues.
 CLUSTER_WEIGHTS = {
-    "value_z": 0.21,
-    "quality_z": 0.21,
-    "momentum_z": 0.21,
-    "growth_z": 0.11,
-    "lowvol_z": 0.21,
-    "strength_z": 0.05,
+    "value_z": 0.20,
+    "quality_z": 0.25,
+    "momentum_z": 0.20,
+    "pead_z": 0.10,
+    "lowvol_z": 0.10,
+    "growth_z": 0.08,
+    "strength_z": 0.07,
 }
 
 # The Value+Quality joint weight is capped here regardless of the weighting scheme.
@@ -145,7 +160,7 @@ _VQ_CAP = 0.55
 # is deliberately EXCLUDED here: it is off (weight 0) in the default + IC paths
 # and only activated through the explicit ``cluster_weights`` arg, so the IC
 # redistribution math (and its unit tests) are unchanged.
-_IC_CLUSTERS = ["value_z", "quality_z", "momentum_z", "lowvol_z", "strength_z"]
+_IC_CLUSTERS = ["value_z", "quality_z", "momentum_z", "lowvol_z", "strength_z", "pead_z"]
 
 # Short-name aliases for the explicit ``cluster_weights`` arg: "value" -> "value_z".
 _CLUSTER_ALIASES = {c[:-2]: c for c in CLUSTERS}
@@ -240,7 +255,15 @@ def derive_cluster_weights(ic_weights: dict | None = None) -> dict[str, float]:
 # Eligibility: cluster columns whose availability is counted (need >= 3 of 6).
 # Growth is included so a name rich in growth data counts toward the minimum;
 # the threshold stays at 3 (a name never becomes ineligible by adding a cluster).
-_ELIG_CLUSTERS = ["value_z", "quality_z", "momentum_z", "growth_z", "lowvol_z", "strength_z"]
+_ELIG_CLUSTERS = [
+    "value_z",
+    "quality_z",
+    "momentum_z",
+    "growth_z",
+    "lowvol_z",
+    "strength_z",
+    "pead_z",
+]
 _MIN_CLUSTERS = 3
 
 

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -431,5 +431,14 @@ def enrich_features(
         errors="coerce",
     )
 
+    # --- (6) PIT fundamentals from the Sharadar SF1 store: GP/assets (quality) + SUE
+    # (PEAD). Latest filing per ticker; NaN for non-US / no-filing names (US-only store),
+    # so the quality / PEAD clusters degrade gracefully. NaN-safe if the store is absent.
+    from trade_modules.v3.fundamentals import live_fundamentals_factors  # noqa: PLC0415
+
+    ff = live_fundamentals_factors(list(feats.index))
+    feats["gp_assets"] = ff["gp_assets"].reindex(feats.index)
+    feats["sue"] = ff["sue"].reindex(feats.index)
+
     feats.index.name = "ticker"
     return feats

--- a/trade_modules/v3/fundamentals.py
+++ b/trade_modules/v3/fundamentals.py
@@ -117,3 +117,32 @@ def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) ->
             "accruals": ((ni - cf) / assets).where(assets != 0),
         }
     )
+
+
+def live_fundamentals_factors(tickers, *, store_path: str | None = None) -> pd.DataFrame:
+    """Latest-filing GP/assets + SUE per ticker from the PIT SF1 store, for LIVE scoring.
+
+    'Live' = the most recent available filing per ticker. Tickers absent from the store
+    (non-US / no filing) get NaN so the quality / PEAD clusters degrade gracefully.
+    NaN-safe if the store is missing/empty. Returns a frame indexed by ticker with
+    columns ``gp_assets`` and ``sue``.
+    """
+    from trade_modules.v3.fundamentals_store import STORE_PATH, read_asof, read_history
+
+    sp = store_path or STORE_PATH
+    idx = pd.Index([str(t) for t in tickers], name="ticker")
+    out = pd.DataFrame(index=idx)
+    out["gp_assets"] = pd.Series(index=idx, dtype=float)
+    out["sue"] = pd.Series(index=idx, dtype=float)
+
+    fasof = read_asof(list(idx), "2099-12-31", store_path=sp)  # latest filing per ticker
+    if not fasof.empty:
+        gp = pd.to_numeric(fasof.get("gp"), errors="coerce")
+        assets = pd.to_numeric(fasof.get("assets"), errors="coerce")
+        out["gp_assets"] = (gp / assets).where(assets != 0).reindex(idx)
+
+    hist = read_history(list(idx), "2099-12-31", store_path=sp)
+    if not hist.empty:
+        sue = hist.sort_values("datekey").groupby("ticker")["eps"].apply(srw_sue)
+        out["sue"] = pd.to_numeric(sue, errors="coerce").reindex(idx)
+    return out

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -45,14 +45,16 @@ CLUSTER_CELLS = [
     ("momentum_z", "Mom"),
     ("lowvol_z", "Low-vol"),
     ("strength_z", "Strength"),
+    ("pead_z", "PEAD"),
 ]
 
-# Six cluster z-scores used in the collapsed card summary strip (all six clusters
-# including Growth, which the combiner computes even when its weight is 0).
+# Cluster z-scores used in the collapsed card summary strip (all clusters the
+# combiner computes, including Growth even when its weight is 0).
 _CARD_CLUSTERS = [
     ("value_z", "Value"),
     ("quality_z", "Quality"),
     ("momentum_z", "Momentum"),
+    ("pead_z", "PEAD"),
     ("growth_z", "Growth"),
     ("lowvol_z", "Low-vol"),
     ("strength_z", "Strength"),
@@ -80,6 +82,7 @@ DISPLAY_GROUPS = [
             ("gross_margin", "Gross Mgn"),
             ("op_margin", "Op Mgn"),
             ("fcf", "FCF Yld"),
+            ("gp_assets", "GP/Assets"),
             ("current_ratio", "Current Ratio"),
             ("de", "Debt/Eq"),
         ],
@@ -92,6 +95,7 @@ DISPLAY_GROUPS = [
             ("pct_52w_high", "% 52w High"),
         ],
     ),
+    ("PEAD", [("sue", "SUE")]),
     ("Low-vol", [("beta", "Beta"), ("realized_vol", "Realized Vol")]),
     ("Strength", [("short_interest", "Short Int"), ("target_dispersion", "Target Disp")]),
     (
@@ -115,6 +119,7 @@ GROUP_CLUSTER = {
     "Momentum": "momentum_z",
     "Low-vol": "lowvol_z",
     "Strength": "strength_z",
+    "PEAD": "pead_z",
 }
 
 # Formatting hints.

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -54,14 +54,19 @@ CONTENT_W = 680
 # Per-stock factor grid: (cluster label, z-column or None, [(metric_key, short label), ...]).
 CARD_FACTORS = [
     ("Value", "value_z", [("pe_forward", "P/E"), ("pb", "P/B"), ("ps_sector", "P/S")]),
-    ("Quality", "quality_z", [("roe", "ROE"), ("op_margin", "op-mgn"), ("fcf", "FCF")]),
+    ("Quality", "quality_z", [("roe", "ROE"), ("fcf", "FCF"), ("gp_assets", "GP/A")]),
+    ("PEAD", "pead_z", [("sue", "SUE")]),
     ("Growth", "growth_z", [("earn_growth", "EPS"), ("rev_growth", "rev")]),
     (
         "Momentum",
         "momentum_z",
         [("mom_12_1", "12-1"), ("pct_52w_high", "52w"), ("price_perf", "12m")],
     ),
-    ("Analyst", None, [("upside", "upside"), ("buy_pct", "buy"), ("analyst_mom", "revis")]),
+    (
+        "Strength",
+        "strength_z",
+        [("analyst_mom", "revis"), ("upside", "upside"), ("buy_pct", "buy")],
+    ),
     ("Risk", "lowvol_z", [("beta", "β"), ("realized_vol", "vol"), ("de", "D/E")]),
 ]
 
@@ -69,6 +74,8 @@ CARD_FACTORS = [
 # (already a percent), ratio (plain number). Scales verified against live scores.
 _METRIC_FMT = {
     "mom_12_1": ("fracpct", 0, True),
+    "gp_assets": ("fracpct", 0, False),  # gross profit / assets
+    "sue": ("ratio", 2, True),  # standardized unexpected earnings (z-like)
     "pct_52w_high": ("pct", 0, False),
     "price_perf": ("pct", 0, True),
     "pe_forward": ("ratio", 1, False),

--- a/trade_modules/v3/weight_proposal.py
+++ b/trade_modules/v3/weight_proposal.py
@@ -1,0 +1,87 @@
+"""Adaptive cluster-weight proposal — Bayesian shrinkage from the best-bet prior
+toward measured forward IC as evidence accrues (proposes; does NOT auto-impose).
+
+The best-bet prior (``combine.CLUSTER_WEIGHTS``) is where we start while forward IC
+is thin. Each cycle this proposes new weights = a confidence-weighted blend of the
+prior and the IC-implied weights, where confidence ``κ = n / (n + N0)`` grows with the
+number of forward observations. At n=0 the proposal equals the prior; as data
+accumulates it drifts toward what the data actually pays for.
+
+Guardrails: (a) durable-core FLOORS so a regime dip can't zero a decades-premium;
+(b) a per-factor CAP; (c) a DSR gate — a factor may only be raised ABOVE its prior
+once it has cleared the deflated-Sharpe referee (``promoted`` set); un-promoted
+factors can be trimmed but not over-promoted on a lucky-but-unproven IC.
+
+This module only COMPUTES a proposal. Applying it is a human decision (governance):
+the proposal is logged and shown; weights change only on approval.
+"""
+
+from __future__ import annotations
+
+N0_DEFAULT = 42  # months of forward IC at which the data gets ~half the say
+CAP_DEFAULT = 0.30
+# Durable factors keep a floor even through a regime dip (don't chase-drop a premium).
+FLOORS_DEFAULT = {"value_z": 0.10, "quality_z": 0.10, "momentum_z": 0.10}
+
+
+def _kappa(n: float, n0: float) -> float:
+    n = max(float(n or 0.0), 0.0)
+    return n / (n + n0) if n > 0 else 0.0
+
+
+def propose_weights(
+    prior: dict[str, float],
+    ic: dict[str, float],
+    n: dict[str, float],
+    *,
+    n0: float = N0_DEFAULT,
+    cap: float = CAP_DEFAULT,
+    floors: dict[str, float] | None = None,
+    promoted: set[str] | None = None,
+) -> dict[str, float]:
+    """Confidence-weighted blend of ``prior`` and the IC-implied weights.
+
+    Args:
+        prior: the best-bet weights (sum ~1).
+        ic: measured forward IC per cluster (may be negative / missing).
+        n: number of forward observations per cluster (drives confidence).
+        n0: prior strength (months); larger = trust the prior longer.
+        cap: max weight per cluster; floors: per-cluster minimums.
+        promoted: clusters that cleared the DSR gate (only these may exceed their prior).
+
+    Returns proposed weights, non-negative, floored/capped, renormalized to sum 1.
+    At n=0 everywhere this returns the (renormalized) prior unchanged.
+    """
+    clusters = list(prior)
+    floors = floors or FLOORS_DEFAULT
+    promoted = promoted or set()
+
+    ic_pos = {c: max(float(ic.get(c, 0.0) or 0.0), 0.0) for c in clusters}
+    ic_total = sum(ic_pos.values())
+    ic_w = {c: (ic_pos[c] / ic_total if ic_total > 0 else prior[c]) for c in clusters}
+
+    blended: dict[str, float] = {}
+    for c in clusters:
+        k = _kappa(n.get(c, 0.0), n0)
+        w = (1.0 - k) * prior[c] + k * ic_w[c]
+        if c not in promoted:  # DSR gate: un-proven factors can trim, not over-promote
+            w = min(w, prior[c])
+        w = min(max(w, floors.get(c, 0.0)), cap)
+        blended[c] = w
+
+    total = sum(blended.values())
+    return {c: blended[c] / total for c in clusters} if total > 0 else dict(prior)
+
+
+def proposal_table(prior: dict[str, float], proposed: dict[str, float]) -> list[dict]:
+    """Rows [{cluster, prior, proposed, delta}] sorted by |delta| desc — for the report."""
+    rows = [
+        {
+            "cluster": c,
+            "prior": prior[c],
+            "proposed": proposed.get(c, 0.0),
+            "delta": proposed.get(c, 0.0) - prior[c],
+        }
+        for c in prior
+    ]
+    return sorted(rows, key=lambda r: abs(r["delta"]), reverse=True)


### PR DESCRIPTION
Deploys the grounded best-bet factor set for the LIVE book (we can't wait for multi-year forward IC) + the adaptive mechanism that will re-propose weights as data accrues.

## Best-bet prior (grounded in the survivorship-clean backtest + literature)
| Cluster | weight | change |
|---|---|---|
| Quality (ROE+FCF+**GP/assets**) | 0.25 | GP/assets added (best clean IC t3.5 + Novy-Marx) |
| Value (sector-conditional) | 0.20 | held (durable, regime-weak — not chased-dropped) |
| Momentum | 0.20 | held |
| **PEAD/SUE** (new) | 0.10 | best clean β-neutral signal (t2.06) + robust literature |
| Low-vol | 0.10 | trimmed from 0.21 (its 'alpha' was a beta artifact) |
| Growth | 0.08 | trimmed (short-leg-of-value) |
| Strength | 0.07 | — |
| ~~CMA, accruals~~ | excluded | no clean alpha (FM ~0) |

## Wiring
- `live_fundamentals_factors` pulls GP/assets + SUE from the PIT SF1 store (latest filing/ticker; NaN for non-US → graceful) so the new clusters score live.
- `v3/weight_proposal.py`: Bayesian shrinkage — proposes drift prior→measured IC as confidence n/(n+N0) grows; durable-core floors, cap, DSR-gate on promotion; **proposes-not-imposes**. At n=0 returns the prior (deployment invariant tested).

## Tests
15 new/updated; affected v3 surface 909 green. Live scoring now includes GP/assets + SUE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)