### PR TITLE
fix(v3): eToro→Yahoo ticker suffix mapping + rate-limit-safe enrichment

### DIFF
--- a/tests/core/config/test_ticker_mappings.py
+++ b/tests/core/config/test_ticker_mappings.py
@@ -313,6 +313,34 @@ class TestDisplayAndDataFetch:
             result = get_data_fetch_ticker(input_ticker)
             assert result == expected_fetch
 
+    def test_get_data_fetch_ticker_exchange_suffix_mapping(self):
+        """eToro/Bloomberg exchange suffixes map to Yahoo symbols; currency/price-unit
+        lines are stripped; US class shares use the dash form; already-valid suffixes and
+        the deferred Gulf (.DH) names pass through unchanged."""
+        cases = [
+            ("SBMO.NV", "SBMO.AS"),  # Euronext Amsterdam (eToro .NV -> Yahoo .AS)
+            ("28IA.IM", "28IA.MI"),  # Milan (Bloomberg .IM -> Yahoo .MI)
+            ("SHLD.LN", "SHLD.L"),  # London (Bloomberg .LN -> Yahoo .L)
+            ("QUNR.CH", "QUNR.SW"),  # Switzerland (Bloomberg .CH -> Yahoo .SW)
+            ("MSFT.EUR", "MSFT"),  # currency line stripped
+            ("KSP.L.GBX", "KSP.L"),  # pence line stripped, exchange suffix kept
+            ("BRK.B", "BRK-B"),  # US class share -> dash form
+            ("RDS.A", "RDS-A"),  # US class share -> dash form
+            ("7012.T", "7012.T"),  # Tokyo already valid -> unchanged
+            ("UCG.MI", "UCG.MI"),  # already-valid Yahoo suffix -> unchanged
+            ("AAPL", "AAPL"),  # plain US -> unchanged
+            ("MODON.DH", "MODON.DH"),  # Gulf deferred -> unchanged
+        ]
+        for inp, exp in cases:
+            assert get_data_fetch_ticker(inp) == exp, (
+                f"{inp} -> {get_data_fetch_ticker(inp)} (want {exp})"
+            )
+
+    def test_get_data_fetch_ticker_specials_still_honored(self):
+        """VIX + per-name data_fetch_substitutions survive the new suffix logic."""
+        assert get_data_fetch_ticker("VIX") == "^VIX"
+        assert get_data_fetch_ticker("LYXGRE.DE") == "GRE.PA"
+
 
 class TestDualListedDetection:
     """Test cases for dual-listed stock detection."""

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -616,3 +616,92 @@ def test_default_info_fetch_retries_on_empty_dict(monkeypatch):
     out = feat._default_info_fetch(["7012.T"])
     assert out["7012.T"]["shortName"] == "Kawasaki"  # retried past the empty response
     assert seq == []  # both the empty and the populated response were consumed
+
+
+def test_info_cache_round_trip(tmp_path, monkeypatch):
+    """_save_info_cache then _load_info_cache round-trips; a missing file -> {}."""
+    import trade_modules.v3.features as feat
+
+    monkeypatch.setattr(feat, "_info_cache_path", lambda: str(tmp_path / "cache.json"))
+    feat._save_info_cache({"AAPL": {"shortName": "Apple", "trailingPE": 40.5}})
+    assert feat._load_info_cache()["AAPL"]["trailingPE"] == 40.5
+
+    monkeypatch.setattr(feat, "_info_cache_path", lambda: str(tmp_path / "missing.json"))
+    assert feat._load_info_cache() == {}
+
+
+def test_default_info_fetch_uses_cache_hit(monkeypatch):
+    """A cached Yahoo symbol short-circuits the network fetch (keyed by eToro ticker)."""
+    calls = []
+
+    class FakeTicker:
+        def __init__(self, sym):
+            calls.append(sym)
+
+        @property
+        def info(self):
+            return {"shortName": "x", "regularMarketPrice": 1}
+
+    import trade_modules.v3.features as feat
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(Ticker=FakeTicker))
+    monkeypatch.setattr(
+        feat, "_load_info_cache", lambda: {"SBMO.AS": {"shortName": "SBM", "trailingPE": 8.6}}
+    )
+    monkeypatch.setattr(feat, "_save_info_cache", lambda cache: None)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+    out = feat._default_info_fetch(["SBMO.NV"])
+    assert calls == []  # cache hit -> no network call
+    assert out["SBMO.NV"]["trailingPE"] == 8.6
+
+
+def test_default_info_fetch_gives_up_after_retries(monkeypatch):
+    """A persistently empty .info -> {} for the ticker, and empties are NOT cached."""
+    saved: dict = {}
+
+    class FakeTicker:
+        def __init__(self, sym):
+            pass
+
+        @property
+        def info(self):
+            return {}  # always rate-limited / empty
+
+    import trade_modules.v3.features as feat
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(Ticker=FakeTicker))
+    monkeypatch.setattr(feat, "_load_info_cache", lambda: {})
+    monkeypatch.setattr(feat, "_save_info_cache", lambda cache: saved.update(cache))
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+    out = feat._default_info_fetch(["ZZZ"])
+    assert out["ZZZ"] == {}
+    assert saved == {}  # empty results not cached -> retried next run
+
+
+def test_default_accruals_fetch_maps_symbol(monkeypatch):
+    """The accruals fetch maps the eToro ticker (SBMO.NV -> SBMO.AS) before yfinance."""
+    seen = []
+
+    class FakeTicker:
+        def __init__(self, sym):
+            seen.append(sym)
+
+        @property
+        def financials(self):
+            return pd.DataFrame()
+
+        @property
+        def cashflow(self):
+            return pd.DataFrame()
+
+        @property
+        def balance_sheet(self):
+            return pd.DataFrame()
+
+    import trade_modules.v3.features as feat
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(Ticker=FakeTicker))
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+    out = feat._default_accruals_fetch(["SBMO.NV"])
+    assert seen == ["SBMO.AS"]  # mapped to Yahoo symbol
+    assert out == {}  # no statement data -> skipped, never raises

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -705,3 +705,39 @@ def test_default_accruals_fetch_maps_symbol(monkeypatch):
     out = feat._default_accruals_fetch(["SBMO.NV"])
     assert seen == ["SBMO.AS"]  # mapped to Yahoo symbol
     assert out == {}  # no statement data -> skipped, never raises
+
+
+def test_info_cache_path_is_dated_json():
+    """The cache path is a dated JSON under the trading data dir."""
+    import trade_modules.v3.features as feat
+
+    p = feat._info_cache_path()
+    assert p.endswith(".json") and "v3_info_cache_" in p
+
+
+def test_info_cache_is_best_effort_on_bad_path(tmp_path, monkeypatch):
+    """A bad cache path never raises on save; a corrupt/non-JSON file loads as {}."""
+    import trade_modules.v3.features as feat
+
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not json")  # a FILE where a directory would be needed
+    monkeypatch.setattr(feat, "_info_cache_path", lambda: str(blocker / "sub" / "c.json"))
+    feat._save_info_cache({"A": {"shortName": "a"}})  # makedirs under a file -> swallowed
+    monkeypatch.setattr(feat, "_info_cache_path", lambda: str(blocker))
+    assert feat._load_info_cache() == {}  # non-JSON -> {}
+
+
+def test_default_info_fetch_retries_on_exception(monkeypatch):
+    """A raising yfinance (network error) is retried, then yields {} for the ticker."""
+
+    class BoomTicker:
+        def __init__(self, sym):
+            pass
+
+        @property
+        def info(self):
+            raise RuntimeError("network down")
+
+    feat = _patch_info_fetch_env(monkeypatch, BoomTicker)
+    out = feat._default_info_fetch(["ZZZ"])
+    assert out["ZZZ"] == {}  # never raises; unfetchable -> empty

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -3,6 +3,9 @@
 All tests inject FAKE info_fetch + price_fetch and a tmp CSV — no network.
 """
 
+import sys
+import types
+
 import numpy as np
 import pandas as pd
 
@@ -565,3 +568,51 @@ def test_description_word_boundary_fallback(tmp_path):
     assert len(desc) <= 222  # 220 chars + possible "…" (1 char)
     # Must not end with a raw space (no trailing whitespace after trim)
     assert not desc.rstrip("…").endswith(" ")
+
+
+def _patch_info_fetch_env(monkeypatch, fake_ticker_cls):
+    """Wire _default_info_fetch to a fake yfinance + no-op cache/sleep."""
+    import trade_modules.v3.features as feat
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(Ticker=fake_ticker_cls))
+    monkeypatch.setattr(feat, "_load_info_cache", lambda: {})
+    monkeypatch.setattr(feat, "_save_info_cache", lambda cache: None)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+    return feat
+
+
+def test_default_info_fetch_maps_symbol_and_keys_by_etoro(monkeypatch):
+    """The fetch uses the Yahoo symbol (SBMO.NV -> SBMO.AS) but the result is keyed by
+    the original eToro ticker."""
+    seen = []
+
+    class FakeTicker:
+        def __init__(self, sym):
+            seen.append(sym)
+
+        @property
+        def info(self):
+            return {"shortName": "SBM Offshore", "trailingPE": 8.6}
+
+    feat = _patch_info_fetch_env(monkeypatch, FakeTicker)
+    out = feat._default_info_fetch(["SBMO.NV"])
+    assert seen == ["SBMO.AS"]  # fetched the mapped Yahoo symbol
+    assert out["SBMO.NV"]["trailingPE"] == 8.6  # keyed by the original eToro ticker
+
+
+def test_default_info_fetch_retries_on_empty_dict(monkeypatch):
+    """A rate-limited empty .info (no exception) is retried until it populates."""
+    seq = [{}, {"shortName": "Kawasaki", "trailingPE": 20.1}]
+
+    class FakeTicker:
+        def __init__(self, sym):
+            pass
+
+        @property
+        def info(self):
+            return seq.pop(0)
+
+    feat = _patch_info_fetch_env(monkeypatch, FakeTicker)
+    out = feat._default_info_fetch(["7012.T"])
+    assert out["7012.T"]["shortName"] == "Kawasaki"  # retried past the empty response
+    assert seq == []  # both the empty and the populated response were consumed

--- a/tests/unit/trade_modules/test_v3_fetch.py
+++ b/tests/unit/trade_modules/test_v3_fetch.py
@@ -3,10 +3,31 @@
 All tests use a FAKE downloader — no network calls, pause=0 for speed.
 """
 
+import sys
+import types
+
 import numpy as np
 import pandas as pd
 
-from trade_modules.v3.fetch import robust_fetch_prices
+from trade_modules.v3.fetch import _default_downloader, robust_fetch_prices
+
+
+def test_default_downloader_maps_etoro_to_yahoo_and_renames_back(monkeypatch):
+    """_default_downloader fetches Yahoo symbols (SBMO.NV -> SBMO.AS) but returns columns
+    keyed by the original eToro tickers."""
+    captured = {}
+
+    def fake_download(batch, **kwargs):
+        captured["batch"] = list(batch)
+        idx = pd.date_range("2026-01-01", periods=3)
+        cols = pd.MultiIndex.from_product([["Close"], list(batch)])
+        return pd.DataFrame(1.0, index=idx, columns=cols)
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(download=fake_download))
+    out = _default_downloader(["SBMO.NV", "7012.T"], "1mo")
+    assert captured["batch"] == ["SBMO.AS", "7012.T"]  # fetched the mapped Yahoo symbols
+    assert set(out.columns) == {"SBMO.NV", "7012.T"}  # renamed back to eToro tickers
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/trade_modules/test_v3_fetch.py
+++ b/tests/unit/trade_modules/test_v3_fetch.py
@@ -29,6 +29,19 @@ def test_default_downloader_maps_etoro_to_yahoo_and_renames_back(monkeypatch):
     assert set(out.columns) == {"SBMO.NV", "7012.T"}  # renamed back to eToro tickers
 
 
+def test_default_downloader_flat_single_ticker_layout(monkeypatch):
+    """Legacy single-ticker flat 'Close' layout is handled and renamed back to eToro."""
+
+    def fake_download(batch, **kwargs):
+        idx = pd.date_range("2026-01-01", periods=3)
+        return pd.DataFrame({"Open": 1.0, "High": 1.0, "Low": 1.0, "Close": 2.0}, index=idx)
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(download=fake_download))
+    out = _default_downloader(["SBMO.NV"], "1mo")  # -> fetches SBMO.AS, renames back
+    assert list(out.columns) == ["SBMO.NV"]
+    assert float(out["SBMO.NV"].iloc[-1]) == 2.0
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/trade_modules/config_manager.py
+++ b/trade_modules/config_manager.py
@@ -12,6 +12,15 @@ from typing import Any
 
 from .yaml_config_loader import YamlConfigLoader
 
+# eToro/Bloomberg exchange suffix -> Yahoo Finance suffix, applied in get_data_fetch_ticker
+# (Yahoo 404s on the eToro form; verified via live probes). .DH (Gulf) is intentionally
+# absent — Yahoo uses numeric codes there, so it needs per-name data_fetch_substitutions.
+_YAHOO_SUFFIX_MAP = {"NV": "AS", "IM": "MI", "LN": "L", "CH": "SW"}
+# Currency / price-unit lines eToro appends (e.g. MSFT.EUR, KSP.L.GBX) -> stripped before fetch.
+_CURRENCY_SUFFIXES = {"EUR", "USD", "GBP", "GBX"}
+# US class-share letters -> Yahoo dash form (BRK.B -> BRK-B).
+_CLASS_SHARE_LETTERS = {"A", "B", "C"}
+
 
 class ConfigManager:
     """Unified configuration management for the entire application."""
@@ -399,17 +408,27 @@ class ConfigManager:
         ):
             return "^VIX"  # Yahoo Finance uses ^VIX for the VIX index
 
-        # Special case: .NV (Euronext Amsterdam) tickers should fetch as .AS
-        # Yahoo Finance doesn't recognize .NV but does recognize .AS
-        if ticker and ticker.upper().endswith(".NV"):
-            # Replace .NV with .AS for data fetching
-            base_ticker = ticker.upper()[:-3]  # Remove .NV
-            return base_ticker + ".AS"
+        tu = ticker.upper() if ticker else ""
 
-        # Same-security cross-exchange substitution (e.g. LYXGRE.DE → GRE.PA)
-        # for tickers Yahoo doesn't index. See data_fetch_substitutions docstring.
-        if ticker and ticker.upper() in self.data_fetch_substitutions:
-            return self.data_fetch_substitutions[ticker.upper()]
+        # Same-security per-name override wins (e.g. LYXGRE.DE → GRE.PA) for tickers Yahoo
+        # doesn't index. See data_fetch_substitutions docstring.
+        if tu in self.data_fetch_substitutions:
+            return self.data_fetch_substitutions[tu]
+
+        # eToro-suffix → Yahoo-symbol normalization (Yahoo 404s on the eToro form):
+        if "." in tu:
+            stem, _, suf = tu.rpartition(".")
+            if stem:
+                # 1. strip a currency / price-unit line, then re-resolve the stem
+                #    (MSFT.EUR → MSFT ; KSP.L.GBX → KSP.L).
+                if suf in _CURRENCY_SUFFIXES:
+                    return self.get_data_fetch_ticker(stem)
+                # 2. exchange-suffix remap (.NV→.AS, .IM→.MI, .LN→.L, .CH→.SW).
+                if suf in _YAHOO_SUFFIX_MAP:
+                    return stem + "." + _YAHOO_SUFFIX_MAP[suf]
+                # 3. US class share (single letter, no further exchange suffix): BRK.B → BRK-B.
+                if suf in _CLASS_SHARE_LETTERS and "." not in stem:
+                    return stem + "-" + suf
 
         # For data fetching, we might want to use US tickers when available
         # as they often have better data coverage, but we'll normalize the results

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -244,11 +244,14 @@ def _default_accruals_fetch(tickers: list[str]) -> dict[str, float]:
 
     import yfinance as yf  # noqa: PLC0415
 
+    from trade_modules.config_manager import get_config  # noqa: PLC0415
+
+    resolve = get_config().get_data_fetch_ticker  # eToro ticker -> Yahoo symbol
     out: dict[str, float] = {}
     for t in tickers:
         for attempt in range(3):
             try:
-                tkr = yf.Ticker(t)
+                tkr = yf.Ticker(resolve(t))
                 ni = _first_label_value(tkr.financials, _NI_LABELS)
                 ocf = _first_label_value(tkr.cashflow, _OCF_LABELS)
                 ta_vals = _two_most_recent(tkr.balance_sheet, _TA_LABELS)
@@ -273,28 +276,89 @@ def _default_accruals_fetch(tickers: list[str]) -> dict[str, float]:
     return out
 
 
-def _default_info_fetch(tickers: list[str]) -> dict[str, dict]:
-    """Throttled per-ticker yfinance ``.info`` fetch.
+def _info_cache_path() -> str:
+    """Daily on-disk cache for yfinance ``.info`` (keyed by Yahoo symbol)."""
+    import os  # noqa: PLC0415
+    from datetime import date  # noqa: PLC0415
 
-    Sleeps ~0.3s between tickers, retries twice on exception, and skips
-    (never raises) a ticker whose info cannot be retrieved.  Imported at
-    call time so the module stays importable without yfinance installed.
+    return os.path.expanduser(f"~/.weirdapps-trading/v3_info_cache_{date.today():%Y%m%d}.json")
+
+
+def _load_info_cache() -> dict[str, dict]:
+    import json  # noqa: PLC0415
+
+    try:
+        with open(_info_cache_path()) as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:  # noqa: BLE001  (best-effort: missing/corrupt -> refetch)
+        return {}
+
+
+def _save_info_cache(cache: dict[str, dict]) -> None:
+    import json  # noqa: PLC0415
+    import os  # noqa: PLC0415
+
+    try:
+        path = _info_cache_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as fh:
+            json.dump(cache, fh, default=str)
+    except Exception:  # noqa: BLE001  (best-effort cache; never fail the run)
+        pass
+
+
+def _info_is_populated(info) -> bool:
+    """A rate-limited ``.info`` comes back as an empty/sparse dict WITHOUT raising.
+    Treat 'no shortName and no price' as a fetch failure so it is retried."""
+    return isinstance(info, dict) and bool(
+        info.get("shortName") or info.get("regularMarketPrice") is not None
+    )
+
+
+def _default_info_fetch(tickers: list[str]) -> dict[str, dict]:
+    """Throttled per-ticker yfinance ``.info`` fetch, provider-mapped + rate-limit-safe.
+
+    Maps each eToro ticker to its Yahoo symbol (``get_data_fetch_ticker``: ``.NV``→``.AS``,
+    ``.IM``→``.MI``, currency-line strip, class-share dash, …) before fetching, but keys the
+    result by the ORIGINAL eToro ticker. Retries on exception AND on an empty/sparse dict
+    (yfinance returns ``{}`` when rate-limited, without raising) with exponential back-off.
+    A daily on-disk cache keyed by Yahoo symbol skips already-fetched names (the overlay runs
+    every 4h — the cache collapses ~6 fetches/day to ~1). Never raises; unfetchable → ``{}``.
     """
     import time  # noqa: PLC0415
 
     import yfinance as yf  # noqa: PLC0415
 
+    from trade_modules.config_manager import get_config  # noqa: PLC0415
+
+    resolve = get_config().get_data_fetch_ticker
+    cache = _load_info_cache()
     out: dict[str, dict] = {}
+    dirty = False
     for t in tickers:
+        y = resolve(t)
+        if y in cache:  # cache hit (populated result stored earlier today)
+            out[t] = cache[y]
+            continue
+        info: dict = {}
         for attempt in range(3):  # initial try + 2 retries
             try:
-                info = yf.Ticker(t).info
-                out[t] = info if isinstance(info, dict) else {}
-                break
+                got = yf.Ticker(y).info
+                if _info_is_populated(got):
+                    info = got
+                    break
             except Exception:  # noqa: BLE001
-                if attempt < 2:
-                    time.sleep(0.3 * (attempt + 1))
+                pass
+            if attempt < 2:
+                time.sleep(0.5 * (3**attempt))  # 0.5s, 1.5s back-off (rate-limit recovery)
+        out[t] = info
+        if info:  # cache only populated results, so rate-limited names retry next run
+            cache[y] = info
+            dirty = True
         time.sleep(0.3)
+    if dirty:
+        _save_info_cache(cache)
     return out
 
 

--- a/trade_modules/v3/fetch.py
+++ b/trade_modules/v3/fetch.py
@@ -20,12 +20,26 @@ def _default_downloader(batch: list[str], period: str) -> pd.DataFrame:
     - Legacy single-ticker: flat columns ("Open", "High", …, "Close") —
       extract the "Close" column and rename to the ticker symbol.
 
+    Maps eToro tickers to Yahoo symbols (``get_data_fetch_ticker``: ``.NV``→``.AS``,
+    ``.IM``→``.MI``, currency-line strip, class-share dash, …) for the download, then
+    renames the columns back to the ORIGINAL eToro tickers so callers are unaffected.
+
     Imported at call time so the module is safe to import without yfinance.
     """
     import yfinance as yf  # noqa: PLC0415
 
+    from trade_modules.config_manager import get_config  # noqa: PLC0415
+
+    resolve = get_config().get_data_fetch_ticker
+    y2e: dict[str, str] = {}  # Yahoo symbol -> original eToro ticker
+    ybatch: list[str] = []
+    for t in batch:
+        y = resolve(t)
+        y2e[y] = t
+        ybatch.append(y)
+
     data = yf.download(
-        batch,
+        ybatch,
         period=period,
         auto_adjust=True,
         progress=False,
@@ -37,22 +51,23 @@ def _default_downloader(batch: list[str], period: str) -> pd.DataFrame:
         close = data["Close"]
         if isinstance(close, pd.Series):
             # Shouldn't happen with MultiIndex, but guard anyway.
-            close = close.to_frame(name=batch[0])
+            close = close.to_frame(name=ybatch[0])
     elif "Close" in data.columns:
         # Legacy single-ticker flat layout: columns are metric names.
-        close = data[["Close"]].rename(columns={"Close": batch[0]})
+        close = data[["Close"]].rename(columns={"Close": ybatch[0]})
     else:
         close = data
 
     if isinstance(close, pd.Series):
-        close = close.to_frame(name=batch[0])
+        close = close.to_frame(name=ybatch[0])
 
     # Safety net: if yfinance returns a 1-column frame but the name doesn't
-    # match the requested ticker (e.g. version quirks), fix it up.
-    if len(batch) == 1 and len(close.columns) == 1 and close.columns[0] != batch[0]:
-        close = close.rename(columns={close.columns[0]: batch[0]})
+    # match the requested symbol (e.g. version quirks), fix it up.
+    if len(ybatch) == 1 and len(close.columns) == 1 and close.columns[0] != ybatch[0]:
+        close = close.rename(columns={close.columns[0]: ybatch[0]})
 
-    return close
+    # Rename Yahoo columns back to the original eToro tickers.
+    return close.rename(columns=y2e)
 
 
 def robust_fetch_prices(


### PR DESCRIPTION
## Why
Owner saw blank metrics for whole stocks (`SBMO.NV`) and intermittently for Tokyo/others, despite Yahoo + eToro having the data. Two root causes, live-probed:

1. **Incomplete eToro→Yahoo suffix mapping.** `config_manager.get_data_fetch_ticker` only handled `.NV`→`.AS`. Other suffixes 404 on Yahoo.
2. **v3 enrichment bypassed the resolver AND kept rate-limited empty `.info` silently** (retry only on exception; a 500-name burst drops names randomly → the Tokyo "no data").

## Changes
- **`config_manager.get_data_fetch_ticker`** generalized: currency/price-unit strip (`MSFT.EUR`→`MSFT`, `KSP.L.GBX`→`KSP.L`), suffix remap `{.NV:.AS, .IM:.MI, .LN:.L, .CH:.SW}`, US class shares `.A/.B/.C`→`-A/-B/-C`. The providers already call this → **signal pipeline (`etoro.csv` build) fixed for free**.
- **v3 fetchers** (`features._default_info_fetch`, `_default_accruals_fetch`, `fetch._default_downloader`) now map via the resolver, keyed by the original eToro ticker.
- **Rate-limit robustness**: empty/sparse `.info` treated as a failure → exponential back-off retry; daily on-disk cache keyed by Yahoo symbol.
- **Deferred**: `.DH` (33 Gulf names, numeric on Yahoo) → `data_fetch_substitutions` later.

## Verification
- `SBMO.NV` 0/9 → filled (via `SBMO.AS`, price 32.32); resolver maps all failing suffixes; Tokyo 8/8.
- TDD; v3 suite **478 green**, resolver + provider tests green, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)