### PR TITLE
feat(v3): value-trap gate — exclude forward P/E > 1.10x trailing

### DIFF
--- a/scripts/v3_pipeline_map.py
+++ b/scripts/v3_pipeline_map.py
@@ -80,6 +80,7 @@ CLUSTER_LABEL = {
 
 # Curated non-scored classification (documented FIX-NOW / redesign decisions).
 GATES = {
+    "earn_trajectory": "value-trap EXCLUDE gate — forward P/E &gt; 1.10x trailing (earnings expected to fall) → ineligible: never a new BUY, held names flagged SELL/TRIM (owner rule 2026-07-20)",
     "short_interest": "squeeze / hard-to-borrow EXCLUDE gate (SI &gt; 20%) — not scored",
     "de": "distress screen (with current ratio) — financial strength, not profitability",
     "current_ratio": "distress screen (with D/E) — liquidity, not profitability",

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -115,6 +115,31 @@ def test_no_quote_type_column_means_all_eligible():
 # sheet). Coverage is now via test_fixnow_quality_interim_is_roe_fcf.
 
 
+def test_value_trap_gate_excludes_forward_pe_far_above_trailing():
+    """Owner rule (2026-07-20): forward P/E > 1.10x trailing (earn_trajectory < 1/1.10)
+    = value trap -> INELIGIBLE, so a trap never surfaces as a BUY and a held trap trips
+    the overlay's weak-name SELL. Names at/below the threshold stay eligible."""
+    idx = ["GOOD", "FLAT", "TRAP"]
+    df = _base(idx)
+    df["quote_type"] = ["EQUITY", "EQUITY", "EQUITY"]
+    df["price"] = [100.0, 50.0, 80.0]
+    df["pe_trailing"] = [10.0, 15.0, 3.2]
+    df["roe"] = [30.0, 20.0, 25.0]
+    df["mom_12_1"] = [0.20, 0.15, 0.10]
+    df["realized_vol"] = [0.20, 0.22, 0.25]
+    # earn_trajectory = PET/PEF: GOOD 1.11 (forward cheaper), FLAT 1.0 (=trailing, not a
+    # trap), TRAP 3.2/46 = 0.07 (forward 14x trailing = earnings collapsing).
+    df["earn_trajectory"] = [1.11, 1.0, 3.2 / 46.0]
+
+    scores = compute_scores(df, sector_neutral=False)
+
+    assert bool(scores.loc["GOOD", "eligible"]) is True
+    assert bool(scores.loc["FLAT", "eligible"]) is True  # exactly flat is not a trap
+    assert bool(scores.loc["TRAP", "eligible"]) is False
+    assert pd.isna(scores.loc["TRAP", "conviction"])
+    assert pd.isna(scores.loc["TRAP", "rank"])
+
+
 def test_eligibility_excludes_non_equity_and_dataless():
     """With quote_type present, ETFs and dataless names drop out of the ranking."""
     idx = ["EQ1", "EQ2", "ETF1", "DATALESS"]

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -290,6 +290,15 @@ _ELIG_CLUSTERS = [
 ]
 _MIN_CLUSTERS = 3
 
+# Value-trap gate (2026-07-20, owner rule): a forward P/E materially above trailing means
+# earnings are expected to FALL (a value trap / cyclical peak) — the trailing-cheap look is
+# a mirage. earn_trajectory = PET/PEF, so "forward > 1.10x trailing" is earn_trajectory <
+# 1/1.10. Trap names are made INELIGIBLE: they never surface as a new BUY, and a held trap
+# trips the overlay's weak-name SELL — so a collapsing-earnings name is never recommended
+# as attractive. Names with a missing PET or PEF (NaN trajectory) are never gated.
+_TRAP_MAX_FWD_TTM = 1.10
+_TRAP_MIN_TRAJECTORY = 1.0 / _TRAP_MAX_FWD_TTM
+
 
 def _rank_z(s: pd.Series) -> pd.Series:
     """Rank-normal (van der Waerden) cross-sectional score.
@@ -401,6 +410,10 @@ def _eligibility(out: pd.DataFrame) -> pd.Series:
             ok &= pd.to_numeric(out[col], errors="coerce").notna()
     clusters_present = out[_ELIG_CLUSTERS].notna().sum(axis=1)
     ok &= clusters_present >= _MIN_CLUSTERS
+    # Value-trap gate: forward P/E > 1.10x trailing (earn_trajectory below 1/1.10).
+    if "earn_trajectory" in out.columns:
+        traj = pd.to_numeric(out["earn_trajectory"], errors="coerce")
+        ok &= ~(traj < _TRAP_MIN_TRAJECTORY)  # NaN trajectory (missing PET/PEF) never gated
     return ok.fillna(False).astype(bool)
 
 


### PR DESCRIPTION
## Why
Owner still saw recommendations with forward P/E far above trailing — e.g. a held name at **P/E TTM 3.20 / P/E Fwd 46** scoring **+1.83 on Value** (trailing-cheap mirage while earnings collapse). The 0.10 trajectory tilt is too soft; a hard gate is needed.

## Data (buy.csv / etoro.csv)
- 13% of the universe has forward P/E > 1.10× trailing
- **11 of 165 BUY candidates were traps** (LTC 16→25, HAFNI 8→12, AER 6.5→8.6, 8316.T, 8253.T, …)

## Owner decisions
- **Threshold: strict 1.10×** (forward > 1.10× trailing = trap)
- **Held traps: flag SELL/TRIM** (not just block new buys)

## Implementation
Eligibility gate in `compute_scores._eligibility`: `earn_trajectory` (PET/PEF) < 1/1.10 → **ineligible**, which
- drops it from the new-BUY pool (pool = eligible names), and
- trips the overlay's `_is_weak` SELL for a held trap (NaN conviction).

Names with a missing PET or PEF (NaN trajectory) are never gated.

TDD; v3 suite **476 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)