### PR TITLE
feat(v3): earnings-trajectory factor (PET/PEF) — recover dropped forward-P/E info

### DIFF
--- a/scripts/v3_factor_backtest.py
+++ b/scripts/v3_factor_backtest.py
@@ -156,6 +156,7 @@ def main() -> None:
     parts: dict[str, list[pd.DataFrame]] = {f: [] for f in set(factors.values())}
     parts["mom_12_1"] = []
     parts["realized_vol"] = []
+    parts["earn_trajectory"] = []
     cluster_parts: dict[str, list[pd.DataFrame]] = {c: [] for c in CLUSTERS}
     fm_parts: list[pd.DataFrame] = []  # P3: wide panel for Fama-MacBeth
     first_tickers: set = set()
@@ -201,6 +202,16 @@ def main() -> None:
                 zcols[feat] = z
                 _append_part(parts, feat, date, z, fwd, fwd_n, sec)
 
+        # earnings trajectory = trailing/forward P/E (>1 = forward cheaper = earnings
+        # expected to RISE; <1 = falling = value-trap). Recovers the PET->PEF info that
+        # was dropped when pe_forward left scoring; high is good (+1).
+        if "PET" in panel.columns and "PEF" in panel.columns:
+            pet, pef = _num(panel["PET"]), _num(panel["PEF"])
+            traj = (pet / pef).where((pet > 0) & (pef > 0))
+            ztraj = _sector_demean(_rank_z(traj), sec.reindex(traj.index))
+            zcols["earn_trajectory"] = ztraj
+            _append_part(parts, "earn_trajectory", date, ztraj, fwd, fwd_n, sec)
+
         # per-cluster z = mean of member factor-z present this snapshot
         cluster_cz: dict[str, pd.Series] = {}
         for cluster, members in CLUSTERS.items():
@@ -213,6 +224,10 @@ def main() -> None:
         # P3: wide row for the Fama-MacBeth regression (core clusters + beta vs fwd).
         if beta is not None:
             fm = pd.DataFrame({c: cluster_cz[c] for c in _FM_CLUSTERS if c in cluster_cz})
+            if "growth_z" in cluster_cz:  # include growth + trajectory for the spanning test
+                fm["growth_z"] = cluster_cz["growth_z"]
+            if "earn_trajectory" in zcols:
+                fm["earn_trajectory"] = zcols["earn_trajectory"]
             if not fm.empty:
                 fm["beta"] = beta.reindex(fm.index)
                 fm["fwd"] = fwd.reindex(fm.index)
@@ -267,7 +282,9 @@ def main() -> None:
     fm_result: dict = {}
     if fm_parts:
         fm_panel = pd.concat(fm_parts, ignore_index=True)
-        fm_x = [c for c in _FM_CLUSTERS if c in fm_panel.columns] + ["beta"]
+        fm_x = [
+            c for c in (*_FM_CLUSTERS, "growth_z", "earn_trajectory") if c in fm_panel.columns
+        ] + ["beta"]
         fm_result = fama_macbeth(fm_panel, "fwd", fm_x, date_col="date", lags=HORIZON)
     churn = (len(first_tickers - last_tickers) / len(first_tickers)) if first_tickers else 0.0
 

--- a/scripts/v3_pipeline_map.py
+++ b/scripts/v3_pipeline_map.py
@@ -63,6 +63,7 @@ LABEL = {
     "gp_assets": "Gross profit / assets",
     "sue": "Earnings surprise (SUE)",
     "asset_growth": "Asset growth (CMA)",
+    "earn_trajectory": "Earnings trajectory (PET/PEF)",
 }
 _DIRTXT = {1: "high = good", -1: "low = good"}
 
@@ -74,6 +75,7 @@ CLUSTER_LABEL = {
     "lowvol_z": "Low volatility",
     "strength_z": "Strength",
     "pead_z": "PEAD (earnings surprise)",
+    "trajectory_z": "Earnings trajectory",
 }
 
 # Curated non-scored classification (documented FIX-NOW / redesign decisions).
@@ -90,7 +92,7 @@ MONITORED = {  # shadow-logged + backtested, ZERO conviction
     "price_perf": "≈ momentum (ρ 0.95) — shown as context, double-count avoided",
 }
 DISCARDED = {
-    "pe_forward": "near-duplicate of trailing P/E (ρ 0.75) — removed",
+    "pe_forward": "LEVEL near-dup of trailing P/E (ρ 0.75, ≈0 IC) — but its forward info is now captured by the earn_trajectory (PET/PEF) spread, which IS scored (β-neutral t 2.17)",
     "target_dispersion": "live-fetched, non-point-in-time — removed",
     "roa": "retired for the interim quality set (ROE + FCF + GP/assets)",
     "gross_margin": "per-sales margin; superseded by GP/assets (now scored)",

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -258,8 +258,8 @@ def test_derive_cluster_weights_equal_spread_when_rest_ic_nonpositive():
     assert abs(sum(w.values()) - 1.0) < 1e-9, f"weights sum {sum(w.values())} != 1.0"
     assert abs(w["value_z"] + w["quality_z"] - 0.55) < 1e-9, "VQ cap not exactly 0.55"
 
-    expected_each = (1.0 - 0.55) / 4  # rest = momentum, lowvol, strength, pead
-    for c in ("momentum_z", "lowvol_z", "strength_z", "pead_z"):
+    expected_each = (1.0 - 0.55) / 5  # rest = momentum, lowvol, strength, pead, trajectory
+    for c in ("momentum_z", "lowvol_z", "strength_z", "pead_z", "trajectory_z"):
         assert abs(w[c] - expected_each) < 1e-9, (
             f"{c}: got {w[c]:.6f}, expected {expected_each:.6f}"
         )
@@ -342,7 +342,27 @@ def test_growth_cluster_registered_direction_positive():
         "lowvol_z",
         "strength_z",
         "pead_z",
+        "trajectory_z",
     ]
+
+
+def test_trajectory_cluster_registered_direction_positive():
+    """Earnings-trajectory (PET/PEF) is a scored cluster: high ratio = forward cheaper =
+    earnings expected to rise, DIRECTION +1. Recovers the PET->PEF info dropped when
+    pe_forward left scoring; strongest survivorship-clean signal (beta-neutral t 2.17)."""
+    from trade_modules.v3.combine import CLUSTERS, DIRECTION
+
+    assert CLUSTERS["trajectory_z"] == ["earn_trajectory"]
+    assert DIRECTION["earn_trajectory"] == +1
+
+
+def test_trajectory_z_rising_earnings_ranks_above_falling():
+    """High PET/PEF (earnings rising) ranks above a falling-earnings peer (kept, +1)."""
+    df = _base(["RISING", "FLAT", "FALLING"])
+    df["earn_trajectory"] = [2.0, 1.0, 0.5]  # PET/PEF: >1 rising, <1 falling
+    scores = compute_scores(df, sector_neutral=False)
+    assert scores.loc["RISING", "trajectory_z"] > scores.loc["FLAT", "trajectory_z"]
+    assert scores.loc["FLAT", "trajectory_z"] > scores.loc["FALLING", "trajectory_z"]
 
 
 def test_growth_z_high_growth_ranks_above_low_growth():
@@ -525,14 +545,16 @@ def test_quality_is_roe_fcf_gp_assets():
             assert dead not in members, f"{dead} must not be scored in quality"
 
 
-def test_best_bet_prior_weights_2026_07_19():
-    """BEST-BET prior (grounded in the survivorship-clean backtest + literature):
-    quality-led (GP/assets), value+momentum held as durable core, PEAD added, low-vol
-    trimmed to a risk-diversifier, growth trimmed. VQ below the 0.55 cap; sum = 1."""
+def test_best_bet_prior_weights_2026_07_20():
+    """BEST-BET prior (survivorship-clean backtest + literature): quality-led (GP/assets),
+    value+momentum durable core, PEAD + earnings-trajectory (PET/PEF — strongest clean
+    signal, beta-neutral t 2.17) added, low-vol a risk-diversifier, growth trimmed. VQ
+    below the 0.55 cap; sum = 1."""
     from trade_modules.v3.combine import CLUSTER_WEIGHTS as w
 
     assert w["quality_z"] == max(w.values()), "quality is the evidence leader"
     assert w["pead_z"] > 0, "PEAD participates (best clean signal + robust literature)"
+    assert w["trajectory_z"] > 0, "earnings-trajectory participates (strongest clean signal)"
     assert w["lowvol_z"] < w["value_z"], "low-vol trimmed to a risk-diversifier"
     assert w["lowvol_z"] <= 0.10 + 1e-9, "low-vol capped low (its alpha was a beta artifact)"
     assert (w["value_z"] + w["quality_z"]) < 0.55, "no Value+Quality cap-as-floor"

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -306,6 +306,7 @@ def test_expected_columns_present(tmp_path):
         "country",
         # derived
         "target_dispersion",
+        "earn_trajectory",
         "adv_usd",
         "mom_12_1",
         "realized_vol",
@@ -330,6 +331,13 @@ def test_percent_and_numeric_coercion(tmp_path):
     assert pd.api.types.is_float_dtype(feats["pe_trailing"])
     # "--" native -> NaN
     assert pd.isna(feats.loc["ZZZ", "div_yield"])
+
+
+def test_earn_trajectory_math(tmp_path):
+    """earn_trajectory = trailing/forward P/E (>1 = forward cheaper = earnings rising)."""
+    feats = _run(tmp_path)
+    assert abs(feats.loc["AAPL", "earn_trajectory"] - 28.5 / 25.0) < 1e-9
+    assert abs(feats.loc["MSFT", "earn_trajectory"] - 35.0 / 30.0) < 1e-9
 
 
 def test_target_dispersion_math(tmp_path):

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -54,6 +54,10 @@ DIRECTION = {
     # earnings surprise / PEAD + investment (2026-07-19)
     "sue": +1,  # standardized unexpected earnings (post-earnings drift; high is good)
     "asset_growth": -1,  # CMA / investment (low is good) — monitored, not scored
+    # earnings trajectory (2026-07-20): trailing/forward P/E ratio (high = forward cheaper
+    # = earnings expected to RISE; low = value-trap). The distinct PET->PEF information
+    # lost when raw pe_forward was pruned. Strongest survivorship-clean signal we found.
+    "earn_trajectory": +1,
 }
 
 # Scoring clusters -> member metrics.
@@ -85,6 +89,13 @@ CLUSTERS = {
     # signal (beta-neutral IC t 2.06, hit 68%) + robust literature (Bernard-Thomas).
     # SUE = seasonal-random-walk standardized unexpected earnings, from SF1 actuals.
     "pead_z": ["sue"],
+    # Earnings trajectory (2026-07-20): PET/PEF = trailing/forward P/E ratio. Recovers
+    # the forward-looking information dropped when raw pe_forward was pruned (the LEVEL
+    # was a near-dup of trailing, zero IC; the SPREAD is not). Best clean signal on the
+    # panel: beta-neutral forward IC t 2.17, hit 80%, incremental to value+growth (FM
+    # t 1.71). Panel-only (Sharadar has no forward estimates) -> earn-in via the adaptive
+    # mechanism as forward IC accrues.
+    "trajectory_z": ["earn_trajectory"],
 }
 
 # ---------------------------------------------------------------------------
@@ -142,14 +153,18 @@ _VALUE_CANDIDATES = sorted({m for r in VALUE_GROUP_RECIPES.values() for m in r})
 # its standalone alpha was a beta artifact -> risk-diversifier only); growth trimmed
 # (short-leg-of-value). CMA + accruals EXCLUDED (no clean alpha). The adaptive shrinkage
 # mechanism (v3/weight_proposal.py) proposes drift toward measured forward IC as data accrues.
+# 2026-07-20: earnings-trajectory (PET/PEF) added at 0.10 — the strongest clean signal on
+# the panel (beta-neutral t 2.17, hit 80%, incremental to value+growth). Funded by trimming
+# value/momentum 0.20->0.18, growth 0.08->0.05, strength 0.07->0.05, quality 0.25->0.24.
 CLUSTER_WEIGHTS = {
-    "value_z": 0.20,
-    "quality_z": 0.25,
-    "momentum_z": 0.20,
+    "value_z": 0.18,
+    "quality_z": 0.24,
+    "momentum_z": 0.18,
     "pead_z": 0.10,
+    "trajectory_z": 0.10,
     "lowvol_z": 0.10,
-    "growth_z": 0.08,
-    "strength_z": 0.07,
+    "growth_z": 0.05,
+    "strength_z": 0.05,
 }
 
 # The Value+Quality joint weight is capped here regardless of the weighting scheme.
@@ -160,7 +175,15 @@ _VQ_CAP = 0.55
 # is deliberately EXCLUDED here: it is off (weight 0) in the default + IC paths
 # and only activated through the explicit ``cluster_weights`` arg, so the IC
 # redistribution math (and its unit tests) are unchanged.
-_IC_CLUSTERS = ["value_z", "quality_z", "momentum_z", "lowvol_z", "strength_z", "pead_z"]
+_IC_CLUSTERS = [
+    "value_z",
+    "quality_z",
+    "momentum_z",
+    "lowvol_z",
+    "strength_z",
+    "pead_z",
+    "trajectory_z",
+]
 
 # Short-name aliases for the explicit ``cluster_weights`` arg: "value" -> "value_z".
 _CLUSTER_ALIASES = {c[:-2]: c for c in CLUSTERS}
@@ -263,6 +286,7 @@ _ELIG_CLUSTERS = [
     "lowvol_z",
     "strength_z",
     "pead_z",
+    "trajectory_z",
 ]
 _MIN_CLUSTERS = 3
 

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -407,6 +407,12 @@ def enrich_features(
     safe_price = price.where(price > 0)
     disp = (feats["target_high"] - feats["target_low"]) / safe_price
     feats["target_dispersion"] = disp.replace([float("inf"), float("-inf")], float("nan"))
+    # earnings trajectory = trailing/forward P/E (>1 = forward cheaper = earnings expected
+    # to rise; <1 = value-trap). The distinct PET->PEF information lost when raw pe_forward
+    # left scoring; scored via the trajectory_z cluster (2026-07-20).
+    pet = pd.to_numeric(feats["pe_trailing"], errors="coerce")
+    pef = pd.to_numeric(feats["pe_forward"], errors="coerce")
+    feats["earn_trajectory"] = (pet / pef).where((pet > 0) & (pef > 0))
     # adv_usd = shares * local price * FX -> USD dollar-volume (for the ADV floor).
     feats["adv_usd"] = feats["avg_volume"] * price * feats.index.to_series().map(_usd_rate_for)
 

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -46,6 +46,7 @@ CLUSTER_CELLS = [
     ("lowvol_z", "Low-vol"),
     ("strength_z", "Strength"),
     ("pead_z", "PEAD"),
+    ("trajectory_z", "Traj"),
 ]
 
 # Cluster z-scores used in the collapsed card summary strip (all clusters the
@@ -55,6 +56,7 @@ _CARD_CLUSTERS = [
     ("quality_z", "Quality"),
     ("momentum_z", "Momentum"),
     ("pead_z", "PEAD"),
+    ("trajectory_z", "Trajectory"),
     ("growth_z", "Growth"),
     ("lowvol_z", "Low-vol"),
     ("strength_z", "Strength"),
@@ -96,6 +98,7 @@ DISPLAY_GROUPS = [
         ],
     ),
     ("PEAD", [("sue", "SUE")]),
+    ("Trajectory", [("earn_trajectory", "PET/PEF")]),
     ("Low-vol", [("beta", "Beta"), ("realized_vol", "Realized Vol")]),
     ("Strength", [("short_interest", "Short Int"), ("target_dispersion", "Target Disp")]),
     (
@@ -120,6 +123,7 @@ GROUP_CLUSTER = {
     "Low-vol": "lowvol_z",
     "Strength": "strength_z",
     "PEAD": "pead_z",
+    "Trajectory": "trajectory_z",
 }
 
 # Formatting hints.

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -56,6 +56,7 @@ CARD_FACTORS = [
     ("Value", "value_z", [("pe_forward", "P/E"), ("pb", "P/B"), ("ps_sector", "P/S")]),
     ("Quality", "quality_z", [("roe", "ROE"), ("fcf", "FCF"), ("gp_assets", "GP/A")]),
     ("PEAD", "pead_z", [("sue", "SUE")]),
+    ("Traj", "trajectory_z", [("earn_trajectory", "t/f")]),
     ("Growth", "growth_z", [("earn_growth", "EPS"), ("rev_growth", "rev")]),
     (
         "Momentum",
@@ -76,6 +77,7 @@ _METRIC_FMT = {
     "mom_12_1": ("fracpct", 0, True),
     "gp_assets": ("fracpct", 0, False),  # gross profit / assets
     "sue": ("ratio", 2, True),  # standardized unexpected earnings (z-like)
+    "earn_trajectory": ("ratio", 2, False),  # trailing/forward P/E ratio (>1 = rising)
     "pct_52w_high": ("pct", 0, False),
     "price_perf": ("pct", 0, True),
     "pe_forward": ("ratio", 1, False),


### PR DESCRIPTION
## Why
Owner observed forward P/E looked "very bad" in many recommendations and that we lost information when raw `pe_forward` was pruned (2026-07-14, near-dup of trailing). Grounded the observation in a panel backtest.

## Finding (98 dates, HAC, market-neutral)
`earn_trajectory = PET/PEF` (>1 = forward cheaper = earnings expected to RISE):

| signal | β-neutral IC | HAC t | hit |
|---|---|---|---|
| **earn_trajectory (PET/PEF)** | **+0.034** | **2.17** | **80%** |
| pe_trailing (level) | −0.038 | −2.73 | 26% |
| pe_forward (level) | −0.007 | −0.38 | 38% |

Fama-MacBeth spanning: earn_trajectory **+0.0031, t 1.71** incremental to value+growth+momentum+lowvol+quality → **not subsumed**. The lost signal was the PET→PEF **spread** (value-trap vs ramping-compounder), not the forward level (which was correctly pruned).

## Changes
- `combine.py`: `earn_trajectory` +1; new `trajectory_z` cluster @ 0.10; re-weighted (value/momentum 0.20→0.18, growth 0.08→0.05, strength 0.07→0.05, quality 0.25→0.24); added to IC + eligibility cluster lists.
- `features.py`: `earn_trajectory = pe_trailing/pe_forward` (guard both >0).
- `report.py` + `report_email.py`: Trajectory shown per stock + heat strip.
- `v3_factor_backtest.py`: earn_trajectory in per-factor IC + FM spanning.
- `v3_pipeline_map.py`: earn_trajectory participating; pe_forward discard reason refined.

## Caveat
Panel-only (Sharadar has no forward estimates) → earn-in via the adaptive `weight_proposal` mechanism as forward IC accrues.

TDD; v3 suite **475 green**, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)