### PR TITLE
fix(v3): email _nan catches pandas NAType (rank Int64) — heatmap crash on live data

### DIFF
--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -256,3 +256,14 @@ def test_heat_hex_tint():
     assert int(pos[3:5], 16) > int(pos[1:3], 16)  # G > R for green
     assert int(neg[1:3], 16) > int(neg[3:5], 16)  # R > G for red
     assert rem._heat_hex(NAN) == rem.WARM
+
+
+def test_heatmap_handles_na_rank_and_conviction():
+    """An ineligible name carries an Int64 NA rank + NaN conviction — the heatmap must
+    render it without crashing (regression: int(pd.NA) TypeError on live data)."""
+    s = _scores().copy()
+    s["rank"] = s["rank"].astype("Int64")
+    s.loc["CCC", "rank"] = pd.NA
+    s.loc["CCC", "conviction"] = NAN
+    html = rem.render_email_report(s, _meta(), portfolio=_view(), actions=_actions())
+    assert isinstance(html, str) and "Conviction heatmap" in html

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -23,7 +23,8 @@ unchanged.
 from __future__ import annotations
 
 import html as _htmllib
-import math
+
+import pandas as pd
 
 # Single-source the data model + metric formatting from the browser report so the two
 # editions never drift — only the HTML rendering differs (this file stays email-safe).
@@ -69,7 +70,12 @@ def _esc(v) -> str:
 
 
 def _nan(v) -> bool:
-    return v is None or (isinstance(v, float) and math.isnan(v))
+    # pd.isna catches None, float NaN, and pandas NAType (rank is an Int64 that can be NA);
+    # guard the array case (never expected here) so a stray Series can't raise.
+    try:
+        return bool(pd.isna(v))
+    except (TypeError, ValueError):
+        return v is None
 
 
 def _money(v) -> str:
@@ -464,8 +470,6 @@ def _heat_z(z) -> str:
 def _heatmap_section(scores, max_rows: int = 120) -> str:
     """Ranked names × cluster z heat-strip — the browser overview, as an email table.
     Shows all holdings plus the top ``max_rows`` by conviction (email-deliverable size)."""
-    import pandas as pd  # noqa: PLC0415
-
     if scores is None or "conviction" not in getattr(scores, "columns", []):
         return ""
     ranked = scores.sort_values("conviction", ascending=False, na_position="last")


### PR DESCRIPTION
## Bug
The just-merged rich email (#161) crashed on **live** data: `rank` is an `Int64` column that is `pd.NA` for ineligible names; `_nan` only checked `float` NaN, so `int(pd.NA)` raised `TypeError` in the heatmap row. The 4h VPS mail would have failed. The unit fixture used plain-int ranks, so it passed.

## Fix
`_nan` now uses `pd.isna` (catches `None` / float NaN / `NAType`). Regression test renders a NA-rank + NaN-conviction row without crashing. Dropped the now-unused `math` import + a redundant local pandas import.

Verified: live overlay re-render writes the email edition (rc=0, no traceback); report_email suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)