### PR TITLE
feat(v3): C — upweight analyst_mom (strength_z) 0.05->0.08

### DIFF
--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -583,6 +583,9 @@ def test_best_bet_prior_weights_2026_07_20():
     assert w["lowvol_z"] < w["value_z"], "low-vol trimmed to a risk-diversifier"
     assert w["lowvol_z"] <= 0.10 + 1e-9, "low-vol capped low (its alpha was a beta artifact)"
     assert (w["value_z"] + w["quality_z"]) < 0.55, "no Value+Quality cap-as-floor"
+    # C (2026-07-20): analyst_mom upweighted (β-neutral t 2.36) above growth.
+    assert w["strength_z"] >= 0.08 - 1e-9, "analyst_mom (strength) upweighted per C"
+    assert w["strength_z"] > w["growth_z"], "strength now ranks above the trimmed growth satellite"
     assert abs(sum(w.values()) - 1.0) < 1e-9
 
 

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -156,15 +156,20 @@ _VALUE_CANDIDATES = sorted({m for r in VALUE_GROUP_RECIPES.values() for m in r})
 # 2026-07-20: earnings-trajectory (PET/PEF) added at 0.10 — the strongest clean signal on
 # the panel (beta-neutral t 2.17, hit 80%, incremental to value+growth). Funded by trimming
 # value/momentum 0.20->0.18, growth 0.08->0.05, strength 0.07->0.05, quality 0.25->0.24.
+# 2026-07-20 (C): analyst_mom (strength_z) upweighted 0.05->0.08 — β-neutral forward IC
+# t 2.36 on the panel, the 2nd-strongest clean signal after trajectory; kept modest (it is
+# a single noisy metric: raw IC ~0, hit 50%). Funded by growth 0.05->0.03 (theory-weak) +
+# low-vol 0.10->0.09 (risk-diversifier, not alpha). Upside/EXR stay MONITOR (zero β-alpha,
+# t -0.15) — a negative-upside BUY is often a right contrarian bet (see capitulation study).
 CLUSTER_WEIGHTS = {
     "value_z": 0.18,
     "quality_z": 0.24,
     "momentum_z": 0.18,
     "pead_z": 0.10,
     "trajectory_z": 0.10,
-    "lowvol_z": 0.10,
-    "growth_z": 0.05,
-    "strength_z": 0.05,
+    "lowvol_z": 0.09,
+    "strength_z": 0.08,
+    "growth_z": 0.03,
 }
 
 # The Value+Quality joint weight is capped here regardless of the weighting scheme.


### PR DESCRIPTION
## Why
`analyst_mom` is the 2nd-strongest clean signal (β-neutral forward IC **t 2.36**, after trajectory t 2.17) yet was underweighted at 0.05.

## Change
`strength_z` 0.05 → **0.08** (modest — single noisy metric, raw IC ~0, hit 50%). Funded by `growth_z` 0.05→0.03 + `lowvol_z` 0.10→0.09. Quality stays leader (0.24); sum 1.0.

`upside`/EXR stay MONITOR (zero β-alpha t −0.15) — the capitulation study (option B) showed negative-upside BUYs slightly *outperform*, so no gate.

TDD; combine + weight-proposal suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)