### PR TITLE
feat(v3): rich email snapshot — full info-parity with the browser attachment

### DIFF
--- a/scripts/v3_capitulation_study.py
+++ b/scripts/v3_capitulation_study.py
@@ -1,0 +1,127 @@
+"""Study: does an 'analyst capitulation' conjunction predict UNDERperformance?
+
+Tests option B — a capitulation gate that would block a NEW BUY when the analyst
+consensus is uniformly bearish: ``upside < threshold`` AND ``analyst_mom < 0``.
+
+For the gate to earn its place it must show that, AMONG would-be buys (top-conviction
+names), capitulation names underperform the rest. We reconstruct the etoro.csv panel
+from git history (PIT), compute a panel-native conviction proxy + beta-neutral forward
+returns, and report — per upside threshold — the buy-zone (top 15% conviction) forward-
+return difference (capitulation - rest) with a HAC t-stat, plus the pooled unconditional
+difference. Research only; prints a table, writes nothing to production.
+
+    .venv/bin/python scripts/v3_capitulation_study.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from v3_factor_backtest import git_snapshots, load_panel_at  # noqa: E402
+
+from trade_modules.v3.combine import _rank_z  # noqa: E402
+from trade_modules.v3.factor_backtest import (  # noqa: E402
+    beta_neutralize,
+    forward_return_at,
+    hac_tstat,
+)
+from trade_modules.v3.features import _num  # noqa: E402
+from trade_modules.v3.prices import load_eur_close  # noqa: E402
+from trade_modules.v3.universe import load_universe  # noqa: E402
+
+ETORO = "yahoofinance/output/etoro.csv"
+HORIZON = 21
+BUY_PCTILE = 0.85  # top 15% conviction = would-be buys (overlay buy_pctile)
+THRESHOLDS = [-5.0, -10.0, -15.0]  # upside % floors to test for the capitulation flag
+# Panel-native conviction proxy (value/quality/momentum-proxy/low-vol), directional.
+CONV = {"PET": -1, "ROE": +1, "FCF": +1, "52W": +1, "EG": +1, "B": -1}
+
+
+def _conviction(panel: pd.DataFrame) -> pd.Series:
+    zs = [_rank_z(_num(panel[c])) * d for c, d in CONV.items() if c in panel.columns]
+    return pd.concat(zs, axis=1).mean(axis=1, skipna=True) if zs else pd.Series(dtype=float)
+
+
+def _mean(x: list[float]) -> float:
+    s = pd.Series(x, dtype=float)
+    return float(s.mean()) if len(s) else float("nan")
+
+
+def main() -> None:
+    snaps = git_snapshots(ETORO, weekly=False)
+    universe = set(load_universe(ETORO, min_factor_coverage=6))
+    px = load_eur_close(sorted(universe), period="1y")
+    pidx = px.index
+    print(f"snapshots: {len(snaps)}  universe: {len(universe)}  priced: {px.shape[1]}")
+
+    per_date_diff: dict[float, list[float]] = {t: [] for t in THRESHOLDS}
+    pooled_cap: dict[float, list[float]] = {t: [] for t in THRESHOLDS}
+    pooled_non: dict[float, list[float]] = {t: [] for t in THRESHOLDS}
+    n_flag_buyzone: dict[float, int] = dict.fromkeys(THRESHOLDS, 0)
+    n_buyzone = 0
+    n_dates = 0
+
+    for commit, date in snaps:
+        panel = load_panel_at(commit, ETORO)
+        if panel is None:
+            continue
+        panel = panel[panel.index.astype(str).isin(universe)]
+        if panel.empty or "UP%" not in panel.columns or "AM" not in panel.columns:
+            continue
+        mask = pidx <= pd.Timestamp(date)
+        if not mask.any():
+            continue
+        fwd = forward_return_at(px, pidx[mask].max(), HORIZON)
+        if fwd.empty:
+            continue
+        beta = _num(panel["B"]).reindex(fwd.index) if "B" in panel.columns else None
+        fwd_n = beta_neutralize(fwd, beta) if beta is not None else fwd
+
+        idx = panel.index
+        fn = fwd_n.reindex(idx)
+        up = _num(panel["UP%"]).reindex(idx)
+        am = _num(panel["AM"]).reindex(idx)
+        conv = _conviction(panel)
+        if conv.dropna().empty:
+            continue
+        top = (conv >= conv.quantile(BUY_PCTILE)) & fn.notna()
+        n_dates += 1
+        n_buyzone += int(top.sum())
+
+        for thr in THRESHOLDS:
+            cap = (up < thr) & (am < 0)
+            bz_cap = top & cap
+            bz_non = top & ~cap
+            n_flag_buyzone[thr] += int(bz_cap.sum())
+            if bz_cap.sum() >= 1 and bz_non.sum() >= 1:
+                per_date_diff[thr].append(float(fn[bz_cap].mean() - fn[bz_non].mean()))
+            pooled_cap[thr].extend(fn[cap & fn.notna()].tolist())
+            pooled_non[thr].extend(fn[(~cap) & fn.notna()].tolist())
+
+    print(f"\ndates used: {n_dates}   avg buy-zone names/date: {n_buyzone / max(n_dates, 1):.0f}")
+    print("\n=== CAPITULATION GATE STUDY (beta-neutral forward return @ 21td) ===")
+    print("(a diff < 0 with |t| > 2 would justify the gate: capitulation names underperform)\n")
+    hdr = (
+        f"{'upside<':>8}{'BUY-ZONE diff':>15}{'HAC t':>8}{'dates':>7}{'flagged':>9}"
+        f"{'POOLED cap':>12}{'pooled non':>12}{'n_cap':>7}"
+    )
+    print(hdr)
+    for thr in THRESHOLDS:
+        diffs = pd.Series(per_date_diff[thr], dtype=float)
+        t = hac_tstat(diffs, HORIZON) if len(diffs) > 2 else float("nan")
+        cap_m, non_m = _mean(pooled_cap[thr]), _mean(pooled_non[thr])
+        print(
+            f"{thr:>7.0f}%{_mean(per_date_diff[thr]) * 100:>14.2f}%{t:>8.2f}"
+            f"{len(diffs):>7}{n_flag_buyzone[thr]:>9}"
+            f"{cap_m * 100:>11.2f}%{non_m * 100:>11.2f}%{len(pooled_cap[thr]):>7}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -29,6 +29,10 @@ V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 \
 
 # 3) Email the freshest report — the Outlook-safe EMAIL edition (table-based,
 #    inline styles), not the browser HTML which the Outlook body sanitizer breaks.
+#    This edition is now at FULL info-parity with the browser attachment (conviction
+#    heatmap + full per-stock factor cards + trade levels). It is the ONLY thing this
+#    scheduled job mails — the pipeline map + factor backtest are on-demand (sent with
+#    the snapshot only when the owner asks for "all three files").
 REPORT="$(ls -t "$HOME/Downloads/"*_v3_overlay_email.html 2>/dev/null | head -1 || true)"
 if [ -z "${REPORT:-}" ]; then
   echo "ERROR: no v3 overlay email report produced" >&2

--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -43,6 +43,37 @@ def _scores() -> pd.DataFrame:
             "beta": [-0.2, 0.4, 1.0],
             "realized_vol": [0.35, 0.25, 0.30],
             "de": [40.4, NAN, 15.5],
+            # ranking + heatmap
+            "conviction": [1.66, -0.8, 0.5],
+            "rank": [1, 3, 2],
+            "is_portfolio": [True, False, True],
+            "pead_z": [0.6, -0.4, 0.1],
+            "trajectory_z": [0.9, 0.0, -0.3],
+            "strength_z": [0.5, -0.2, 0.0],
+            # full-metric parity (browser-only before)
+            "pe_trailing": [28.0, 12.0, 9.0],
+            "ev_ebitda": [15.0, 6.0, 8.0],
+            "peg": [1.2, 0.8, NAN],
+            "roa": [0.12, 0.06, NAN],
+            "gross_margin": [0.44, 0.30, NAN],
+            "current_ratio": [1.2, 2.0, 1.1],
+            "gp_assets": [0.30, 0.12, NAN],
+            "sue": [1.5, -0.5, 0.2],
+            "earn_trajectory": [1.14, 0.90, 1.00],
+            "short_interest": [1.1, 5.0, 0.8],
+            "target_dispersion": [0.5, 0.2, 0.3],
+            "target_high": [250.0, 60.0, 15.0],
+            "target_low": [150.0, 40.0, 10.0],
+            "cap": [3.5e12, 8e9, 5e8],
+            "avg_volume": [1e6, 5e5, 2e5],
+            "adv_usd": [2e8, 1e7, 1e6],
+            "div_yield": [0.005, 0.030, 0.010],
+            "price": [200.0, 50.0, 12.0],
+            # vol-scaled trade levels
+            "entry": [200.0, 50.0, 12.0],
+            "stop_loss": [180.0, 45.0, 10.5],
+            "take_profit": [240.0, 60.0, 15.0],
+            "rr": [2.0, 1.5, 1.8],
         },
         index=["AAA", "BBB", "CCC"],
     )
@@ -158,18 +189,41 @@ def test_render_email_is_outlook_safe():
     for forbidden in ("var(--", "<details", "display:flex", "display:grid", "<svg"):
         assert forbidden not in html, forbidden
     assert "&amp;amp;" not in html  # no HTML-entity double-escaping
-    # sections + all six factor clusters present
+    # sections + all factor groups (DISPLAY_GROUPS parity with the browser report)
     for token in (
         "Factor Snapshot",
+        "Conviction heatmap",  # new overview section
         "Value",
         "Quality",
-        "PEAD",
-        "Growth",
         "Momentum",
+        "PEAD",
+        "Trajectory",
+        "Low-vol",
         "Strength",
-        "Risk",
+        "Analyst",
+        "Size-Liq",
+        "Income",
     ):
         assert token in html, token
+    # full-metric parity: labels that were browser-only before now render in the email
+    for label in (
+        "EV/EBITDA",
+        "P/E TTM",
+        "ROA",
+        "Op Mgn",
+        "GP/Assets",
+        "Tgt High",
+        "ADV",
+        "Div Yield",
+    ):
+        assert label in html, label
+    # trade levels per card
+    for lvl in ("R:R", "Stop", "Target", "Entry"):
+        assert lvl in html, lvl
+    # heatmap actually rendered cells (solid hex tint on a bgcolor cell)
+    assert 'bgcolor="#' in html
+    # methodology text
+    assert "winsorized" in html
     # USD-bloc breach surfaced (0.68 > 0.65 cap)
     assert "BREACH" in html
     # full name resolved from the description (not the truncated eToro name)
@@ -193,10 +247,12 @@ def test_full_name_extraction():
     assert rem._full_name(None, "FB") == "FB"
 
 
-def test_metric_formatting():
-    assert rem._mfmt("mom_12_1", 0.30) == "+30%"  # fraction -> signed percent
-    assert rem._mfmt("roe", 18.9) == "18.9%"  # already a percent
-    assert rem._mfmt("pe_forward", 23.0) == "23.0"  # ratio
-    assert rem._mfmt("beta", -0.2) == "-0.20"
-    assert rem._mfmt("upside", 15.5) == "+15.5%"
-    assert rem._mfmt("de", NAN) == "n/a"
+def test_heat_hex_tint():
+    """Heat cell tint: green above-peer, red below, neutral warm for NaN — solid hex."""
+    assert rem._heat_hex(1.5).startswith("#") and len(rem._heat_hex(1.5)) == 7
+    # positive leans green (G channel highest), negative leans red (R channel highest)
+    pos = rem._heat_hex(2.0)
+    neg = rem._heat_hex(-2.0)
+    assert int(pos[3:5], 16) > int(pos[1:3], 16)  # G > R for green
+    assert int(neg[1:3], 16) > int(neg[3:5], 16)  # R > G for red
+    assert rem._heat_hex(NAN) == rem.WARM

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -25,6 +25,17 @@ from __future__ import annotations
 import html as _htmllib
 import math
 
+# Single-source the data model + metric formatting from the browser report so the two
+# editions never drift — only the HTML rendering differs (this file stays email-safe).
+from trade_modules.v3.report import (
+    CLUSTER_CELLS,
+    DISPLAY_GROUPS,
+    GROUP_CLUSTER,
+)
+from trade_modules.v3.report import (
+    _fmt as _bfmt,
+)
+
 # --- Palette (literal; Outlook has no CSS variables) ------------------------
 INK = "#16181d"
 INK2 = "#4a4e57"
@@ -50,52 +61,6 @@ ACTION_META = {
 }
 ACTION_ORDER = ["BUY", "ADD", "TRIM", "SELL", "HOLD"]
 CONTENT_W = 680
-
-# Per-stock factor grid: (cluster label, z-column or None, [(metric_key, short label), ...]).
-CARD_FACTORS = [
-    ("Value", "value_z", [("pe_forward", "P/E"), ("pb", "P/B"), ("ps_sector", "P/S")]),
-    ("Quality", "quality_z", [("roe", "ROE"), ("fcf", "FCF"), ("gp_assets", "GP/A")]),
-    ("PEAD", "pead_z", [("sue", "SUE")]),
-    ("Traj", "trajectory_z", [("earn_trajectory", "t/f")]),
-    ("Growth", "growth_z", [("earn_growth", "EPS"), ("rev_growth", "rev")]),
-    (
-        "Momentum",
-        "momentum_z",
-        [("mom_12_1", "12-1"), ("pct_52w_high", "52w"), ("price_perf", "12m")],
-    ),
-    (
-        "Strength",
-        "strength_z",
-        [("analyst_mom", "revis"), ("upside", "upside"), ("buy_pct", "buy")],
-    ),
-    ("Risk", "lowvol_z", [("beta", "β"), ("realized_vol", "vol"), ("de", "D/E")]),
-]
-
-# metric formatting: key -> (kind, decimals, signed). kind: fracpct (x100), pct
-# (already a percent), ratio (plain number). Scales verified against live scores.
-_METRIC_FMT = {
-    "mom_12_1": ("fracpct", 0, True),
-    "gp_assets": ("fracpct", 0, False),  # gross profit / assets
-    "sue": ("ratio", 2, True),  # standardized unexpected earnings (z-like)
-    "earn_trajectory": ("ratio", 2, False),  # trailing/forward P/E ratio (>1 = rising)
-    "pct_52w_high": ("pct", 0, False),
-    "price_perf": ("pct", 0, True),
-    "pe_forward": ("ratio", 1, False),
-    "pb": ("ratio", 2, False),
-    "ps_sector": ("ratio", 2, False),
-    "roe": ("pct", 1, False),
-    "op_margin": ("fracpct", 0, False),
-    "fcf": ("pct", 1, False),
-    "earn_growth": ("pct", 0, True),
-    "rev_growth": ("fracpct", 0, True),
-    "upside": ("pct", 1, True),
-    "buy_pct": ("pct", 0, False),
-    "analyst_mom": ("ratio", 0, True),
-    "beta": ("ratio", 2, False),
-    "realized_vol": ("fracpct", 0, False),
-    "de": ("ratio", 1, False),
-    "target_dispersion": ("fracpct", 0, False),
-}
 
 
 # --- Formatters -------------------------------------------------------------
@@ -131,20 +96,6 @@ def _pp(v) -> str:  # fraction delta -> "-2.5pp"
 
 def _num(v, d=2) -> str:
     return "n/a" if _nan(v) else f"{v:.{d}f}"
-
-
-def _mfmt(key: str, v) -> str:
-    """Format a raw factor metric for the card grid (compact, readable units)."""
-    if _nan(v):
-        return "n/a"
-    try:
-        v = float(v)
-    except (TypeError, ValueError):
-        return _esc(v)
-    kind, dp, signed = _METRIC_FMT.get(key, ("ratio", 2, False))
-    x = v * 100 if kind == "fracpct" else v
-    body = f"{x:+.{dp}f}" if signed else f"{x:.{dp}f}"
-    return body + ("%" if kind in ("fracpct", "pct") else "")
 
 
 def _tone(v) -> str:
@@ -301,7 +252,7 @@ def _factor_cell(label: str, z_col: str | None, metrics: list, row) -> str:
     sep = f' <span style="color:{MUTED};">·</span> '
     chips = sep.join(
         f'<span style="color:{MUTED};">{_esc(lbl)}</span> '
-        f'<span style="color:{INK};font-weight:700;">{_mfmt(k, _get(row, k))}</span>'
+        f'<span style="color:{INK};font-weight:700;">{_bfmt(k, _get(row, k))}</span>'
         for k, lbl in metrics
     )
     return (
@@ -316,7 +267,9 @@ def _factor_cell(label: str, z_col: str | None, metrics: list, row) -> str:
 def _factor_grid(row) -> str:
     if row is None:
         return ""
-    cells = [_factor_cell(lbl, zc, ms, row) for lbl, zc, ms in CARD_FACTORS]
+    # Full info-parity with the browser report: every DISPLAY_GROUPS group + all its
+    # metrics (not the old CARD_FACTORS subset), with the cluster z from GROUP_CLUSTER.
+    cells = [_factor_cell(lbl, GROUP_CLUSTER.get(lbl), ms, row) for lbl, ms in DISPLAY_GROUPS]
     rows = []
     for i in range(0, len(cells), 2):
         pair = cells[i : i + 2]
@@ -327,6 +280,33 @@ def _factor_grid(row) -> str:
         f'<div style="border-top:1px solid {LINE};margin:10px 0 0 0;padding-top:8px;">'
         '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
         f'style="border-collapse:collapse;">{"".join(rows)}</table></div>'
+    )
+
+
+def _levels_tiles(row) -> str:
+    """Vol-scaled trade levels (entry / stop / target / R:R) as email tiles."""
+    if row is None:
+        return ""
+    entry, stop, tp, rr = (
+        _get(row, "entry"),
+        _get(row, "stop_loss"),
+        _get(row, "take_profit"),
+        _get(row, "rr"),
+    )
+    if all(_nan(x) for x in (entry, stop, tp, rr)):
+        return ""
+    return (
+        '<div style="margin-top:8px;">'
+        + _tiles(
+            [
+                ("Entry", _money(entry), "", INK),
+                ("Stop", _money(stop), "vol-scaled", BEAR),
+                ("Target", _money(tp), "vol-scaled", BULL),
+                ("R:R", _num(rr, 1), "reward/risk", INK),
+            ],
+            per_row=4,
+        )
+        + "</div>"
     )
 
 
@@ -403,13 +383,14 @@ def _header_row(a: dict, color: str, cmax: float) -> str:
 
 
 def _action_card(a: dict, row, color: str, cmax: float) -> str:
-    """Rich per-stock card: header + six-cluster factor grid."""
+    """Rich per-stock card: header + trade levels + full factor grid + description."""
     return (
         '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
         'style="border-collapse:separate;margin-bottom:10px;"><tr>'
         f'<td bgcolor="{CANVAS}" style="background:{CANVAS};border:1px solid {LINE};'
         f'border-left:3px solid {color};border-radius:0 9px 9px 0;padding:12px 14px;">'
-        f"{_header_row(a, color, cmax)}{_factor_grid(row)}{_desc_block(a.get('_desc'))}"
+        f"{_header_row(a, color, cmax)}{_levels_tiles(row)}{_factor_grid(row)}"
+        f"{_desc_block(a.get('_desc'))}"
         "</td></tr></table>"
     )
 
@@ -458,6 +439,85 @@ def _action_group(act: str, rows: list, cmax: float, scores) -> str:
         body = "".join(_action_card(a, _row_of(a), color, cmax) for a in rows)
         body += '<div style="height:8px;font-size:0;">&nbsp;</div>'
     return header + body
+
+
+# --- Conviction heatmap (email-safe: solid bgcolor cells, no rgba) ----------
+def _heat_hex(z) -> str:
+    """Solid hex tint for a heat cell — the browser's green/red rgba blended over
+    white (Outlook's ``bgcolor`` needs a solid hex, not rgba)."""
+    if _nan(z):
+        return WARM
+    a = min(abs(float(z)) / 2.0, 1.0)
+    alpha = 0.10 + a * 0.50
+    r, g, b = (45, 106, 79) if z >= 0 else (179, 64, 47)
+
+    def _mix(c: int) -> int:
+        return round(255 * (1 - alpha) + c * alpha)
+
+    return f"#{_mix(r):02x}{_mix(g):02x}{_mix(b):02x}"
+
+
+def _heat_z(z) -> str:
+    return "·" if _nan(z) else f"{z:+.1f}"
+
+
+def _heatmap_section(scores, max_rows: int = 120) -> str:
+    """Ranked names × cluster z heat-strip — the browser overview, as an email table.
+    Shows all holdings plus the top ``max_rows`` by conviction (email-deliverable size)."""
+    import pandas as pd  # noqa: PLC0415
+
+    if scores is None or "conviction" not in getattr(scores, "columns", []):
+        return ""
+    ranked = scores.sort_values("conviction", ascending=False, na_position="last")
+    total = int(ranked["conviction"].notna().sum())
+    if total == 0:
+        return ""
+    held = ranked.index[ranked.get("is_portfolio", pd.Series(False, index=ranked.index)) == True]  # noqa: E712
+    keep = set(held) | set(ranked.head(max_rows).index)
+    shown = ranked.loc[[i for i in ranked.index if i in keep]]
+
+    def _th(txt: str, align: str = "center") -> str:
+        return (
+            f'<td align="{align}" style="font-family:{FONT};font-size:9px;font-weight:700;'
+            f'letter-spacing:.3px;text-transform:uppercase;color:{MUTED};padding:0 3px 6px;">{txt}</td>'
+        )
+
+    header = (
+        '<tr><td style="padding:0 8px 6px 0;">&nbsp;</td>'
+        + "".join(_th(lbl) for _, lbl in CLUSTER_CELLS)
+        + _th("Conv", "right")
+        + _th("Rank", "right")
+        + "</tr>"
+    )
+    body = []
+    for tkr, r in shown.iterrows():
+        conv, rank = r.get("conviction"), r.get("rank")
+        pf = (
+            f' <span style="color:{ACCENT};font-size:8px;font-weight:700;">PF</span>'
+            if bool(r.get("is_portfolio"))
+            else ""
+        )
+        cells = "".join(
+            f'<td bgcolor="{_heat_hex(r.get(zc))}" align="center" style="font-family:{MONO};'
+            f'font-size:9.5px;color:{INK};padding:4px 3px;border:2px solid {CANVAS};">{_heat_z(r.get(zc))}</td>'
+            for zc, _ in CLUSTER_CELLS
+        )
+        body.append(
+            f'<tr><td style="font-family:{MONO};font-size:10.5px;font-weight:700;color:{INK};'
+            f'padding:4px 8px 4px 0;white-space:nowrap;">{_esc(str(tkr))}{pf}</td>{cells}'
+            f'<td align="right" style="font-family:{MONO};font-size:10px;font-weight:700;'
+            f'color:{_tone(conv)};padding:4px 0 4px 8px;">{"·" if _nan(conv) else f"{conv:+.2f}"}</td>'
+            f'<td align="right" style="font-family:{MONO};font-size:9.5px;color:{MUTED};'
+            f'padding:4px 0 4px 6px;">{"" if _nan(rank) else "#" + str(int(rank))}</td></tr>'
+        )
+    cap = f" &middot; showing {len(shown)} of {total}" if len(shown) < total else ""
+    return (
+        '<div style="overflow-x:auto;-webkit-overflow-scrolling:touch;">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
+        f'style="border-collapse:collapse;">{header}{"".join(body)}</table></div>'
+        f'<div style="font-family:{FONT};font-size:10px;color:{MUTED};margin-top:6px;">'
+        f"Cluster z per name &middot; green above-peer / red below{cap}.</div>"
+    )
 
 
 # --- Main -------------------------------------------------------------------
@@ -512,8 +572,8 @@ def render_email_report(
         f'<div style="border-top:2px solid {INK};width:44px;font-size:0;line-height:0;margin:14px 0;">&nbsp;</div>'
         f'<div style="font-family:{FONT};font-size:12px;color:{INK2};line-height:1.6;">'
         f"A daily overlay on your live eToro book: keep what clears the bar, sell the genuinely weak, "
-        f"buy the strongest non-held names, then risk-gate the whole book. Each traded name carries its "
-        f"six-cluster factor breakdown.</div>"
+        f"buy the strongest non-held names, then risk-gate the whole book. Every scored name is ranked "
+        f"in the conviction heatmap; each traded name carries its full factor breakdown + trade levels.</div>"
         f'<div style="margin-top:12px;">'
         f'<span style="font-family:{MONO};font-size:11px;color:{INK};background:{WARM};'
         f'border:1px solid {LINE};border-radius:20px;padding:4px 11px;">Regime <b>{_esc(regime)}</b></span>'
@@ -625,9 +685,10 @@ def render_email_report(
         f"Universe {cov.get('n_scored', 'n/a')} scored &middot; {cov.get('n_eligible', 'n/a')} eligible"
         f"{(' (' + _pct1(cov_pct) + ' coverage)') if cov_pct is not None else ''}"
         f" &middot; caps name {_pct1(caps.get('name'))} / sector {_pct1(caps.get('sector'))} / USD-bloc {_pct1(caps.get('usd_bloc'))}.<br>"
-        f"Factor grid z-scores are the rank-normalized cluster contributions (value, quality, momentum, growth, "
-        f"low-vol, strength); metrics are the underlying raw values. ERC + conviction tilt, hard risk gate. "
-        f"Decision-support, not advice. Generated {gen}."
+        f"Factor grid z-scores are the rank-normalized cluster contributions (value, quality, momentum, "
+        f"PEAD, trajectory, low-vol, strength, growth); metrics are the underlying raw values. Each metric "
+        f"is winsorized (1/99) and cross-sectionally z-scored; conviction re-z-scored, rank 1 = best. "
+        f"ERC + conviction tilt, hard risk gate. Decision-support, not advice. Generated {gen}."
         "</div>"
     )
 
@@ -643,11 +704,17 @@ def render_email_report(
         + '<div style="height:12px;font-size:0;">&nbsp;</div>'
         + pos_tiles
         + _rule()
-        + _section_head("III", "Decisions", f"{len(actions)} names · factor cards for every trade")
+        + _section_head("III", "Conviction heatmap", "every scored name, ranked · cluster z-scores")
+        + '<div style="height:12px;font-size:0;">&nbsp;</div>'
+        + _heatmap_section(scores)
+        + _rule()
+        + _section_head(
+            "IV", "Decisions", f"{len(actions)} names · full factor cards for every trade"
+        )
         + '<div style="height:14px;font-size:0;">&nbsp;</div>'
         + groups
         + _rule()
-        + _section_head("IV", "Allocation", "current book by geography, asset, sector")
+        + _section_head("V", "Allocation", "current book by geography, asset, sector")
         + '<div style="height:12px;font-size:0;">&nbsp;</div>'
         + alloc_html
         + _rule()


### PR DESCRIPTION
## Why
The scheduled 4h "Factor Snapshot" mail showed only a subset of the browser attachment. The owner wants the emailed snapshot to carry **all** the info the attachment does, same beautiful way, responsive — so the mail IS the snapshot.

## What
`report_email.py` now renders (email-safe: tables + inline CSS + `bgcolor`; no flex/grid/details):
- **Conviction heatmap** (Section III) — ranked names × the cluster heat-strip, tinted cells + conviction + rank; holdings + top ~120, "showing N of M" when capped.
- **Full per-stock cards** — all `DISPLAY_GROUPS` metrics (was ~3/cluster) + a **trade-levels** row (entry/stop/target/R:R).
- **Methodology** text.

Single-sources the data model from `report.py` (imports `DISPLAY_GROUPS`/`CLUSTER_CELLS`/`GROUP_CLUSTER`/`_fmt`) — only the HTML differs; removed the dead `CARD_FACTORS`/`_mfmt`/`_METRIC_FMT`.

## Delivery (unchanged, already correct)
`run-v3-report.sh` emails this edition every 4h → it's now the rich snapshot automatically. Pipeline + backtest stay **on-demand** (sent with the snapshot only on "all three files").

## Verification
- report_email + report suites green; v3 surface **487 green**; email-safe grep clean.
- Rendered + visually verified (screenshot): heatmap, full cards, trade-level tiles, allocation, methodology.

Also includes `scripts/v3_capitulation_study.py` (option-B backtest — verdict: no gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)