### PR TITLE
feat(v3): factor-model overhaul — new factors, weights, sizing, generators

### DIFF
--- a/scripts/v3_factor_backtest.py
+++ b/scripts/v3_factor_backtest.py
@@ -379,31 +379,374 @@ _STATUS_BADGE = {
 }
 
 
-def _cluster_benchmark(fac: list[dict]) -> str:
-    """Cluster-organized parameter benchmark: per cluster, every metric (scored / monitored /
-    gate / excluded) with its weight + forward-IC stats — the individual-metric contribution."""
-    by = {r["name"]: r for r in fac}
+# Plain-language description per metric (owner wants to know what each metric IS).
+_METRIC_DESC = {
+    "pe_trailing": "price ÷ trailing-12m earnings — cheaper = higher earnings yield",
+    "ev_ebitda": "enterprise value ÷ EBITDA — capital-structure-neutral cheapness",
+    "pb": "price ÷ book value — Fama-French value anchor (banks / REITs)",
+    "ps_sector": "price ÷ sales — value for unprofitable / growth names",
+    "peg": "P/E ÷ earnings growth — growth-adjusted value",
+    "pe_forward": "price ÷ next-12m expected earnings",
+    "earn_trajectory": "trailing-P/E ÷ forward-P/E — >1 = earnings expected to RISE (value-trap guard)",
+    "roe": "net income ÷ shareholders' equity — return on equity",
+    "roa": "net income ÷ total assets — return on assets",
+    "gross_margin": "gross profit ÷ revenue",
+    "op_margin": "operating profit ÷ revenue",
+    "fcf": "free-cash-flow yield — cash after capex ÷ price",
+    "gp_assets": "gross profit ÷ total assets — Novy-Marx profitability (the quality anchor)",
+    "current_ratio": "current assets ÷ current liabilities — short-term liquidity",
+    "de": "total debt ÷ equity — leverage",
+    "accruals": "(net income − operating cash flow) ÷ assets — earnings quality, Sloan (high = bad)",
+    "mom_12_1": "12-month return skipping the last month — classic momentum",
+    "pct_52w_high": "price ÷ 52-week high — proximity to the highs",
+    "price_perf": "recent 12-month price performance",
+    "sue": "standardized unexpected earnings — post-earnings-announcement drift (PEAD)",
+    "beta": "sensitivity to the market — lower = more defensive",
+    "realized_vol": "annualized volatility of daily returns — lower = calmer",
+    "analyst_mom": "direction of analyst estimate revisions — up = upgrades",
+    "upside": "analyst avg target ÷ price − 1 — implied upside",
+    "buy_pct": "% of covering analysts rating Buy",
+    "target_dispersion": "spread of analyst price targets — disagreement",
+    "short_interest": "% of float sold short — squeeze / borrow risk",
+    "earn_growth": "year-over-year earnings growth",
+    "rev_growth": "year-over-year revenue growth",
+    "asset_growth": "year-over-year total-asset growth — CMA investment factor (high = bad)",
+    "div_yield": "dividend ÷ price",
+}
+# etoro-panel metric -> fundamentals-backtest factor name (the 10yr survivorship-clean stat).
+_FUND_STAT = {
+    "pe_trailing": "earnings_yield",
+    "pb": "book_to_price",
+    "ps_sector": "sales_yield",
+    "gp_assets": "gp_assets",
+    "sue": "sue",
+    "asset_growth": "asset_growth",
+    "accruals": "accruals",
+    # profitability / margins / growth / leverage / cash-flow (derived + Sharadar precomputed)
+    "roe": "roe",
+    "roa": "roa",
+    "gross_margin": "gross_margin",
+    "op_margin": "op_margin",
+    "earn_growth": "earn_growth",
+    "rev_growth": "rev_growth",
+    "fcf": "fcf_yield",
+    "de": "de",
+    "current_ratio": "current_ratio",
+    "ev_ebitda": "ev_ebitda",
+    # price-derived (monthly marketcap proxy over the 10yr Sharadar DAILY panel)
+    "mom_12_1": "mom_12_1",
+    "price_perf": "price_perf",
+    "pct_52w_high": "pct_52w_high",
+    "beta": "beta",
+    "realized_vol": "realized_vol",
+    "div_yield": "div_yield",
+}
+# Metrics for which NO 10yr backtest is possible — Sharadar has no analyst estimates,
+# forward earnings, short-interest or dividend history. These legitimately stay on the
+# ~5-mo etoro git panel (or have no backtest at all); it is NOT a coverage gap.
+_NO_10YR = {
+    "pe_forward",
+    "earn_trajectory",
+    "analyst_mom",
+    "upside",
+    "buy_pct",
+    "target_dispersion",
+    "peg",
+    "short_interest",
+}
 
-    def _mrow(metric: str, status: str, weight: str, note: str) -> str:
-        r = by.get(metric)
-        fg, bg = _STATUS_BADGE.get(status, ("#6b7280", "#eef0f2"))
-        badge = f'<span class="b" style="color:{fg};background:{bg}">{status}</span>'
-        if r:
-            rc = "#0a7d33" if (r["ic_raw"] or 0) > 0 else "#b91c1c"
-            nc = "#0a7d33" if (r["ic_neu"] or 0) > 0 else "#b91c1c"
-            tw = "700" if abs(r.get("t_neu_hac") or 0) >= 2 else "400"
-            stats = (
-                f"<td style='color:{rc}'>{_f(r['ic_raw'])}</td>"
-                f"<td style='color:{nc}'>{_f(r['ic_neu'])}</td>"
-                f"<td style='font-weight:{tw}'>{_f(r['t_neu_hac'], 2)}</td>"
-                f"<td>{_f(r['hit_neu'], 2)}</td>"
+
+_PROPOSAL_BADGE = {
+    "keep": ("#0a7d33", "#e5f6ea"),  # green — scored + validated, hold
+    "promote?": ("#1d4ed8", "#e7edfd"),  # blue — unscored but strong 10yr, candidate
+    "earn-in": ("#0e7490", "#e0f2f7"),  # teal — no 10yr possible, accrue on 5mo
+    "watch": ("#916516", "#f8f1df"),  # amber — weak / regime-dependent, monitor
+    "drop": ("#6b7280", "#eef0f2"),  # grey — confirm exclude, no clean alpha
+}
+# My data-driven call per metric given the 10yr β-neutral evidence (proposes, does NOT
+# impose — weights stay frozen / earn-in per governance). (verdict, one-line rationale).
+_PROPOSAL = {
+    # quality
+    "roe": ("keep", "scored · 10yr t3.5 ✓"),
+    "fcf": ("keep", "scored · 10yr t2.8 ✓"),
+    "gp_assets": ("keep", "quality anchor · 10yr t3.0 ✓"),
+    "roa": ("promote?", "10yr t4.0 (>roe, but ρ-high) — swap/blend with roe"),
+    "op_margin": ("promote?", "10yr t2.8, additive — add to quality"),
+    "gross_margin": ("drop", "10yr t≈0 — confirm exclude (gp_assets dominates)"),
+    "current_ratio": ("keep", "distress gate — keep"),
+    "de": ("keep", "leverage gate — keep"),
+    "accruals": ("drop", "10yr t-1.9, no clean alpha — confirm exclude"),
+    # value
+    "pe_trailing": (
+        "keep",
+        "value regime-weak 10yr — keep at DISCOUNTED weight (durable premium, don't kill)",
+    ),
+    "ev_ebitda": ("keep", "value regime-weak 10yr — keep discounted vs pe_trailing"),
+    "pb": ("keep", "sector recipe (banks / REIT) — hold"),
+    "ps_sector": ("keep", "sector recipe (tech / health) — hold"),
+    "pe_forward": ("drop", "level ≈0 IC; spread scored via trajectory — keep excluded"),
+    "peg": ("drop", "noisy, no 10yr — keep monitor"),
+    # momentum
+    "mom_12_1": ("keep", "scored · 10yr t2.6 ✓"),
+    "pct_52w_high": ("keep", "scored · 10yr t3.8 (top momentum) ✓"),
+    "price_perf": ("drop", "ρ0.95 with mom_12-1 — keep monitor (double-count)"),
+    # low-vol
+    "beta": ("keep", "scored · 10yr t2.2 ✓ (was a broken 25-date read)"),
+    "realized_vol": ("keep", "scored · 10yr t3.9 ✓"),
+    # strength (analyst / forward — no 10yr possible)
+    "analyst_mom": ("earn-in", "scored on 5mo; no 10yr possible — earn-in"),
+    "short_interest": ("keep", "squeeze gate — keep"),
+    "upside": ("drop", "5mo zero/neg β-alpha — keep monitor, do NOT gate"),
+    "buy_pct": ("drop", "5mo ≈0 IC — keep monitor"),
+    "target_dispersion": ("drop", "non-PIT, live-fetched — keep excluded"),
+    # growth
+    "earn_growth": ("keep", "scored · 10yr t2.7 ✓"),
+    "rev_growth": ("watch", "10yr t1.7 borderline — monitor"),
+    # pead
+    "sue": ("keep", "scored · 10yr t2.0 ✓"),
+    # trajectory (no 10yr possible)
+    "earn_trajectory": ("earn-in", "value-trap gate + 5mo scored — earn-in"),
+    # investment / income
+    "asset_growth": ("drop", "CMA / investment, FM≈0 — keep excluded"),
+    "div_yield": ("watch", "mildly positive; no 10yr — keep monitor"),
+}
+
+
+def _load_fund_stats() -> dict:
+    """The 10yr survivorship-clean stats cached by scripts/v3_fundamentals_backtest.py."""
+    import json  # noqa: PLC0415
+
+    try:
+        with open(os.path.expanduser("~/.weirdapps-trading/v3_fundamentals_stats.json")) as fh:
+            return json.load(fh)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+# Proposed per-metric weights (RAW points — normalized to 100% in the decision table).
+# Method: diversified equal-risk, NOT IC-proportional. Correlated profitability metrics share
+# a capped sleeve; value is kept at a regime-discounted floor (its weak 10yr is a value-hostile
+# regime, not death); analyst/forward sit on a small earn-in sleeve (unvalidatable on 10yr).
+# A PROPOSAL to earn into per governance, not an in-sample optimum.
+_PROPOSED_WT_RAW = {
+    # profitability / quality (strongest 10yr; 5 correlated members → capped sleeve)
+    "gp_assets": 6.0,
+    "roa": 5.0,
+    "roe": 5.0,
+    "op_margin": 5.0,
+    "fcf": 5.0,
+    # momentum
+    "pct_52w_high": 7.0,
+    "mom_12_1": 6.0,
+    # low-vol
+    "realized_vol": 7.0,
+    "beta": 6.0,
+    # value (regime-discounted floor; sector-conditional recipe)
+    "pe_trailing": 4.0,
+    "pb": 4.0,
+    "ps_sector": 4.0,
+    "ev_ebitda": 3.0,
+    # pead
+    "sue": 6.0,
+    # growth
+    "earn_growth": 5.0,
+    # analyst / forward — earn-in (no 10yr possible → kept small)
+    "analyst_mom": 5.0,
+    "earn_trajectory": 4.0,
+}
+# Active exclusion screens (no weight — kept as gates, not scored signals).
+_GATES = {"current_ratio", "de", "short_interest"}
+# metric -> cluster key (for the Cluster column)
+_CLUSTER_OF: dict[str, str] = {}
+for _cl, _mem in CLUSTERS.items():
+    for _m in _mem:
+        _CLUSTER_OF[_m] = _cl
+for _m, (_cl, _st, _nt) in _NONSCORED.items():
+    _CLUSTER_OF.setdefault(_m, _cl)
+
+
+def _decision_table(fac: list[dict]) -> str:
+    """The MAIN view: a flat, per-metric decision table. Proposed weight (diversified
+    equal-risk) sorted ↓ for the participating set, then WATCH, GATES, DROP — each row with
+    current weight, Δ, and the best-available 10yr / 5mo evidence, so the owner can judge
+    whether each weight is right."""
+    by = {r["name"]: r for r in fac}
+    fund_f = _load_fund_stats().get("factors", {})
+    cur: dict[str, float] = {}
+    for cl, mem in CLUSTERS.items():
+        w = CLUSTER_WEIGHTS.get(cl, 0.0)
+        for m in mem:
+            cur[m] = 100.0 * w / len(mem)
+    tot = sum(_PROPOSED_WT_RAW.values()) or 1.0
+    prop = {m: 100.0 * v / tot for m, v in _PROPOSED_WT_RAW.items()}
+
+    def _stat(metric: str):
+        fkey = _FUND_STAT.get(metric)
+        if fkey and fkey in fund_f:
+            s = fund_f[fkey]
+            return "10yr", "#0a7d33", s["ic_neu"], s["t_hac"], s["hit"]
+        if metric in by:
+            r = by[metric]
+            win = "5mo·no10yr" if metric in _NO_10YR else "5mo"
+            return win, "#916516", r["ic_neu"], r["t_neu_hac"], r["hit_neu"]
+        return "—", "#9aa1a9", None, None, None
+
+    def _row(metric: str, pw, cw) -> str:
+        cl = _CLUSTER_OF.get(metric, "")
+        clabel = _CLUSTER_LABEL.get(cl, cl).split(" ")[0] if cl else ""
+        win, wc, icn, t, hit = _stat(metric)
+        nc = "#0a7d33" if (icn or 0) > 0 else "#b91c1c"
+        tw = "700" if abs(t or 0) >= 2 else "400"
+        if isinstance(pw, float) and isinstance(cw, (int, float)):
+            d = pw - cw
+            dc = "#0a7d33" if d > 0.05 else ("#b91c1c" if d < -0.05 else "#6b7280")
+            dtxt = f"<span style='color:{dc}'>{d:+.1f}</span>"
+        else:
+            dtxt = "<span style='color:#9aa1a9'>—</span>"
+        pwt = (
+            f"<b>{pw:.1f}%</b>"
+            if isinstance(pw, float)
+            else f"<span style='color:#6b7280'>{pw}</span>"
+        )
+        cwt = (
+            f"{cw:.1f}%"
+            if isinstance(cw, (int, float))
+            else f"<span style='color:#9aa1a9'>{cw}</span>"
+        )
+        why = _PROPOSAL.get(metric, ("", ""))[1]
+        return (
+            f"<tr><td><code>{metric}</code></td><td style='color:#5b6470'>{clabel}</td>"
+            f"<td>{pwt}</td><td>{cwt}</td><td>{dtxt}</td>"
+            f"<td class='win' style='color:{wc}'>{win}</td>"
+            f"<td style='color:{nc}'>{_f(icn)}</td><td style='font-weight:{tw}'>{_f(t, 2)}</td>"
+            f"<td>{_f(hit, 2)}</td><td class='mdesc'>{why}</td></tr>"
+        )
+
+    part = sorted(_PROPOSED_WT_RAW, key=lambda m: -prop[m])
+    watch = sorted(
+        m
+        for m, (v, _) in _PROPOSAL.items()
+        if v == "watch" and m not in _PROPOSED_WT_RAW and m not in _GATES
+    )
+    gates = sorted(_GATES)
+    drop = sorted(m for m, (v, _) in _PROPOSAL.items() if v == "drop" and m not in _PROPOSED_WT_RAW)
+
+    def _tier(label: str, bg: str) -> str:
+        return (
+            f"<tr><td colspan='10' style='background:{bg};font-weight:700;padding:6px 9px'>"
+            f"{label}</td></tr>"
+        )
+
+    # current weight: cluster members carry their live weight; pb/ps_sector are a sector
+    # recipe (no fixed number); everything else is currently unscored → 0%.
+    _recipe = {"pb", "ps_sector"}
+
+    def _cur_wt(m):
+        if m in cur:
+            return cur[m]
+        return "recipe" if m in _recipe else 0.0
+
+    prows = "".join(_row(m, prop[m], _cur_wt(m)) for m in part)
+    wrows = "".join(_row(m, "—", _cur_wt(m)) for m in watch)
+    grows = "".join(_row(m, "gate", _cur_wt(m)) for m in gates)
+    drows = "".join(_row(m, "—", _cur_wt(m)) for m in drop)
+    body = (
+        _tier(f"● PARTICIPATE — scored · proposed weight ↓ · Σ = 100% ({len(part)})", "#e5f6ea")
+        + prows
+        + _tier(f"◐ WATCH — shadow, 0 weight ({len(watch)})", "#f8f1df")
+        + wrows
+        + _tier(f"▣ GATES — active exclusion screens, no weight ({len(gates)})", "#e7edfd")
+        + grows
+        + _tier(f"○ DROP — excluded, no clean alpha ({len(drop)})", "#eef0f2")
+        + drows
+    )
+    return (
+        "<h2>Decision table — proposed weights vs evidence</h2>"
+        '<p class="note">The <b>main</b> view: every metric, flat. <b>Proposed weight</b> = '
+        "diversified equal-risk (NOT IC-proportional) — correlated profitability metrics share a "
+        "capped sleeve; value is kept at a <b>regime-discounted</b> floor (its weak 10yr is a "
+        "value-hostile regime, not death); analyst / forward sit on a small <b>earn-in</b> sleeve "
+        "(unvalidatable on 10yr). A proposal to <b>earn into</b> per governance, not an in-sample "
+        "optimum. Judge each proposed weight against its 10yr <b>t (HAC)</b> + hit; <b>Δ pp</b> = "
+        "proposed − current (— where current is a sector recipe). Bold t = |HAC t| ≥ 2.</p>"
+        "<table><thead><tr><th>Metric</th><th>Cluster</th><th>Proposed</th><th>Current</th>"
+        "<th>Δ pp</th><th>window</th><th>IC β-neut</th><th>t (HAC)</th><th>hit</th>"
+        "<th>Rationale</th></tr></thead>"
+        f"<tbody>{body}</tbody></table>"
+    )
+
+
+def _cluster_benchmark(fac: list[dict]) -> str:
+    """Cluster-organized parameter benchmark: per cluster, every metric with a plain-language
+    description, its weight, and its BEST-available forward-IC stats — the 10yr survivorship-clean
+    Sharadar backtest where we have it, else the ~5-mo etoro git panel."""
+    by = {r["name"]: r for r in fac}
+    fund = _load_fund_stats()
+    fund_f = fund.get("factors", {})
+    fund_win = str(fund.get("window", "10yr"))
+
+    def _stat_cells(metric: str) -> str:
+        fkey = _FUND_STAT.get(metric)
+        if fkey and fkey in fund_f:
+            s = fund_f[fkey]
+            ic_raw, ic_neu, t, hit, win, wc = (
+                s["ic_raw"],
+                s["ic_neu"],
+                s["t_hac"],
+                s["hit"],
+                "10yr",
+                "#0a7d33",
+            )
+        elif metric in by:
+            r = by[metric]
+            ic_raw, ic_neu, t, hit, win, wc = (
+                r["ic_raw"],
+                r["ic_neu"],
+                r["t_neu_hac"],
+                r["hit_neu"],
+                "5mo",
+                "#916516",
             )
         else:
-            stats = "<td colspan='4' style='color:#9aa1a9'>not in this panel (see fundamentals backtest / .info-only)</td>"
-        dtxt = "high=good" if DIRECTION.get(metric, 1) > 0 else "low=good"
+            reason = (
+                "analyst / forward — no 10yr data possible"
+                if metric in _NO_10YR
+                else "no backtest data (.info-only)"
+            )
+            return f"<td class='win'>—</td><td colspan='4' style='color:#9aa1a9'>{reason}</td>"
+        rc = "#0a7d33" if (ic_raw or 0) > 0 else "#b91c1c"
+        nc = "#0a7d33" if (ic_neu or 0) > 0 else "#b91c1c"
+        tw = "700" if abs(t or 0) >= 2 else "400"
+        # A 5mo window on an analyst/forward metric is legitimate (no Sharadar 10yr), not a gap.
+        win_cell = (
+            f"<td class='win' style='color:{wc}'>5mo "
+            "<span style='font-size:10px;color:#9aa1a9'>no 10yr</span></td>"
+            if (win == "5mo" and metric in _NO_10YR)
+            else f"<td class='win' style='color:{wc};font-weight:700'>{win}</td>"
+        )
         return (
-            f"<tr><td><code>{metric}</code> {badge}</td><td>{weight}</td>"
-            f"<td class='dir'>{dtxt}</td>{stats}<td class='mnote'>{note}</td></tr>"
+            win_cell
+            + f"<td style='color:{rc}'>{_f(ic_raw)}</td><td style='color:{nc}'>{_f(ic_neu)}</td>"
+            f"<td style='font-weight:{tw}'>{_f(t, 2)}</td><td>{_f(hit, 2)}</td>"
+        )
+
+    def _prop_cell(metric: str) -> str:
+        verdict, why = _PROPOSAL.get(metric, ("", ""))
+        if not verdict:
+            return "<td></td>"
+        fg, bg = _PROPOSAL_BADGE.get(verdict, ("#6b7280", "#eef0f2"))
+        return (
+            f'<td><span class="b" style="color:{fg};background:{bg}">{verdict}</span>'
+            f'<div class="mdesc" style="margin-top:3px">{why}</div></td>'
+        )
+
+    def _mrow(metric: str, status: str, weight: str) -> str:
+        fg, bg = _STATUS_BADGE.get(status, ("#6b7280", "#eef0f2"))
+        badge = f'<span class="b" style="color:{fg};background:{bg}">{status}</span>'
+        return (
+            f"<tr><td><code>{metric}</code> {badge}</td>"
+            f"<td class='mdesc'>{_METRIC_DESC.get(metric, '')}</td>"
+            f"<td>{weight}</td>{_stat_cells(metric)}{_prop_cell(metric)}</tr>"
         )
 
     order = sorted(CLUSTER_WEIGHTS, key=lambda c: -CLUSTER_WEIGHTS[c]) + ["_income", "_investment"]
@@ -412,30 +755,44 @@ def _cluster_benchmark(fac: list[dict]) -> str:
         members = CLUSTERS.get(cl, [])
         w = CLUSTER_WEIGHTS.get(cl, 0.0)
         n = len(members) or 1
-        rows = []
-        for m in members:  # SCORED members
-            eff = "recipe" if cl == "value_z" else f"{100 * w / n:.1f}%"
-            rows.append(_mrow(m, "scored", eff, "member of the scored cluster"))
-        for m, (mc, status, note) in _NONSCORED.items():  # monitored / gate / excluded here
+        rows = [
+            _mrow(m, "scored", "recipe" if cl == "value_z" else f"{100 * w / n:.1f}%")
+            for m in members
+        ]
+        for m, (mc, status, _note) in _NONSCORED.items():
             if mc == cl:
-                rows.append(_mrow(m, status, "—" if status != "scored*" else "recipe", note))
+                rows.append(_mrow(m, status, "recipe" if status == "scored*" else "—"))
         if not rows:
             continue
         wtxt = f" · cluster weight <b>{w * 100:.0f}%</b>" if w else " · not a scored cluster"
         blocks.append(
-            f"<h3>{_CLUSTER_LABEL.get(cl, cl)}{wtxt} · {len(members)} scored</h3>"
-            "<table><thead><tr><th>Metric</th><th>weight</th><th>dir</th>"
-            "<th>IC raw</th><th>IC β-neut</th><th>t (HAC)</th><th>hit</th><th>note</th></tr></thead>"
+            f"<h3>{_CLUSTER_LABEL.get(cl, cl)}{wtxt}</h3>"
+            "<table><thead><tr><th>Metric</th><th>What it measures</th><th>weight</th>"
+            "<th>window</th><th>IC raw</th><th>IC β-neut</th><th>t (HAC)</th><th>hit</th>"
+            "<th>Proposal</th></tr></thead>"
             f"<tbody>{''.join(rows)}</tbody></table>"
         )
+    fund_range = fund_win.replace("10yr ", "").strip("()") or "10yr Sharadar"
     return (
         "<h2>Parameter benchmark — by cluster</h2>"
-        '<p class="note">Every parameter grouped by its cluster, with the cluster weight, the '
-        "metric's weight <i>within</i> conviction (cluster weight ÷ members, equal-mean; Value is "
-        "sector-conditional so its members are recipe-weighted), and its forward-IC stats. "
-        "<b>scored</b> = live in conviction · <b>scored*</b> = scored only in some sector recipes · "
-        "<b>monitor</b> = shadow, zero weight · <b>gate</b> = exclusion screen, not scored · "
-        "<b>exclude</b> = dropped (no clean alpha). Bold t = |HAC t| ≥ 2.</p>" + "".join(blocks)
+        '<p class="note">Every parameter grouped by its cluster, with a plain-language description, '
+        "its weight within conviction (cluster weight ÷ members; Value is sector-conditional → "
+        "recipe-weighted), and its <b>best-available</b> forward-IC stats — "
+        f"<b style='color:#0a7d33'>10yr</b> = survivorship-clean Sharadar ({fund_range}); "
+        "<b style='color:#916516'>5mo</b> = the etoro git panel — now used <b>only</b> for "
+        "analyst / forward metrics (analyst revisions, forward P/E, earnings trajectory, short "
+        "interest), where Sharadar has no 10yr equivalent. Every durable-fundamental or "
+        "price-based parameter (roe, roa, margins, growth, leverage, momentum, vol, beta …) is "
+        "now on the 10yr window. "
+        "<b>scored</b> = live in conviction · <b>scored*</b> = some sector recipes only · "
+        "<b>monitor</b> = shadow, 0 weight · <b>gate</b> = exclusion screen · <b>exclude</b> = dropped. "
+        "Bold t = |HAC t| ≥ 2.<br><b>Proposal</b> = my data-driven call given the 10yr evidence "
+        "(proposes, does not impose — weights stay frozen / earn-in per governance): "
+        "<b style='color:#0a7d33'>keep</b> = scored &amp; validated · "
+        "<b style='color:#1d4ed8'>promote?</b> = unscored but strong 10yr, candidate · "
+        "<b style='color:#0e7490'>earn-in</b> = no 10yr possible, accrue on 5mo · "
+        "<b style='color:#916516'>watch</b> = weak / regime-dependent · "
+        "<b style='color:#6b7280'>drop</b> = confirm exclude.</p>" + "".join(blocks)
     )
 
 
@@ -537,12 +894,13 @@ table{{width:100%;border-collapse:collapse;font-size:13px}}th{{text-align:left;b
 td{{padding:6px 9px;border-bottom:1px solid #eef0f2}}code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:12px}}
 .b{{font-size:10px;font-weight:700;padding:1px 6px;border-radius:20px;margin-left:4px}}.act{{color:#0a7d33;background:#e5f6ea}}.disc{{color:#6b7280;background:#eef0f2}}
 .note{{color:#5b6470;font-size:12.5px;margin:6px 0 2px}}
-h3{{font-size:14.5px;margin:18px 0 6px;color:#1a1a1a}}.dir{{color:#5b6470;font-size:12px}}.mnote{{color:#5b6470;font-size:11.5px}}</style></head><body>
+h3{{font-size:14.5px;margin:18px 0 6px;color:#1a1a1a}}.mdesc{{color:#374151;font-size:12px;max-width:360px}}.win{{font-size:11px;text-align:center}}</style></head><body>
 <h1>v3 Panel-History Factor Backtest</h1>
 <div class="sub">Forward IC (Spearman) at {HORIZON}td, over {n_snap} daily point-in-time snapshots
 ({snaps[0][1]} .. {snaps[-1][1]}) reconstructed from etoro.csv git history · universe {n_uni:,} global coverage names, {n_px:,} priced (EUR).</div>
 <p class="note"><b>How to read:</b> <b>IC raw</b> = Spearman(factor-z, raw forward return); <b>IC β-neutral</b> = vs the beta-residualised return (per-date OLS residual on beta) — this removes the market-beta component that dominates a trending regime and is the <b>honest test of factor alpha</b>. Positive β-neutral IC with |t|≥2 (bold) = evidence of alpha on this (short) sample. <b>active</b> = in a live cluster; <b>discarded</b> = removed from scoring (shown to validate the discard). ~{n_snap} daily dates — indicative, NOT the deflated-Sharpe gate.</p>
 {pit_note}
+{_decision_table(fac)}
 {_cluster_benchmark(fac)}
 <h2>Clusters</h2>
 <table><thead><tr><th>Cluster</th><th>IC raw</th><th>IC β-neutral</th><th>t (naive)</th><th>t (HAC)</th><th>hit</th><th>dates</th><th>obs</th></tr></thead><tbody>{ch}</tbody></table>

--- a/scripts/v3_factor_redundancy.py
+++ b/scripts/v3_factor_redundancy.py
@@ -1,0 +1,142 @@
+"""Redundancy / incremental-IC analysis on the 10yr survivorship-clean z-panel.
+
+Answers the owner's questions with numbers, not opinion:
+  - Are gp_assets ≈ roa ≈ roe ≈ op_margin (profitability redundancy)?
+  - Is mom_12_1 ≈ price_perf ≈ pct_52w_high (momentum redundancy)?
+  - Is beta ≈ realized_vol (low-vol redundancy)?
+  - Does each group add incremental IC beyond its best single member, or is combining
+    just double-counting the same bet?
+  - Is realized_vol a distinct alpha (survives controlling for the others) or a proxy?
+
+Reads the signed-z panel dumped by scripts/v3_fundamentals_backtest.py
+(~/.weirdapps-trading/v3_factor_zpanel.parquet: ticker × date × signed-z per factor + fwd).
+All z are already sign-applied (high = good), so within a same-direction group a high
+positive correlation = genuine redundancy.
+
+    .venv/bin/python scripts/v3_factor_redundancy.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from trade_modules.validation.xsection_ic import cross_sectional_ic  # noqa: E402
+
+ZP = os.path.expanduser("~/.weirdapps-trading/v3_factor_zpanel.parquet")
+OUT = os.path.expanduser("~/.weirdapps-trading/v3_redundancy.json")
+
+# The owner's groups, using the z-panel's fundamentals-backtest factor names.
+GROUPS = {
+    "profitability": ["gp_assets", "roa", "roe", "op_margin", "fcf_yield"],
+    "momentum": ["mom_12_1", "price_perf", "pct_52w_high"],
+    "low_vol": ["beta", "realized_vol"],
+    "value": ["earnings_yield", "book_to_price", "sales_yield", "ev_ebitda"],
+    "growth_income": ["earn_growth", "rev_growth", "div_yield"],
+}
+
+
+def _ic(df: pd.DataFrame, x: str) -> float:
+    sub = df.dropna(subset=[x, "fwd"])
+    if len(sub) < 50:
+        return float("nan")
+    r = cross_sectional_ic(sub, x, "fwd", date_col="date")
+    return float(r.get("mean_ic") or float("nan"))
+
+
+def _mean_corr(z: pd.DataFrame, factors: list[str]) -> pd.DataFrame:
+    """Time-averaged cross-sectional correlation of the signed z's."""
+    acc, n = None, 0
+    for _, g in z.groupby("date"):
+        c = g[factors].corr()
+        if c.notna().to_numpy().any():
+            acc = c if acc is None else acc.add(c, fill_value=0.0)
+            n += 1
+    return (acc / n) if acc is not None and n else pd.DataFrame(index=factors, columns=factors)
+
+
+def main() -> None:
+    if not Path(ZP).exists():
+        print(f"no z-panel at {ZP} — run scripts/v3_fundamentals_backtest.py first")
+        return
+    z = pd.read_parquet(ZP)
+    factors = [c for c in z.columns if c not in ("ticker", "fwd", "date")]
+    print(f"z-panel: {len(z):,} rows, {z['date'].nunique()} dates, {len(factors)} factors\n")
+
+    result: dict = {"groups": {}}
+    for gname, members in GROUPS.items():
+        mem = [m for m in members if m in factors]
+        if len(mem) < 2:
+            continue
+        corr = _mean_corr(z, mem)
+        singles = {m: _ic(z, m) for m in mem}
+        z["_combo"] = z[mem].mean(axis=1, skipna=True)
+        combo_ic = _ic(z, "_combo")
+        best = max(singles, key=lambda m: singles[m] if singles[m] == singles[m] else -9)
+        # incremental IC of the combo over the best single member
+        uplift = combo_ic - singles[best]
+
+        print(f"=== {gname.upper()} ===")
+        print("mean cross-sectional correlation:")
+        print(corr.round(2).to_string())
+        print("single-factor IC:", {m: round(v, 4) for m, v in singles.items()})
+        print(
+            f"combo (equal-wt) IC {combo_ic:.4f} vs best single {best} {singles[best]:.4f} "
+            f"→ uplift {uplift:+.4f}"
+        )
+        # off-diagonal average correlation (redundancy summary)
+        offdiag = corr.where(~np.eye(len(mem), dtype=bool)).stack()
+        print(f"avg off-diagonal corr: {offdiag.mean():.2f} (>0.7 = strongly redundant)\n")
+
+        result["groups"][gname] = {
+            "members": mem,
+            "corr": {a: {b: _rnd(corr.loc[a, b]) for b in mem} for a in mem},
+            "single_ic": {m: _rnd(v) for m, v in singles.items()},
+            "combo_ic": _rnd(combo_ic),
+            "best_single": best,
+            "uplift_vs_best": _rnd(uplift),
+            "avg_offdiag_corr": _rnd(offdiag.mean()),
+        }
+
+    # cross-group: does low_vol overlap momentum/quality? (realized_vol distinctness)
+    key = [
+        "realized_vol",
+        "beta",
+        "gp_assets",
+        "roa",
+        "pct_52w_high",
+        "mom_12_1",
+        "earnings_yield",
+        "sue",
+        "earn_growth",
+        "div_yield",
+        "net_issuance",
+    ]
+    key = [k for k in key if k in factors]
+    gcorr = _mean_corr(z, key)
+    print("=== CROSS-FACTOR correlation (distinctness check) ===")
+    print(gcorr.round(2).to_string())
+    result["cross_corr"] = {a: {b: _rnd(gcorr.loc[a, b]) for b in key} for a in key}
+
+    with open(OUT, "w") as fh:
+        json.dump(result, fh, indent=2)
+    print(f"\nsaved -> {OUT}")
+
+
+def _rnd(v) -> float | None:
+    try:
+        f = float(v)
+        return round(f, 4) if f == f else None
+    except (TypeError, ValueError):
+        return None
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_fundamentals_backtest.py
+++ b/scripts/v3_fundamentals_backtest.py
@@ -54,7 +54,41 @@ SIGNS = {
     "asset_growth": -1,
     "accruals": -1,
     "sue": +1,
+    # profitability / margins / growth / leverage / cash-flow (from factor_panel)
+    "roe": +1,
+    "roa": +1,
+    "gross_margin": +1,
+    "op_margin": +1,
+    "earn_growth": +1,
+    "rev_growth": +1,
+    "fcf_yield": +1,
+    "de": -1,
+    "current_ratio": +1,
+    "ev_ebitda": -1,
+    "div_yield": +1,
+    "net_issuance": -1,  # dilution bad / buyback good (Pontiff-Woodgate)
+    # price-derived (monthly marketcap price proxy)
+    "mom_12_1": +1,
+    "price_perf": +1,
+    "pct_52w_high": +1,
+    "beta": -1,
+    "realized_vol": -1,
+    "reversal_1m": -1,  # short-term reversal: high last-month return -> lower next-month
+    "residual_mom": +1,  # beta-residual 12-1 momentum (idiosyncratic)
+    "earn_stability": +1,  # low earnings coefficient-of-variation = QMJ 'safety'
 }
+# The joint Fama-MacBeth stays on the ORIGINAL durable premia — adding the full 22
+# (with collinear pairs like mom_12_1/price_perf and roe/roa) would make the per-date
+# cross-sectional regression singular. Individual IC below still covers all factors.
+FM_FACTORS = [
+    "book_to_price",
+    "earnings_yield",
+    "sales_yield",
+    "gp_assets",
+    "asset_growth",
+    "accruals",
+    "sue",
+]
 
 
 def _matrix(daily: pd.DataFrame, col: str) -> pd.DataFrame:
@@ -79,6 +113,25 @@ def _sue_table(sf1: pd.DataFrame) -> pd.DataFrame:
             pd.DataFrame({"ticker": tkr, "datekey": g["datekey"].to_numpy(), "sue": sue.to_numpy()})
         )
     return pd.concat(out, ignore_index=True).dropna(subset=["sue"]) if out else pd.DataFrame()
+
+
+def _estab_table(sf1: pd.DataFrame) -> pd.DataFrame:
+    """Per (ticker, datekey) earnings stability = -(coefficient of variation of trailing EPS).
+
+    Low CV = steady earnings = the QMJ 'safety' leg. Scale-free (std / |mean|), so it is not a
+    size proxy; higher (less negative) = more stable."""
+    out = []
+    for tkr, g in sf1.sort_values("datekey").groupby("ticker"):
+        eps = pd.to_numeric(g["eps"], errors="coerce")
+        sd = eps.rolling(8, min_periods=4).std()
+        mn = eps.rolling(8, min_periods=4).mean().abs()
+        stab = -(sd / (mn + 1e-6))
+        out.append(
+            pd.DataFrame(
+                {"ticker": tkr, "datekey": g["datekey"].to_numpy(), "stab": stab.to_numpy()}
+            )
+        )
+    return pd.concat(out, ignore_index=True).dropna(subset=["stab"]) if out else pd.DataFrame()
 
 
 def main() -> None:
@@ -106,8 +159,25 @@ def main() -> None:
     fwd_mat = price.shift(-1) / price - 1.0
     mret = price.pct_change(fill_method=None)
     mkt = mret.mean(axis=1)
-    beta_mat = mret.rolling(BETA_WIN).cov(mkt).div(mkt.rolling(BETA_WIN).var(), axis=0)
+    # min_periods = half-window: the delisted-inclusive price proxy has gaps (median ~75/127
+    # months per name), so demanding a FULL 24-month window collapsed beta to 25 dates (0 in
+    # 2026). A half-window floor restores ~110 dates and — since this same beta drives the
+    # β-neutralization — repairs fwd_n for every factor, not just the beta factor itself.
+    _bmp = BETA_WIN // 2
+    beta_mat = (
+        mret.rolling(BETA_WIN, min_periods=_bmp)
+        .cov(mkt)
+        .div(mkt.rolling(BETA_WIN, min_periods=_bmp).var(), axis=0)
+    )
+    # price-derived factors from the monthly price proxy
+    mom_mat = price.shift(1) / price.shift(12) - 1.0  # 12-1 momentum (skip the last month)
+    perf_mat = price / price.shift(12) - 1.0  # trailing 12-month price performance
+    hi_mat = price / price.rolling(12).max()  # proximity to the 12-month high (<=1)
+    vol_mat = mret.rolling(12).std()  # realized volatility of monthly returns
+    res_mat = mret.sub(beta_mat.mul(mkt, axis=0))  # residual (idiosyncratic) monthly return
+    resmom_mat = res_mat.shift(1).rolling(11, min_periods=6).sum()  # residual 12-1 momentum
     sue_tbl = _sue_table(sf1)
+    estab_tbl = _estab_table(sf1)
 
     parts: dict[str, list[pd.DataFrame]] = {f: [] for f in SIGNS}
     fm_parts: list[pd.DataFrame] = []
@@ -130,12 +200,40 @@ def main() -> None:
         for name, ratio in (("book_to_price", pb), ("earnings_yield", pe), ("sales_yield", ps)):
             r = ratio.loc[T]
             vals[name] = (1.0 / r).where(r > 0)
-        # SF1 balance-sheet / cash-flow factors
+        # SF1 balance-sheet / cash-flow / profitability factors
         fp = factor_panel(fasof, _asof(sf1, pkey), mc.loc[T])
-        for name in ("gp_assets", "asset_growth", "accruals"):
+        for name in (
+            "gp_assets",
+            "asset_growth",
+            "accruals",
+            "roe",
+            "roa",
+            "gross_margin",
+            "op_margin",
+            "earn_growth",
+            "rev_growth",
+            "fcf_yield",
+            "de",
+            "current_ratio",
+            "ev_ebitda",
+            "div_yield",
+            "net_issuance",
+        ):
             vals[name] = fp[name]
         sue_asof = _asof(sue_tbl, tkey) if not sue_tbl.empty else pd.DataFrame()
         vals["sue"] = sue_asof["sue"] if "sue" in sue_asof.columns else pd.Series(dtype=float)
+        # price-derived (from the monthly price proxy matrices)
+        vals["mom_12_1"] = mom_mat.loc[T]
+        vals["price_perf"] = perf_mat.loc[T]
+        vals["pct_52w_high"] = hi_mat.loc[T]
+        vals["realized_vol"] = vol_mat.loc[T]
+        vals["beta"] = beta_mat.loc[T] if T in beta_mat.index else pd.Series(dtype=float)
+        vals["reversal_1m"] = mret.loc[T]  # last-month return (signed -1 in SIGNS)
+        vals["residual_mom"] = resmom_mat.loc[T]
+        estab_asof = _asof(estab_tbl, tkey) if not estab_tbl.empty else pd.DataFrame()
+        vals["earn_stability"] = (
+            estab_asof["stab"] if "stab" in estab_asof.columns else pd.Series(dtype=float)
+        )
 
         beta_T = beta_mat.loc[T] if T in beta_mat.index else None
         fwd_n = (
@@ -187,10 +285,45 @@ def main() -> None:
         )
     )
 
+    # Cache the 10yr survivorship-clean stats so the etoro-panel cluster benchmark can show
+    # the BEST available window per metric (10yr Sharadar here vs the ~5-mo etoro panel there).
+    try:
+        import json as _json  # noqa: PLC0415
+
+        sp = os.path.expanduser("~/.weirdapps-trading/v3_fundamentals_stats.json")
+        os.makedirs(os.path.dirname(sp), exist_ok=True)
+        win = f"10yr ({dates[0].date()}..{dates[-1].date()})" if len(dates) else "10yr"
+        payload = {
+            "window": win,
+            "factors": {
+                r["name"]: {
+                    "ic_raw": r["ic_raw"],
+                    "ic_neu": r["ic_neu"],
+                    "t_hac": r["t_neu"],
+                    "hit": r["hit"],
+                    "n_dates": r["n_dates"],
+                }
+                for r in rows
+            },
+        }
+        with open(sp, "w") as fh:
+            _json.dump(payload, fh)
+        print(f"stats cache -> {sp}")
+    except Exception:  # noqa: BLE001  (best-effort cache; never fail the backtest)
+        pass
+
     fm = {}
     if fm_parts:
         fmp = pd.concat(fm_parts, ignore_index=True)
-        fm = fama_macbeth(fmp, "fwd", list(SIGNS), date_col="date", lags=HAC_LAGS)
+        # Dump the stacked signed-z panel (date × ticker × all factors + fwd) so the
+        # redundancy / incremental-IC analysis can read it without rebuilding the panel.
+        try:
+            zp = os.path.expanduser("~/.weirdapps-trading/v3_factor_zpanel.parquet")
+            fmp.to_parquet(zp, index=False)
+            print(f"z-panel -> {zp}  ({len(fmp):,} rows)")
+        except Exception:  # noqa: BLE001  (best-effort; never fail the backtest)
+            pass
+        fm = fama_macbeth(fmp, "fwd", FM_FACTORS, date_col="date", lags=HAC_LAGS)
 
     _print(rows, fm, n_used, mc)
     out = _render(rows, fm, n_used, dates, mc.shape[1])

--- a/scripts/v3_master_taxonomy.py
+++ b/scripts/v3_master_taxonomy.py
@@ -1,0 +1,482 @@
+"""Render the v3 MASTER factor taxonomy — the single decision table.
+
+Six dimensions (size / value+quality / growth / momentum / risk / analysts). Every metric we
+have access to, with role (active / gate / sizing / watch / discard), weight (active only),
+best-available 10yr evidence (from v3_fundamentals_stats.json), and rationale. Plus the locked
+gates + the sizing rule. Pure rendering — no backtest.
+
+    .venv/bin/python scripts/v3_master_taxonomy.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+STATS = json.load(open(os.path.expanduser("~/.weirdapps-trading/v3_fundamentals_stats.json"))).get(
+    "factors", {}
+)
+
+# metric -> 10yr stats key (None = no 10yr: 5mo/live-only or gate with no scored backtest)
+SK = {
+    "roa": "roa",
+    "roa/roe": "roa",
+    "pe_trailing": "earnings_yield",
+    "gp_assets": "gp_assets",
+    "net_issuance": "net_issuance",
+    "fcf": "fcf_yield",
+    "value_ps": "sales_yield",
+    "value_pb": "book_to_price",
+    "roe": "roe",
+    "op_margin": "op_margin",
+    "ev_ebitda": "ev_ebitda",
+    "gross_margin": "gross_margin",
+    "accruals": "accruals",
+    "current_ratio": "current_ratio",
+    "de": "de",
+    "earn_growth": "earn_growth",
+    "earn_stability": "earn_stability",
+    "sue": "sue",
+    "rev_growth": "rev_growth",
+    "pct_52w_high": "pct_52w_high",
+    "mom_12_1": "mom_12_1",
+    "price_perf": "price_perf",
+    "residual_mom": "residual_mom",
+    "reversal_1m": "reversal_1m",
+    "realized_vol": "realized_vol",
+    "beta": "beta",
+    "div_yield": "div_yield",
+    "asset_growth": "asset_growth",
+}
+NO10 = {
+    "earn_trajectory",
+    "trajectory_spread",
+    "analyst_mom",
+    "upside",
+    "buy_pct",
+    "target_dispersion",
+    "analyst_count",
+    "pe_forward",
+    "expected_return",
+    "short_interest",
+    "piotroski",
+}
+
+# (dimension, metric, role, weight_pct, rationale). role: active | active* | gate | sizing | watch | discard
+TAX = [
+    # ---- SIZE ----
+    (
+        "SIZE",
+        "market_cap",
+        "sizing",
+        None,
+        "SIZING input (bigger/steadier → larger cap) + PROMINENT display of what size we hold. Size premium itself weak — not a scored bet.",
+    ),
+    (
+        "SIZE",
+        "adv_usd",
+        "gate",
+        None,
+        "Tradeability: ADV(20d) ≥ $3M AND target position ≤ 10-15% of one day's ADV (full exit clears).",
+    ),
+    (
+        "SIZE",
+        "amihud",
+        "watch",
+        None,
+        "Illiquidity/price-impact — UNTESTED (needs volume ingest). Finer ADV; sizing/cost, not alpha.",
+    ),
+    # ---- VALUE (incl QUALITY) ----
+    (
+        "VALUE (incl quality)",
+        "roa/roe",
+        "active",
+        13,
+        "t4.01 — leverage-clean profitability level. SECTOR-CONDITIONAL: ROA default, ROE for financials/REITs (one slot; near-identical stats).",
+    ),
+    (
+        "VALUE (incl quality)",
+        "gp_assets",
+        "active",
+        13,
+        "t2.98 — the cleanest diversifier (ρ<0.18 to every factor). Novy-Marx quality anchor.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "net_issuance",
+        "active",
+        9,
+        "t2.95 — buyback(+)/dilution(−) capital-allocation quality (Pontiff-Woodgate). Bumped above P/S per evidence-order.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "fcf",
+        "active",
+        7,
+        "t2.80 — distinct cash-quality channel (ρ 0.26-0.45 vs profitability level).",
+    ),
+    (
+        "VALUE (incl quality)",
+        "value_ps",
+        "active",
+        7,
+        "P/S (sales-yield), sector-conditional DEFAULT — trap-immune value lead; trimmed to 7 (t1.07 ≪ net_issuance).",
+    ),
+    (
+        "VALUE (incl quality)",
+        "pe_forward",
+        "active",
+        6,
+        "OWNER CALL: full scored value factor REPLACING pe_trailing. EARN-IN — 5mo/live only, no 10yr PIT; caveat: analyst-optimism bias (worst for growth names).",
+    ),
+    (
+        "VALUE (incl quality)",
+        "value_pb",
+        "active",
+        3,
+        "P/B, sector-FENCED — financials/REITs only (NAV / regulatory-capital proxy).",
+    ),
+    (
+        "VALUE (incl quality)",
+        "div_yield",
+        "sizing",
+        None,
+        "SIZING input — quality/stability lens (moderate yield up-sizes; >6% = value-trap flag, no up-size). Not scored.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "earn_trajectory",
+        "gate",
+        None,
+        "Value-trap GATE: fwd P/E > 1.10× trailing → ineligible for new BUY; held trap → SELL.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "current_ratio",
+        "gate",
+        None,
+        "Loose solvency: <1.0 flag, <0.8 + rising leverage → ineligible. SUPPRESSED for financials.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "de",
+        "gate",
+        None,
+        "Loose leverage screen on extreme non-financial gearing. SUPPRESSED for financials.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "piotroski",
+        "gate",
+        None,
+        "delta-F (0-5) value-trap discriminator within the value sleeve (earn-in). Components, NOT the aggregate score.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "pe_trailing",
+        "discard",
+        None,
+        "Replaced by pe_forward (owner call). t≈0 standalone this regime.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "op_margin",
+        "discard",
+        None,
+        "ρ0.68 w/ roa — ~0 incremental (confirmed). Double-counts profitability.",
+    ),
+    (
+        "VALUE (incl quality)",
+        "ev_ebitda",
+        "discard",
+        None,
+        "ρ0.71 w/ pe, t≈0 — and the wrong metric for banks (P/B is the financials value axis).",
+    ),
+    ("VALUE (incl quality)", "gross_margin", "discard", None, "t≈0 — superseded by gp_assets."),
+    ("VALUE (incl quality)", "accruals", "discard", None, "t−1.9, no clean alpha (Sloan)."),
+    # ---- GROWTH (earnings) ----
+    (
+        "GROWTH",
+        "earn_growth",
+        "active",
+        8,
+        "t2.67 — the scored earnings/growth slot (persistent, fits monthly cadence).",
+    ),
+    (
+        "GROWTH",
+        "sue",
+        "active",
+        6,
+        "t2.02 — PEAD. Bumped to 6 (owner call). Note: event-trigger — monthly cadence captures only part of the drift.",
+    ),
+    (
+        "GROWTH",
+        "trajectory_spread",
+        "active",
+        5,
+        "PET/PEF spread, earn-in (5mo/no-PIT) — the forward view scored as a SPREAD (was the strongest clean signal, t2.17).",
+    ),
+    (
+        "GROWTH",
+        "earn_stability",
+        "active",
+        4,
+        "t2.36 — QMJ 'safety' (low earnings coefficient-of-variation). DISTINCT (ρ≤0.18 to all). Borderline/probation.",
+    ),
+    (
+        "GROWTH",
+        "rev_growth",
+        "watch",
+        None,
+        "t1.66 sub-bar — margin-CONDITIONING variable (reward growth only WITH margin expansion; CGS-trap guard).",
+    ),
+    # ---- MOMENTUM ----
+    (
+        "MOMENTUM",
+        "pct_52w_high",
+        "active",
+        14,
+        "t3.77 — strongest single momentum (George-Hwang). The ONE momentum slot.",
+    ),
+    (
+        "MOMENTUM",
+        "residual_mom",
+        "watch",
+        None,
+        "Tested t0.79 — no lift over pct_52w_high here, but conceptually distinct → WATCH (not discarded).",
+    ),
+    (
+        "MOMENTUM",
+        "reversal_1m",
+        "watch",
+        None,
+        "Tested t0.05 — dead at monthly cadence; kept as an entry-timing overlay candidate → WATCH.",
+    ),
+    (
+        "MOMENTUM",
+        "mom_12_1",
+        "discard",
+        None,
+        "ρ0.95 w/ price_perf, 0.66-0.75 w/ pct_52w_high — clone.",
+    ),
+    ("MOMENTUM", "price_perf", "discard", None, "ρ0.95 w/ mom_12_1 — outright clone."),
+    # ---- RISK (sizing / gate, NOT alpha) ----
+    (
+        "RISK",
+        "realized_vol",
+        "sizing",
+        None,
+        "Inverse-vol SIZING (raw IC real but a sector+rate-duration collinearity artifact — not scored).",
+    ),
+    (
+        "RISK",
+        "beta",
+        "sizing",
+        None,
+        "De-gross only (raw cross-sectional IC ≈ 0). Vasicek-shrunk. Never lever beta up.",
+    ),
+    (
+        "RISK",
+        "short_interest",
+        "gate",
+        None,
+        "GRADED: <10% full · 10-20% SOFT size-down ×0.5 + flag · ≥20% HARD exclude.",
+    ),
+    (
+        "RISK",
+        "MAX",
+        "discard",
+        None,
+        "Lottery-demand — subsumed by realized_vol (red-team reject).",
+    ),
+    # ---- EXPECTATIONS (analyst / forward-looking; yfinance, no PIT) ----
+    (
+        "EXPECTATIONS",
+        "analyst_mom",
+        "active",
+        5,
+        "EPS-revision momentum — bumped to 5 (owner call). EARN-IN: no 10yr PIT, KILL on 3mo negative live-IC. yfinance ~5mo git-panel + growing.",
+    ),
+    (
+        "EXPECTATIONS",
+        "analyst_count",
+        "gate",
+        None,
+        "≥3 covering analysts required to APPLY any analyst overlay (kills single-analyst noise).",
+    ),
+    (
+        "EXPECTATIONS",
+        "upside",
+        "gate",
+        None,
+        "LOOSE downside-guard: < −5% → size ×0.75; < −15% & ≥5 analysts → exclude. NEVER rewards high upside (anti-selection).",
+    ),
+    (
+        "EXPECTATIONS",
+        "buy_pct",
+        "gate",
+        None,
+        "Confidence weight + sell-tail guard: < 25% (majority SELL) → size-down. NOT a ⅔ hard gate (that re-imports anti-selection).",
+    ),
+    (
+        "EXPECTATIONS",
+        "target_dispersion",
+        "gate",
+        None,
+        "Analyst-confidence: high dispersion → down-weight analyst signals + small size haircut (×0.85).",
+    ),
+    (
+        "EXPECTATIONS",
+        "expected_return",
+        "watch",
+        None,
+        "buy% × upside — derivative of the gate inputs; MONITORED, does NOT participate in any decision.",
+    ),
+]
+
+ROLE_BADGE = {
+    "active": ("#0a7d33", "#e5f6ea"),
+    "active*": ("#0a7d33", "#e5f6ea"),
+    "gate": ("#1d4ed8", "#e7edfd"),
+    "sizing": ("#0e7490", "#e0f2f7"),
+    "watch": ("#916516", "#f8f1df"),
+    "discard": ("#6b7280", "#eef0f2"),
+}
+GATES = [
+    ("ADV tradeability (HARD)", "ADV(20d) ≥ $3M AND target position ≤ 10-15% of one day's ADV."),
+    (
+        "Short interest (GRADED)",
+        "SI/float < 10% full size · 10-20% soft ×0.5 + flag · ≥ 20% HARD exclude.",
+    ),
+    (
+        "Value-trap earn_trajectory (HARD)",
+        "fwd P/E > 1.10× trailing → ineligible new BUY; held → SELL.",
+    ),
+    (
+        "Solvency current_ratio (LOOSE)",
+        "< 1.0 flag · < 0.8 + rising leverage → ineligible. Suppressed for financials.",
+    ),
+    (
+        "Leverage D/E (LOOSE)",
+        "Extreme non-financial gearing → ineligible. Suppressed for financials.",
+    ),
+    (
+        "Analyst coverage (HARD, signal-only)",
+        "≥ 3 covering analysts required to apply any analyst overlay.",
+    ),
+    (
+        "Upside downside-guard (SOFT)",
+        "< −5% → size ×0.75 · < −15% & ≥5 analysts → exclude. Never rewards high upside.",
+    ),
+    (
+        "Buy% sell-tail (SOFT)",
+        "< 25% (majority SELL) → size-down. Confidence weight otherwise; NOT a ⅔ hard gate.",
+    ),
+]
+SIZING = (
+    "<b>Inputs: market_cap, div_yield, realized_vol, beta</b> (all role=sizing). "
+    "Post-selection (alpha picks WHICH names, risk sets HOW MUCH). "
+    "weight ∝ conviction × (1 / max(beta, 0.6)) × (1 + 0.5·div_yield) × size_tier, then capped. "
+    "Beta de-gross only (Vasicek-shrunk); div_yield rewarded 1-4% (stability) but > 6% = value-trap flag (NO up-size); "
+    "vol-floor so utilities aren't over-loaded; high-vol mega (NVDA-type) haircut to ~7%."
+)
+CAPS = [
+    ("Mega > $200B", "10%"),
+    ("Large $20-200B", "5%"),
+    ("Mid $2-20B", "2%"),
+    ("Small $0.3-2B", "0.5%"),
+    ("Micro < $0.3B", "0.25%"),
+]
+
+
+def _f(v, nd=4):
+    return f"{v:.{nd}f}" if isinstance(v, (int, float)) and v == v else "—"
+
+
+def _ev(metric):
+    k = SK.get(metric)
+    if k and k in STATS:
+        s = STATS[k]
+        return "10yr", "#0a7d33", s.get("ic_neu"), s.get("t_hac"), s.get("hit")
+    return ("5mo/live" if metric in NO10 else "—"), "#916516", None, None, None
+
+
+def _rows(dim):
+    out = ""
+    for d, m, role, wt, why in TAX:
+        if d != dim:
+            continue
+        fg, bg = ROLE_BADGE.get(role, ("#6b7280", "#eef0f2"))
+        win, wc, icn, t, hit = _ev(m)
+        nc = "#0a7d33" if (icn or 0) > 0 else "#b91c1c"
+        tw = "700" if abs(t or 0) >= 2 else "400"
+        wtxt = (
+            f"<b>{wt}%</b>"
+            if isinstance(wt, (int, float))
+            else ("<span style='color:#9aa1a9'>—</span>")
+        )
+        out += (
+            f"<tr><td><code>{m}</code></td>"
+            f"<td><span class='b' style='color:{fg};background:{bg}'>{role}</span></td>"
+            f"<td>{wtxt}</td><td class='win' style='color:{wc}'>{win}</td>"
+            f"<td style='color:{nc}'>{_f(icn)}</td><td style='font-weight:{tw}'>{_f(t, 2)}</td>"
+            f"<td>{_f(hit, 2)}</td><td class='mdesc'>{why}</td></tr>"
+        )
+    return out
+
+
+def main():
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_master_taxonomy.html")
+    active = [(m, wt) for _, m, r, wt, _ in TAX if r == "active" and isinstance(wt, (int, float))]
+    tot = sum(wt for _, wt in active)
+    dims = ["SIZE", "VALUE (incl quality)", "GROWTH", "MOMENTUM", "RISK", "EXPECTATIONS"]
+    blocks = ""
+    for dim in dims:
+        blocks += (
+            f"<h2>{dim}</h2><table><thead><tr><th>Metric</th><th>Role</th><th>Weight</th>"
+            "<th>window</th><th>IC β-neut</th><th>t (HAC)</th><th>hit</th><th>Rationale</th>"
+            f"</tr></thead><tbody>{_rows(dim)}</tbody></table>"
+        )
+    gaterows = "".join(f"<tr><td><b>{g}</b></td><td class='mdesc'>{r}</td></tr>" for g, r in GATES)
+    caprows = "".join(f"<tr><td>{t}</td><td><b>{c}</b></td></tr>" for t, c in CAPS)
+    html = f"""<!doctype html><html><head><meta charset="utf-8"><title>v3 Master Factor Taxonomy</title>
+<style>body{{font:14px -apple-system,Segoe UI,Arial,sans-serif;color:#1a1a1a;background:#fff;max-width:1060px;margin:0 auto;padding:30px}}
+h1{{font-size:23px;margin:0 0 4px}}.sub{{color:#5b6470;font-size:13px;margin-bottom:14px}}
+h2{{font-size:16px;margin:24px 0 6px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}}
+table{{width:100%;border-collapse:collapse;font-size:12.5px;margin-top:4px}}
+th{{text-align:left;background:#f7f8fa;padding:6px 9px;border-bottom:1px solid #e6e8ec}}
+td{{padding:6px 9px;border-bottom:1px solid #eef0f2;vertical-align:top}}
+code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:11.5px}}
+.mdesc{{color:#374151;font-size:11.5px;max-width:440px}}.win{{font-size:11px;text-align:center}}
+.b{{font-size:10px;font-weight:700;padding:1px 6px;border-radius:20px}}
+.note{{color:#5b6470;font-size:12.5px;margin:6px 0}}.two{{display:flex;gap:24px;flex-wrap:wrap}}.two>div{{flex:1;min-width:320px}}</style></head><body>
+<h1>v3 Master Factor Taxonomy — the decision table</h1>
+<div class="sub">{stamp} UTC · live ~$1.1M book · 6 dimensions × every metric × role × weight × 10yr evidence.
+Active (scored) Σ = <b>{tot}%</b>. <b>Weights frozen / earn-in — proposal for sign-off, not executed.</b><br>
+Roles: <span class="b" style="color:#0a7d33;background:#e5f6ea">active</span> scored ·
+<span class="b" style="color:#0a7d33;background:#e5f6ea">active*</span> sector-substitute ·
+<span class="b" style="color:#1d4ed8;background:#e7edfd">gate</span> eligibility screen ·
+<span class="b" style="color:#0e7490;background:#e0f2f7">sizing</span> position-size input ·
+<span class="b" style="color:#916516;background:#f8f1df">watch</span> shadow/monitor ·
+<span class="b" style="color:#6b7280;background:#eef0f2">discard</span> dropped.
+10yr = survivorship-clean Sharadar (114 mo); 5mo/live = yfinance git-panel, earn-in. Bold t = |t| ≥ 2.</div>
+{blocks}
+<h2>Gates (eligibility screens)</h2>
+<table><thead><tr><th>Gate</th><th>Rule</th></tr></thead><tbody>{gaterows}</tbody></table>
+<h2>Sizing rule &amp; caps</h2>
+<div class="two"><div><p class="note">{SIZING}</p></div>
+<div><table><thead><tr><th>Cap tier</th><th>Max single name</th></tr></thead><tbody>{caprows}</tbody></table>
+<p class="note">+ portfolio guards: max sector ~25-30% · top-10 ≤ ~55-60% · long gross ≤ 100%.</p></div></div>
+<h2>Sector recipes</h2>
+<p class="note"><b>Profitability:</b> ROA + gp_assets + fcf (default) · Financials/REITs → <b>ROE</b> (gp_assets undefined, leverage is the business). ·
+<b>Value:</b> P/S (default) · Financials/REITs → <b>P/B</b>. · Z-score EVERY factor WITHIN GICS sector. · Suppress current_ratio/D-E for financials.</p>
+</body></html>"""
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(html)
+    print(f"master taxonomy -> {out}  | active Σ={tot}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_next_iteration_memo.py
+++ b/scripts/v3_next_iteration_memo.py
@@ -1,0 +1,325 @@
+"""Render the v3 next-iteration decision memo (one self-contained HTML).
+
+Combines three artifacts already on disk:
+  - ~/.weirdapps-trading/v3_fundamentals_stats.json   (10yr survivorship-clean per-factor IC/t/hit)
+  - ~/.weirdapps-trading/v3_redundancy.json           (time-avg cross-sectional correlations)
+  - ~/.weirdapps-trading/v3_debate.json               (CIO synthesis + red-team from the 7-agent debate)
+
+Sections: exec summary -> decision table (proposed weights vs evidence, post-debate) -> redundancy
+evidence -> missing factors / shadow earn-in book -> analyst-data sourcing -> open risks ->
+parameter benchmark by cluster. No backtest re-run — pure rendering.
+
+    .venv/bin/python scripts/v3_next_iteration_memo.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+W = os.path.expanduser("~/.weirdapps-trading")
+STATS = json.load(open(f"{W}/v3_fundamentals_stats.json")).get("factors", {})
+RED = json.load(open(f"{W}/v3_redundancy.json"))
+DEB = json.load(open(f"{W}/v3_debate.json"))
+SYN = DEB["synth"]
+
+# metric token -> 10yr fundamentals-stats key (evidence lookup)
+STAT_KEY = {
+    "gp_assets": "gp_assets",
+    "roa": "roa",
+    "roe": "roe",
+    "op_margin": "op_margin",
+    "fcf": "fcf_yield",
+    "pct_52w_high": "pct_52w_high",
+    "mom_12_1": "mom_12_1",
+    "price_perf": "price_perf",
+    "realized_vol": "realized_vol",
+    "beta": "beta",
+    "sue": "sue",
+    "earn_growth": "earn_growth",
+    "rev_growth": "rev_growth",
+    "div_yield": "div_yield",
+    "ev_ebitda": "ev_ebitda",
+    "pe": "earnings_yield",
+    "pb": "book_to_price",
+    "value_composite": "sales_yield",
+    "de": "de",
+    "current_ratio": "current_ratio",
+    "gross_margin": "gross_margin",
+    "accruals": "accruals",
+    "asset_growth": "asset_growth",
+}
+# current live per-metric weight (cluster model: cluster_wt / n_members); recipe = sector-conditional
+CUR = {
+    "roe": 8.0,
+    "fcf": 8.0,
+    "gp_assets": 8.0,
+    "pe": 9.0,
+    "ev_ebitda": 9.0,
+    "mom_12_1": 9.0,
+    "pct_52w_high": 9.0,
+    "earn_growth": 1.5,
+    "rev_growth": 1.5,
+    "beta": 4.5,
+    "realized_vol": 4.5,
+    "sue": 10.0,
+    "earn_trajectory": 10.0,
+    "value_composite": 18.0,
+}
+NO10YR = {
+    "earn_trajectory",
+    "short_interest",
+    "analyst_mom",
+    "upside",
+    "buy_pct",
+    "pe_forward",
+    "peg",
+}
+TIER_ORDER = ["participate", "sizing-only", "watch", "gate", "drop"]
+TIER_BADGE = {
+    "participate": ("#0a7d33", "#e5f6ea"),
+    "sizing-only": ("#0e7490", "#e0f2f7"),
+    "watch": ("#916516", "#f8f1df"),
+    "gate": ("#1d4ed8", "#e7edfd"),
+    "drop": ("#6b7280", "#eef0f2"),
+    "add-now": ("#0a7d33", "#e5f6ea"),
+    "shadow-earn-in": ("#7c3aed", "#f1e9fd"),
+    "reject": ("#6b7280", "#eef0f2"),
+}
+
+
+def _tok(metric: str) -> str:
+    return metric.split(" (")[0].split(" /")[0].strip()
+
+
+def _f(v, nd=4):
+    return f"{v:.{nd}f}" if isinstance(v, (int, float)) and v == v else "—"
+
+
+def _evidence(token: str):
+    k = STAT_KEY.get(token)
+    if k and k in STATS:
+        s = STATS[k]
+        return "10yr", s.get("ic_neu"), s.get("t_hac"), s.get("hit")
+    win = "5mo·no10yr" if token in NO10YR else "—"
+    return win, None, None, None
+
+
+def _decision_table() -> str:
+    rows_by_tier: dict[str, list] = {t: [] for t in TIER_ORDER}
+    for fx in SYN["factor_set"]:
+        rows_by_tier.setdefault(fx["tier"], []).append(fx)
+    body = ""
+    labels = {
+        "participate": ("● PARTICIPATE — scored (Σ ≈ 100%)", "#e5f6ea"),
+        "sizing-only": ("◆ SIZING-ONLY — risk input, not alpha (0 selection weight)", "#e0f2f7"),
+        "watch": ("◐ WATCH / conditioning — 0 weight", "#f8f1df"),
+        "gate": ("▣ GATES — eligibility screens, no weight", "#e7edfd"),
+        "drop": ("○ DROP — redundant / no clean alpha", "#eef0f2"),
+    }
+    for tier in TIER_ORDER:
+        items = rows_by_tier.get(tier, [])
+        if not items:
+            continue
+        if tier == "participate":
+            items = sorted(items, key=lambda x: -x["proposed_weight_pct"])
+        lab, bg = labels[tier]
+        body += f"<tr><td colspan='9' style='background:{bg};font-weight:700;padding:6px 9px'>{lab}</td></tr>"
+        for fx in items:
+            tok = _tok(fx["metric"])
+            win, icn, t, hit = _evidence(tok)
+            pw = fx["proposed_weight_pct"]
+            cw = CUR.get(tok, 0.0)
+            pwt = f"<b>{pw:.0f}%</b>" if pw else "<span style='color:#6b7280'>0</span>"
+            cwt = f"{cw:.1f}%" if isinstance(cw, (int, float)) and cw else "—"
+            if pw or cw:
+                d = pw - (cw if isinstance(cw, (int, float)) else 0)
+                dc = "#0a7d33" if d > 0.05 else ("#b91c1c" if d < -0.05 else "#6b7280")
+                dtxt = f"<span style='color:{dc}'>{d:+.0f}</span>"
+            else:
+                dtxt = "—"
+            wc = "#0a7d33" if win == "10yr" else "#916516"
+            nc = "#0a7d33" if (icn or 0) > 0 else "#b91c1c"
+            tw = "700" if abs(t or 0) >= 2 else "400"
+            body += (
+                f"<tr><td><code>{fx['metric']}</code></td><td>{pwt}</td><td style='color:#6b7280'>{cwt}</td>"
+                f"<td>{dtxt}</td><td class='win' style='color:{wc}'>{win}</td>"
+                f"<td style='color:{nc}'>{_f(icn)}</td><td style='font-weight:{tw}'>{_f(t, 2)}</td>"
+                f"<td>{_f(hit, 2)}</td><td class='mdesc'>{fx['rationale']}</td></tr>"
+            )
+    return (
+        "<h2>1 · Decision table — proposed weights vs evidence (post-debate)</h2>"
+        '<p class="note">The de-duplicated set from the debate. <b>Proposed</b> = diversified equal-risk after '
+        "collapsing redundant pairs; <b>Δ</b> = proposed − current. Judge each weight against its 10yr "
+        "<b>t (HAC)</b>. Bold t = |t| ≥ 2. <b>sizing-only</b> = real risk signal used for inverse-vol sizing, "
+        "not scored as alpha.</p>"
+        "<table><thead><tr><th>Metric</th><th>Proposed</th><th>Current</th><th>Δ pp</th><th>window</th>"
+        "<th>IC β-neut</th><th>t (HAC)</th><th>hit</th><th>Rationale</th></tr></thead>"
+        f"<tbody>{body}</tbody></table>"
+    )
+
+
+def _redundancy() -> str:
+    g = RED["groups"]
+    out = ""
+    for name, label in [
+        ("profitability", "Profitability"),
+        ("momentum", "Momentum"),
+        ("low_vol", "Low-vol"),
+        ("value", "Value"),
+        ("growth_income", "Growth / Income"),
+    ]:
+        if name not in g:
+            continue
+        blk = g[name]
+        mem = blk["members"]
+        head = "".join(f"<th>{m}</th>" for m in mem)
+        rows = ""
+        for a in mem:
+            cells = ""
+            for b in mem:
+                v = blk["corr"].get(a, {}).get(b)
+                hot = "#b91c1c" if (v or 0) >= 0.85 and a != b else "#1a1a1a"
+                cells += f"<td style='color:{hot};text-align:center'>{_f(v, 2)}</td>"
+            rows += f"<tr><td><code>{a}</code></td>{cells}</tr>"
+        out += (
+            f"<h3 style='margin-top:14px'>{label} — avg off-diag ρ {blk['avg_offdiag_corr']:.2f} · "
+            f"combo IC {blk['combo_ic']:.4f} vs best single {blk['best_single']} "
+            f"({blk['single_ic'][blk['best_single']]:.4f}) → uplift {blk['uplift_vs_best']:+.4f}</h3>"
+            f"<table><thead><tr><th></th>{head}</tr></thead><tbody>{rows}</tbody></table>"
+        )
+    return (
+        "<h2>2 · Why — redundancy evidence (time-avg cross-sectional ρ)</h2>"
+        '<p class="note">ρ ≥ 0.85 (red) = the same bet. Combining redundant members does NOT lift IC — proof '
+        "that piling on correlated metrics silently over-weights one bet without adding signal.</p>"
+        + out
+    )
+
+
+def _missing() -> str:
+    rows = ""
+    for m in SYN["missing_to_add"]:
+        fg, bg = TIER_BADGE.get(m["verdict"], ("#6b7280", "#eef0f2"))
+        badge = f'<span class="b" style="color:{fg};background:{bg}">{m["verdict"]}</span>'
+        rows += (
+            f"<tr><td><b>{m['name']}</b> {badge}</td><td class='mdesc'>{m['data_need']}</td>"
+            f"<td class='mdesc'>{m['rationale']}</td></tr>"
+        )
+    return (
+        "<h2>3 · Missing factors — shadow earn-in book</h2>"
+        '<p class="note">What the 5 lenses + red-team say we lack. <b>add-now</b> = ship (construction, not alpha); '
+        "<b>shadow-earn-in</b> = compute at ZERO live weight, promote only when the live IC logger clears its "
+        "net-of-cost hurdle; <b>reject</b> = not worth it. Almost all are <b>free</b> (Sharadar/price we already own).</p>"
+        "<table><thead><tr><th>Factor</th><th>Data need</th><th>Rationale</th></tr></thead>"
+        f"<tbody>{rows}</tbody></table>"
+    )
+
+
+def _sourcing() -> str:
+    items = "".join(f"<li>{s}</li>" for s in SYN["data_sourcing"])
+    return (
+        "<h2>4 · Analyst / forward-data sourcing</h2>"
+        '<p class="note"><b>Bottom line: do NOT buy an analyst-estimate vendor at $1.1M</b> — the fixed cost dwarfs '
+        "the marginal, fast-decaying, crowded edge; and only estimate <b>revisions</b> work (levels — upside %, "
+        "buy % — are dead, t −0.15). Use free TipRanks as a live-only shadow first.</p>"
+        f"<ul class='src'>{items}</ul>"
+    )
+
+
+def _risks() -> str:
+    items = "".join(f"<li>{r}</li>" for r in SYN["open_risks"])
+    return (
+        "<h2>5 · Open risks (read before trusting any weight)</h2>"
+        '<p class="note">This is real money on ~1 regime of data. The honest caveats:</p>'
+        f"<ul class='risk'>{items}</ul>"
+    )
+
+
+def _benchmark() -> str:
+    clusters = {
+        "Quality / profitability": [
+            "gp_assets",
+            "roa",
+            "roe",
+            "op_margin",
+            "fcf_yield",
+            "gross_margin",
+            "accruals",
+        ],
+        "Value": ["sales_yield", "earnings_yield", "book_to_price", "ev_ebitda"],
+        "Momentum": ["pct_52w_high", "mom_12_1", "price_perf"],
+        "Low-vol": ["realized_vol", "beta"],
+        "PEAD": ["sue"],
+        "Growth / Income": ["earn_growth", "rev_growth", "div_yield"],
+        "Investment": ["asset_growth"],
+    }
+    out = ""
+    for cl, keys in clusters.items():
+        rows = ""
+        for k in keys:
+            if k not in STATS:
+                continue
+            s = STATS[k]
+            icn, t, hit = s.get("ic_neu"), s.get("t_hac"), s.get("hit")
+            nc = "#0a7d33" if (icn or 0) > 0 else "#b91c1c"
+            tw = "700" if abs(t or 0) >= 2 else "400"
+            rows += (
+                f"<tr><td><code>{k}</code></td><td style='color:{nc}'>{_f(icn)}</td>"
+                f"<td style='font-weight:{tw}'>{_f(t, 2)}</td><td>{_f(hit, 2)}</td>"
+                f"<td>{s.get('n_dates', '')}</td></tr>"
+            )
+        if rows:
+            out += (
+                f"<h3 style='margin-top:14px'>{cl}</h3>"
+                "<table><thead><tr><th>Metric</th><th>IC β-neut</th><th>t (HAC)</th><th>hit</th>"
+                f"<th>dates</th></tr></thead><tbody>{rows}</tbody></table>"
+            )
+    return (
+        "<h2>6 · Parameter benchmark by cluster — 10yr survivorship-clean</h2>"
+        '<p class="note">Every 10yr-testable parameter, grouped. Sharadar SF1+DAILY, 114 monthly cross-sections '
+        "2017-2026, delisted-inclusive, β-neutral forward IC, HAC t. Analyst / forward metrics omitted (no 10yr "
+        "data). Bold t = |t| ≥ 2.</p>" + out
+    )
+
+
+def main() -> None:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_next_iteration_memo.html")
+    changes = "".join(f"<li>{c}</li>" for c in SYN.get("key_changes", []))
+    html = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>v3 Factor Model — Next-Iteration Decision Memo</title>
+<style>body{{font:14px -apple-system,Segoe UI,Arial,sans-serif;color:#1a1a1a;background:#fff;max-width:1040px;margin:0 auto;padding:30px}}
+h1{{font-size:23px;margin:0 0 4px}}.sub{{color:#5b6470;font-size:13px;margin-bottom:16px}}
+h2{{font-size:17px;margin:26px 0 8px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}}
+h3{{font-size:13.5px;margin:12px 0 5px;color:#1a1a1a}}
+table{{width:100%;border-collapse:collapse;font-size:12.5px;margin-top:4px}}
+th{{text-align:left;background:#f7f8fa;padding:6px 9px;border-bottom:1px solid #e6e8ec}}
+td{{padding:6px 9px;border-bottom:1px solid #eef0f2;vertical-align:top}}
+code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:11.5px}}
+.note{{color:#5b6470;font-size:12.5px;margin:6px 0}}.mdesc{{color:#374151;font-size:12px;max-width:430px}}
+.win{{font-size:11px;text-align:center}}.b{{font-size:10px;font-weight:700;padding:1px 6px;border-radius:20px;margin-left:4px}}
+.exec{{background:#f7f8fa;border-left:3px solid #1a1a1a;padding:12px 16px;font-size:13px;line-height:1.55;border-radius:0 6px 6px 0}}
+ul.src li,ul.risk li{{margin-bottom:7px;font-size:12.5px;line-height:1.5}}
+ul.risk li{{color:#7a1f1f}}</style></head><body>
+<h1>v3 Factor Model — Next-Iteration Decision Memo</h1>
+<div class="sub">Generated {stamp} UTC · live ~$1.1M book · method: 10yr survivorship-clean quant (114 monthly
+cross-sections) → redundancy/incremental-IC → 5 expert lenses → red-team → CIO synthesis (7 agents).
+<b>Weights stay frozen / earn-in — this is a de-duplication + honesty pass, a proposal for discussion, not an executed change.</b></div>
+<h2>0 · Executive summary</h2>
+<div class="exec">{SYN["executive_summary"]}</div>
+<h3 style="margin-top:14px">Key changes vs current</h3><ul class="src">{changes}</ul>
+{_decision_table()}
+{_redundancy()}
+{_missing()}
+{_sourcing()}
+{_risks()}
+{_benchmark()}
+</body></html>"""
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write(html)
+    print(f"memo -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -63,16 +63,23 @@ PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
 BUY_CSV = "yahoofinance/output/buy.csv"
 ETORO_CSV = "yahoofinance/output/etoro.csv"
 
-PREVIEW_OUT = "~/Downloads/v3_overlay_preview.html"
+# Output dir override (V3_OUT_DIR) — a detached process on macOS can be TCC-blocked from
+# writing to ~/Downloads; point it at a writable dir for local/background runs.
+_OUT_DIR = os.path.expanduser(os.environ.get("V3_OUT_DIR", "~/Downloads"))
+PREVIEW_OUT = os.path.join(_OUT_DIR, "v3_overlay_preview.html")
 
-# Balanced factor tilt requested by the owner for the overlay.
+# 2026-07-21 (owner review): locked master-taxonomy cluster weights (sum of the per-metric
+# weights per cluster). Quality-led (absorbs net_issuance), value = P/S+P/B+pe_forward,
+# growth = earn_growth+earn_stability, low-vol → 0 (beta/realized_vol are SIZING, not alpha).
 BALANCED_WEIGHTS: dict[str, float] = {
-    "value": 0.15,
-    "quality": 0.25,
-    "momentum": 0.25,
-    "growth": 0.15,
-    "lowvol": 0.12,
-    "strength": 0.08,
+    "value": 0.16,
+    "quality": 0.42,
+    "momentum": 0.14,
+    "growth": 0.12,
+    "pead": 0.06,
+    "trajectory": 0.05,
+    "strength": 0.05,
+    "lowvol": 0.00,
 }
 
 # Mega-cap "core" whose kept-vs-sold status is always reported.
@@ -647,7 +654,7 @@ def main() -> None:
     html = render_report(scores, meta, portfolio=view, actions=actions, conditioning=cond)
 
     stamp = now.strftime("%Y%m%d%H%M")
-    out = os.path.expanduser(f"~/Downloads/{stamp}_v3_overlay_report.html")
+    out = os.path.join(_OUT_DIR, f"{stamp}_v3_overlay_report.html")
     with open(out, "w", encoding="utf-8") as fh:
         fh.write(html)
 
@@ -660,7 +667,7 @@ def main() -> None:
     email_html = render_email_report(
         scores, meta, portfolio=view, actions=actions, conditioning=cond
     )
-    email_out = os.path.expanduser(f"~/Downloads/{stamp}_v3_overlay_email.html")
+    email_out = os.path.join(_OUT_DIR, f"{stamp}_v3_overlay_email.html")
     with open(email_out, "w", encoding="utf-8") as fh:
         fh.write(email_html)
     print(f"overlay email  -> {email_out}")

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -18,9 +18,9 @@ def _base(index):
 
 
 def test_value_metric_negation_cheap_ranks_high():
-    """Low P/E (cheap) must produce a HIGH value_z (value metrics are negated)."""
+    """Low forward P/E (cheap) must produce a HIGH value_z (value metrics are negated)."""
     df = _base(["CHEAP", "MID", "RICH"])
-    df["pe_trailing"] = [5.0, 15.0, 50.0]
+    df["pe_forward"] = [5.0, 15.0, 50.0]
     scores = compute_scores(df, sector_neutral=False)
     assert scores.loc["CHEAP", "value_z"] > scores.loc["MID", "value_z"]
     assert scores.loc["MID", "value_z"] > scores.loc["RICH", "value_z"]
@@ -64,9 +64,9 @@ def test_sector_neutral_flips_a_sector_leader_positive():
 
 def test_conviction_and_rank_produced():
     df = _base(["A", "B", "C", "D"])
-    df["pe_trailing"] = [5.0, 12.0, 25.0, 60.0]
+    df["pe_forward"] = [5.0, 12.0, 25.0, 60.0]
     df["roe"] = [40.0, 25.0, 15.0, 5.0]
-    df["mom_12_1"] = [0.30, 0.10, -0.05, -0.20]
+    df["pct_52w_high"] = [0.30, 0.10, -0.05, -0.20]
     scores = compute_scores(df, sector_neutral=False)
 
     assert "conviction" in scores.columns
@@ -83,7 +83,7 @@ def test_conviction_and_rank_produced():
 def test_nans_tolerated():
     """Rows/metrics with NaN don't crash; clusters use present metrics only."""
     df = _base(["A", "B", "C"])
-    df["pe_trailing"] = [5.0, np.nan, 40.0]  # B missing value metric
+    df["pe_forward"] = [5.0, np.nan, 40.0]  # B missing value metric
     df["roe"] = [30.0, 20.0, np.nan]  # C missing quality metric
     scores = compute_scores(df, sector_neutral=False)
 
@@ -146,12 +146,12 @@ def test_eligibility_excludes_non_equity_and_dataless():
     df = _base(idx)
     df["quote_type"] = ["EQUITY", "EQUITY", "ETF", "EQUITY"]
     df["price"] = [100.0, 50.0, 200.0, 30.0]
-    df["pe_trailing"] = [10.0, 20.0, 15.0, 12.0]
+    df["pe_forward"] = [10.0, 20.0, 15.0, 12.0]
     df["roe"] = [30.0, 20.0, 25.0, 18.0]
-    df["mom_12_1"] = [0.20, 0.10, 0.15, 0.05]
+    df["pct_52w_high"] = [0.20, 0.10, 0.15, 0.05]
     df["realized_vol"] = [0.20, 0.25, 0.22, 0.30]
     # DATALESS: strip its core data (no price/mom/vol, and its cluster members go NaN).
-    df.loc["DATALESS", ["price", "pe_trailing", "roe", "mom_12_1", "realized_vol"]] = np.nan
+    df.loc["DATALESS", ["price", "pe_forward", "roe", "pct_52w_high", "realized_vol"]] = np.nan
 
     scores = compute_scores(df, sector_neutral=False)
 
@@ -218,7 +218,7 @@ def test_derive_cluster_weights_proportional_to_positive_ic():
 
 
 def test_derive_cluster_weights_preserves_value_quality_cap():
-    """IC that would over-weight Value+Quality is capped at 0.55, excess to the rest."""
+    """IC that would over-weight Value+Quality is capped at 0.60, excess to the rest."""
     from trade_modules.v3.combine import derive_cluster_weights
 
     ic = {
@@ -231,11 +231,11 @@ def test_derive_cluster_weights_preserves_value_quality_cap():
     w = derive_cluster_weights(ic)
     assert abs(sum(w.values()) - 1.0) < 1e-9
     vq = w["value_z"] + w["quality_z"]
-    assert abs(vq - 0.55) < 1e-9  # capped exactly at the joint cap
+    assert abs(vq - 0.60) < 1e-9  # capped exactly at the joint cap (raised 0.55->0.60)
     # equal IC -> equal split inside the VQ bucket
     assert abs(w["value_z"] - w["quality_z"]) < 1e-9
-    # the freed 0.45 is spread over the other three (equal IC -> equal split)
-    assert abs(w["momentum_z"] - 0.15) < 1e-9
+    # the freed 0.40 is spread over the three positive-IC clusters (equal IC -> equal split)
+    assert abs(w["momentum_z"] - 0.40 / 3) < 1e-9
 
 
 def test_derive_cluster_weights_clamps_negative_ic():
@@ -281,9 +281,9 @@ def test_derive_cluster_weights_equal_spread_when_rest_ic_nonpositive():
     w = derive_cluster_weights(ic)
 
     assert abs(sum(w.values()) - 1.0) < 1e-9, f"weights sum {sum(w.values())} != 1.0"
-    assert abs(w["value_z"] + w["quality_z"] - 0.55) < 1e-9, "VQ cap not exactly 0.55"
+    assert abs(w["value_z"] + w["quality_z"] - 0.60) < 1e-9, "VQ cap not exactly 0.60"
 
-    expected_each = (1.0 - 0.55) / 5  # rest = momentum, lowvol, strength, pead, trajectory
+    expected_each = (1.0 - 0.60) / 5  # rest = momentum, lowvol, strength, pead, trajectory
     for c in ("momentum_z", "lowvol_z", "strength_z", "pead_z", "trajectory_z"):
         assert abs(w[c] - expected_each) < 1e-9, (
             f"{c}: got {w[c]:.6f}, expected {expected_each:.6f}"
@@ -295,8 +295,8 @@ def test_ic_weighting_shifts_conviction_toward_high_ic_cluster():
     a momentum-heavy IC flips it to the momentum name. (Default weights are now
     equal-risk, so the shift is shown via explicit IC vectors, not the default.)"""
     df = _base(["MOM_STAR", "VAL_STAR", "MID1", "MID2"])
-    df["pe_trailing"] = [50.0, 5.0, 20.0, 25.0]  # VAL_STAR cheapest -> best value
-    df["mom_12_1"] = [0.50, -0.20, 0.10, 0.05]  # MOM_STAR strongest momentum
+    df["pe_forward"] = [50.0, 5.0, 20.0, 25.0]  # VAL_STAR cheapest -> best value
+    df["pct_52w_high"] = [0.50, -0.20, 0.10, 0.05]  # MOM_STAR strongest momentum
 
     val = compute_scores(
         df,
@@ -352,13 +352,14 @@ _GROWTH_FORWARD = {
 
 
 def test_growth_cluster_registered_direction_positive():
-    """Growth is the 6th cluster: earnings + revenue growth, DIRECTION +1."""
+    """Growth cluster: earnings growth + earnings stability (2026-07-21: rev_growth demoted
+    to watch/margin-conditioning; earn_stability added as the QMJ 'safety' leg). DIRECTION +1."""
     from trade_modules.v3.combine import CLUSTERS, DIRECTION
 
     assert "growth_z" in CLUSTERS
-    assert set(CLUSTERS["growth_z"]) == {"earn_growth", "rev_growth"}
+    assert set(CLUSTERS["growth_z"]) == {"earn_growth", "earn_stability"}
     assert DIRECTION["earn_growth"] == +1
-    assert DIRECTION["rev_growth"] == +1
+    assert DIRECTION["earn_stability"] == +1
     assert list(CLUSTERS.keys()) == [
         "value_z",
         "quality_z",
@@ -451,8 +452,8 @@ def test_resolve_cluster_weights_accepts_long_and_short_names():
 def test_cluster_weights_precedence_over_ic_and_default():
     """Explicit cluster_weights override BOTH ic_weights and the default."""
     df = _base(["MOM_STAR", "VAL_STAR", "MID"])
-    df["pe_trailing"] = [50.0, 5.0, 20.0]
-    df["mom_12_1"] = [0.50, -0.20, 0.10]
+    df["pe_forward"] = [50.0, 5.0, 20.0]
+    df["pct_52w_high"] = [0.50, -0.20, 0.10]
     # cluster_weights momentum-only should beat an ic_weights that favors value.
     out = compute_scores(
         df,
@@ -466,10 +467,10 @@ def test_cluster_weights_precedence_over_ic_and_default():
 def test_cluster_weights_growth_forward_shifts_ranking():
     """Growth-forward ranks a high-growth expensive name ABOVE a cheap no-growth name."""
     df = _base(["GROWTH_EXP", "VALUE_CHEAP", "MID"])
-    df["pe_trailing"] = [60.0, 6.0, 20.0]  # GROWTH_EXP expensive, VALUE_CHEAP cheap
+    df["pe_forward"] = [60.0, 6.0, 20.0]  # GROWTH_EXP expensive, VALUE_CHEAP cheap
     df["earn_growth"] = [40.0, 1.0, 15.0]  # GROWTH_EXP fast grower, VALUE_CHEAP flat
-    df["rev_growth"] = [0.35, 0.01, 0.12]
-    df["mom_12_1"] = [0.40, -0.10, 0.10]  # momentum reinforces the growth name
+    df["earn_stability"] = [0.9, 0.2, 0.5]  # GROWTH_EXP steadier earnings too
+    df["pct_52w_high"] = [0.40, -0.10, 0.10]  # momentum reinforces the growth name
 
     vh = compute_scores(df, sector_neutral=False, cluster_weights=_VALUE_HEAVY)
     gf = compute_scores(df, sector_neutral=False, cluster_weights=_GROWTH_FORWARD)
@@ -483,21 +484,23 @@ def test_cluster_weights_growth_forward_shifts_ranking():
 def test_backward_compat_none_equals_explicit_default_weights():
     """cluster_weights=None reproduces the default model EXACTLY (allclose)."""
     df = _base(["A", "B", "C", "D"])
-    df["pe_trailing"] = [5.0, 12.0, 25.0, 60.0]
+    df["pe_forward"] = [5.0, 12.0, 25.0, 60.0]
     df["roe"] = [40.0, 25.0, 15.0, 5.0]
-    df["mom_12_1"] = [0.30, 0.10, -0.05, -0.20]
+    df["pct_52w_high"] = [0.30, 0.10, -0.05, -0.20]
 
     default = compute_scores(df, sector_neutral=False)
     explicit = compute_scores(
         df,
         sector_neutral=False,
         cluster_weights={
-            "value": 0.21,
-            "quality": 0.21,
-            "momentum": 0.21,
-            "growth": 0.11,
-            "lowvol": 0.21,
+            "value": 0.16,
+            "quality": 0.42,
+            "momentum": 0.14,
+            "growth": 0.12,
+            "pead": 0.06,
+            "trajectory": 0.05,
             "strength": 0.05,
+            "lowvol": 0.00,
         },
     )
     assert np.allclose(
@@ -547,14 +550,15 @@ def test_fixnow_strength_cluster_is_analyst_mom_only():
             assert dead not in members, f"{dead} must not be scored in any cluster"
 
 
-def test_fixnow_value_drops_raw_pb_anchors_ev_ebitda():
-    """Value = EV/EBITDA (anchor) + trailing P/E; raw P/B is dropped from scoring
-    (intangible-heavy tech universe degrades it) (D7)."""
+def test_value_cluster_is_ps_forward_pb():
+    """2026-07-21 (owner): value = P/S (sector default) + forward P/E + P/B (financials/REITs
+    recipe); pe_trailing + ev_ebitda dropped from scoring (redundant / dead this regime)."""
     from trade_modules.v3.combine import CLUSTERS
 
-    assert CLUSTERS["value_z"] == ["pe_trailing", "ev_ebitda"]
-    for members in CLUSTERS.values():
-        assert "pb" not in members, "raw P/B must not be scored in any cluster"
+    assert CLUSTERS["value_z"] == ["ps_sector", "pe_forward", "pb"]
+    for dead in ("pe_trailing", "ev_ebitda"):
+        for members in CLUSTERS.values():
+            assert dead not in members, f"{dead} must not be scored in any cluster"
 
 
 def test_quality_is_roe_fcf_gp_assets():
@@ -563,29 +567,26 @@ def test_quality_is_roe_fcf_gp_assets():
     + de are a distress filter; accruals shadow-only (no clean alpha)."""
     from trade_modules.v3.combine import CLUSTERS, DIRECTION
 
-    assert CLUSTERS["quality_z"] == ["roe", "fcf", "gp_assets"]
+    assert CLUSTERS["quality_z"] == ["roe", "fcf", "gp_assets", "net_issuance"]
     assert DIRECTION["gp_assets"] == +1
+    assert DIRECTION["net_issuance"] == -1  # dilution bad / buyback good
     for dead in ("roa", "gross_margin", "op_margin", "current_ratio", "de", "accruals"):
         for members in CLUSTERS.values():
             assert dead not in members, f"{dead} must not be scored in quality"
 
 
-def test_best_bet_prior_weights_2026_07_20():
-    """BEST-BET prior (survivorship-clean backtest + literature): quality-led (GP/assets),
-    value+momentum durable core, PEAD + earnings-trajectory (PET/PEF — strongest clean
-    signal, beta-neutral t 2.17) added, low-vol a risk-diversifier, growth trimmed. VQ
-    below the 0.55 cap; sum = 1."""
+def test_master_taxonomy_weights_2026_07_21():
+    """Master-taxonomy cluster weights (owner-locked 2026-07-21): quality-led (absorbs
+    net_issuance t2.95), low-vol -> 0 (beta/realized_vol moved to SIZING, not scored alpha),
+    value = P/S+P/B+pe_forward, growth = earn_growth+earn_stability above the analyst earn-in
+    sleeve, PEAD + trajectory retained. Value+Quality within the 0.60 cap; sum = 1."""
     from trade_modules.v3.combine import CLUSTER_WEIGHTS as w
 
     assert w["quality_z"] == max(w.values()), "quality is the evidence leader"
-    assert w["pead_z"] > 0, "PEAD participates (best clean signal + robust literature)"
-    assert w["trajectory_z"] > 0, "earnings-trajectory participates (strongest clean signal)"
-    assert w["lowvol_z"] < w["value_z"], "low-vol trimmed to a risk-diversifier"
-    assert w["lowvol_z"] <= 0.10 + 1e-9, "low-vol capped low (its alpha was a beta artifact)"
-    assert (w["value_z"] + w["quality_z"]) < 0.55, "no Value+Quality cap-as-floor"
-    # C (2026-07-20): analyst_mom upweighted (β-neutral t 2.36) above growth.
-    assert w["strength_z"] >= 0.08 - 1e-9, "analyst_mom (strength) upweighted per C"
-    assert w["strength_z"] > w["growth_z"], "strength now ranks above the trimmed growth satellite"
+    assert w["pead_z"] > 0 and w["trajectory_z"] > 0, "PEAD + trajectory participate"
+    assert w["lowvol_z"] == 0.0, "low-vol -> 0 (moved to sizing, not alpha)"
+    assert (w["value_z"] + w["quality_z"]) <= 0.60 + 1e-9, "value+quality within the 0.60 cap"
+    assert w["growth_z"] > w["strength_z"], "growth satellite above the analyst earn-in sleeve"
     assert abs(sum(w.values()) - 1.0) < 1e-9
 
 

--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -890,3 +890,43 @@ def test_name_cap_binding_max_weight_respected():
         )
     # Cap is working (not breached): binding flag must be False.
     assert d["binding"]["name_cap"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Owner sizing (2026-07-21): per-name market-cap-tier caps + dividend up-size tilt
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_name_cap_vec_per_name_caps_preserve_total():
+    """Per-name cap vector caps each name at its own cap and preserves the total weight."""
+    from trade_modules.riskfirst.construct import apply_name_cap_vec
+
+    w = np.array([0.5, 0.3, 0.2])
+    caps = np.array([0.1, 0.6, 0.6])
+    out = apply_name_cap_vec(w, caps)
+    assert (out <= caps + 1e-9).all()
+    assert abs(out[0] - 0.1) < 1e-9
+    assert abs(float(out.sum()) - 1.0) < 1e-9
+
+
+def test_tiered_name_caps_by_market_cap():
+    """Market-cap-tier single-name caps: mega 0.10 down to micro 0.0025; unknown -> 0.06."""
+    from trade_modules.v3.construct import _tiered_name_caps
+
+    scored = pd.DataFrame(
+        {"cap": [5e11, 5e10, 5e9, 1e9, 1e8, np.nan]},
+        index=["MEGA", "LARGE", "MID", "SMALL", "MICRO", "UNK"],
+    )
+    caps = _tiered_name_caps(scored, list(scored.index))
+    assert list(caps) == [0.10, 0.06, 0.02, 0.005, 0.0025, 0.06]
+
+
+def test_div_tilt_moderate_upsizes_extreme_yield_flagged():
+    """Dividend up-size: moderate yield (0-4%) up-sizes to +50%; > 6% = value-trap -> no bonus."""
+    from trade_modules.v3.construct import _div_tilt
+
+    scored = pd.DataFrame({"div_yield": [0.0, 0.04, 0.08]}, index=["NONE", "MOD", "HIGH"])
+    t = _div_tilt(scored, list(scored.index))
+    assert abs(t[0] - 1.0) < 1e-9
+    assert abs(t[1] - 1.5) < 1e-9  # 4% -> +50%
+    assert abs(t[2] - 1.0) < 1e-9  # > 6% -> value-trap flag, no up-size

--- a/tests/unit/trade_modules/test_v3_fundamentals.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals.py
@@ -93,6 +93,81 @@ def test_factor_panel_handles_empty_prior():
     assert fp.loc["A", "gp_assets"] == pytest.approx(0.15)  # others still compute
 
 
+def test_factor_panel_extended_factors():
+    # roe/roa/margins/growth are DERIVED; de/current_ratio/ev_ebitda are Sharadar
+    # precomputed passthroughs; fcf_yield = fcf / market cap.
+    fasof = pd.DataFrame(
+        {
+            "equity": [50.0],
+            "assets": [200.0],
+            "gp": [60.0],
+            "netinc": [25.0],
+            "ncfo": [12.0],
+            "revenue": [300.0],
+            "opinc": [45.0],
+            "eps": [2.0],
+            "sharesbas": [10.0],
+            "de": [1.5],
+            "currentratio": [2.0],
+            "evebitda": [12.0],
+            "fcf": [30.0],
+            "divyield": [0.03],
+        },
+        index=["A"],
+    )
+    fprior = pd.DataFrame(
+        {"eps": [1.6], "revenue": [250.0], "assets": [180.0], "sharesbas": [8.0]}, index=["A"]
+    )
+    price = pd.Series({"A": 10.0})  # market cap = 10 * 10 shares = 100
+    fp = factor_panel(fasof, fprior, price)
+    assert fp.loc["A", "div_yield"] == pytest.approx(0.03)  # passthrough
+    assert fp.loc["A", "net_issuance"] == pytest.approx(0.25)  # 10 / 8 - 1 (dilution)
+    assert fp.loc["A", "roe"] == pytest.approx(0.50)  # 25 / 50
+    assert fp.loc["A", "roa"] == pytest.approx(0.125)  # 25 / 200
+    assert fp.loc["A", "gross_margin"] == pytest.approx(0.20)  # 60 / 300
+    assert fp.loc["A", "op_margin"] == pytest.approx(0.15)  # 45 / 300
+    assert fp.loc["A", "de"] == pytest.approx(1.5)  # passthrough
+    assert fp.loc["A", "current_ratio"] == pytest.approx(2.0)  # passthrough
+    assert fp.loc["A", "ev_ebitda"] == pytest.approx(12.0)  # passthrough
+    assert fp.loc["A", "fcf_yield"] == pytest.approx(0.30)  # 30 / 100
+    assert fp.loc["A", "earn_growth"] == pytest.approx(2.0 / 1.6 - 1)  # 0.25
+    assert fp.loc["A", "rev_growth"] == pytest.approx(0.20)  # 300 / 250 - 1
+
+
+def test_factor_panel_extended_guards():
+    # Negative book -> roe NaN; zero revenue -> margins NaN; negative equity makes D/E
+    # negative (distress) -> guarded; negative EV/EBITDA (negative EBITDA) -> guarded;
+    # negative prior EPS -> earn_growth NaN; but negative FCF is meaningful -> kept.
+    fasof = pd.DataFrame(
+        {
+            "equity": [-5.0],
+            "assets": [100.0],
+            "gp": [20.0],
+            "netinc": [5.0],
+            "revenue": [0.0],
+            "opinc": [3.0],
+            "eps": [1.0],
+            "sharesbas": [10.0],
+            "de": [-2.0],
+            "currentratio": [1.1],
+            "evebitda": [-8.0],
+            "fcf": [-4.0],
+        },
+        index=["B"],
+    )
+    fprior = pd.DataFrame({"eps": [-1.0], "revenue": [200.0], "assets": [90.0]}, index=["B"])
+    price = pd.Series({"B": 5.0})  # market cap = 50
+    fp = factor_panel(fasof, fprior, price)
+    assert math.isnan(fp.loc["B", "roe"])  # negative equity
+    assert math.isnan(fp.loc["B", "gross_margin"])  # zero revenue
+    assert math.isnan(fp.loc["B", "op_margin"])
+    assert math.isnan(fp.loc["B", "de"])  # negative (from negative equity) -> guarded
+    assert math.isnan(fp.loc["B", "ev_ebitda"])  # negative EBITDA -> guarded
+    assert fp.loc["B", "fcf_yield"] == pytest.approx(-4.0 / 50.0)  # negative FCF kept
+    assert math.isnan(fp.loc["B", "earn_growth"])  # negative prior EPS
+    assert fp.loc["B", "roa"] == pytest.approx(0.05)  # 5 / 100 (assets positive)
+
+
 def test_live_fundamentals_factors(tmp_path):
     from trade_modules.v3.fundamentals_store import append_records
 

--- a/trade_modules/riskfirst/construct.py
+++ b/trade_modules/riskfirst/construct.py
@@ -113,3 +113,23 @@ def apply_name_cap(w: np.ndarray, cap: float, max_iter: int = 1000) -> np.ndarra
             break
         w[under] += excess * (w[under] / under_sum)
     return w
+
+
+def apply_name_cap_vec(w: np.ndarray, caps: np.ndarray, max_iter: int = 1000) -> np.ndarray:
+    """Per-name cap: cap each weight at ``caps[i]`` (e.g. a market-cap-tier schedule),
+    redistributing the excess proportionally to the remaining HEADROOM of under-cap names.
+    Preserves the total invested weight (headroom-proportional avoids re-exceeding small caps)."""
+    w = np.asarray(w, dtype=float).copy()
+    caps = np.asarray(caps, dtype=float)
+    for _ in range(max_iter):
+        over = w > caps + 1e-12
+        if not over.any():
+            break
+        excess = float((w[over] - caps[over]).sum())
+        w[over] = caps[over]
+        head = np.where(~over, caps - w, 0.0)
+        head_sum = float(head.sum())
+        if head_sum <= 1e-15:
+            break
+        w = w + excess * (head / head_sum)
+    return w

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -58,6 +58,10 @@ DIRECTION = {
     # = earnings expected to RISE; low = value-trap). The distinct PET->PEF information
     # lost when raw pe_forward was pruned. Strongest survivorship-clean signal we found.
     "earn_trajectory": +1,
+    # net share issuance (2026-07-21): dilution bad / buyback good (Pontiff-Woodgate).
+    "net_issuance": -1,
+    # earnings stability (2026-07-21): low earnings coefficient-of-variation = QMJ 'safety'.
+    "earn_stability": +1,
 }
 
 # Scoring clusters -> member metrics.
@@ -69,16 +73,16 @@ CLUSTERS = {
     # FIX-NOW 2026-07-18 (D7): raw P/B dropped (degrades in an intangible-heavy
     # mega-cap-tech universe — shorts the R&D/brand compounders). Anchor on
     # EV/EBITDA + trailing earnings yield. Intangibles-adjusted book -> BUILD.
-    "value_z": ["pe_trailing", "ev_ebitda"],
+    "value_z": ["ps_sector", "pe_forward", "pb"],
     # quality = ROE + FCF + GP/assets. GP/assets (Novy-Marx) added 2026-07-19 once the
     # Sharadar SF1 PIT data was in — it was the best survivorship-clean raw IC (t 3.5)
     # AND the documented profitability anchor. de + current_ratio stay a distress
     # filter; accruals shadow-only (no clean alpha).
-    "quality_z": ["roe", "fcf", "gp_assets"],
+    "quality_z": ["roe", "fcf", "gp_assets", "net_issuance"],
     # price_perf pruned 2026-07-14: rho 0.95 with mom_12_1 (same price move counted
     # twice). Kept the academic 12-1 skip-month + 52w-high proximity (distinct).
-    "momentum_z": ["mom_12_1", "pct_52w_high"],
-    "growth_z": ["earn_growth", "rev_growth"],
+    "momentum_z": ["pct_52w_high"],
+    "growth_z": ["earn_growth", "earn_stability"],
     "lowvol_z": ["beta", "realized_vol"],
     # FIX-NOW 2026-07-18 (agreed setup D2-D6): strength collapses to analyst_mom
     # alone. upside (contaminated/contrarian), buy_pct (zero-IC level),
@@ -128,9 +132,12 @@ _DEFAULT_GROUP = "A"  # unknown / missing sector -> conventional recipe
 # applied over the metrics PRESENT for a row and renormalized, so one present
 # metric reproduces its own z (a name is never penalized for a missing metric).
 VALUE_GROUP_RECIPES = {
-    "A": {"pe_trailing": 1.0, "ev_ebitda": 1.0},  # earnings + enterprise (default)
-    "B": {"pb": 1.0, "pe_trailing": 0.5},  # book primary; EV meaningless for banks/REITs
-    "C": {"ps_sector": 1.0, "ev_ebitda": 0.5},  # sales primary; drop trailing-PE + book
+    # 2026-07-21 (owner): P/S default value lead, P/B for financials/REITs, pe_forward
+    # PROMOTED in place of pe_trailing (earn-in — yfinance forward EPS, no 10yr PIT);
+    # ev_ebitda + pe_trailing dropped (redundant / dead this regime).
+    "A": {"ps_sector": 1.0, "pe_forward": 1.0},  # sales + forward-earnings (default)
+    "B": {"pb": 1.0, "pe_forward": 0.5},  # book primary; banks/REITs
+    "C": {"ps_sector": 1.0, "pe_forward": 0.5},  # sales primary; growth/intangible
 }
 # Per-group multiplier on the value cluster's WEIGHT in conviction (value is weak /
 # sign-inverted in growth/intangible sectors -> halved there, never dropped).
@@ -161,20 +168,25 @@ _VALUE_CANDIDATES = sorted({m for r in VALUE_GROUP_RECIPES.values() for m in r})
 # a single noisy metric: raw IC ~0, hit 50%). Funded by growth 0.05->0.03 (theory-weak) +
 # low-vol 0.10->0.09 (risk-diversifier, not alpha). Upside/EXR stay MONITOR (zero β-alpha,
 # t -0.15) — a negative-upside BUY is often a right contrarian bet (see capitulation study).
+# 2026-07-21 (owner review): cluster weights re-derived as the SUM of the locked per-metric
+# weights per cluster (master taxonomy). Quality absorbs net_issuance (t2.95) + is the
+# strongest sleeve; value = P/S+P/B+pe_forward; growth = earn_growth+earn_stability; low-vol
+# → 0 (beta/realized_vol moved to SIZING, not alpha). Within-cluster is still ~equal-mean here
+# (a first-look approximation of the 13/13/9/7-type per-metric weights).
 CLUSTER_WEIGHTS = {
-    "value_z": 0.18,
-    "quality_z": 0.24,
-    "momentum_z": 0.18,
-    "pead_z": 0.10,
-    "trajectory_z": 0.10,
-    "lowvol_z": 0.09,
-    "strength_z": 0.08,
-    "growth_z": 0.03,
+    "value_z": 0.16,
+    "quality_z": 0.42,
+    "momentum_z": 0.14,
+    "growth_z": 0.12,
+    "pead_z": 0.06,
+    "trajectory_z": 0.05,
+    "strength_z": 0.05,
+    "lowvol_z": 0.00,
 }
 
 # The Value+Quality joint weight is capped here regardless of the weighting scheme.
 _VALUE_QUALITY = ("value_z", "quality_z")
-_VQ_CAP = 0.55
+_VQ_CAP = 0.60  # raised 0.55->0.60 (2026-07-21): the quality-led set puts value+quality at 0.58
 
 # The five "evidence" clusters the IC / default weighting operates over. Growth
 # is deliberately EXCLUDED here: it is off (weight 0) in the default + IC paths

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -35,7 +35,12 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from trade_modules.riskfirst.construct import apply_name_cap, cap_groups, erc_weights
+from trade_modules.riskfirst.construct import (
+    apply_name_cap,
+    apply_name_cap_vec,
+    cap_groups,
+    erc_weights,
+)
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import USD_BLOC, cap_bloc, currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
@@ -374,6 +379,41 @@ def dedup_dual_listings(scored: pd.DataFrame) -> pd.DataFrame:
     return scored.loc[[t for t in tickers if t not in drop]]
 
 
+# Market-cap-tier single-name caps (2026-07-21 owner sizing): mega can concentrate, micro is
+# strictly capped. Applied as a per-name cap vector in place of the flat name_cap.
+_MCAP_TIER_CAPS = [
+    (200e9, 0.10),  # mega  > $200B
+    (20e9, 0.06),  # large $20-200B
+    (2e9, 0.02),  # mid   $2-20B
+    (0.3e9, 0.005),  # small $0.3-2B
+    (0.0, 0.0025),  # micro < $0.3B
+]
+_UNKNOWN_MCAP_CAP = 0.06  # unknown market cap -> large-tier cap (not specially punished)
+
+
+def _tiered_name_caps(scored: pd.DataFrame, selected: list[str]) -> np.ndarray:
+    """Per-name single-name cap from the market-cap tier schedule (NaN cap -> large-tier)."""
+    caps = pd.to_numeric(scored.reindex(selected).get("cap"), errors="coerce").to_numpy()
+    out = []
+    for c in caps:
+        if not (c == c):  # NaN market cap
+            out.append(_UNKNOWN_MCAP_CAP)
+        else:
+            out.append(next((cp for lo, cp in _MCAP_TIER_CAPS if c >= lo), 0.0025))
+    return np.asarray(out, dtype=float)
+
+
+def _div_tilt(scored: pd.DataFrame, selected: list[str]) -> np.ndarray:
+    """Dividend-yield up-size: moderate yield (0-4%) up-sizes to +50%; > 6% = value-trap flag
+    -> no bonus (owner sizing: div_yield is a quality/stability lens applied at sizing)."""
+    dv = (
+        pd.to_numeric(scored.reindex(selected).get("div_yield"), errors="coerce")
+        .fillna(0.0)
+        .to_numpy()
+    )
+    return np.where(dv > 0.06, 1.0, 1.0 + 0.5 * np.clip(dv / 0.04, 0.0, 1.0))
+
+
 def build_portfolio(
     scored: pd.DataFrame,
     prices: pd.DataFrame,
@@ -382,6 +422,7 @@ def build_portfolio(
     conviction_weight: float = 0.5,
     target_vol: float = 0.12,
     name_cap: float = 0.08,
+    sizing_tilt: bool = False,  # 2026-07-21: opt-in owner sizing (div up-size + market-cap-tier caps)
     sector_cap: float = 0.25,
     usd_bloc_cap: float = 0.60,
     region_cap: float = 0.65,
@@ -490,17 +531,35 @@ def build_portfolio(
     if w_sum > 0:
         w = w / w_sum  # renormalize to sum = 1
 
+    # --- owner sizing (2026-07-21): dividend up-size tilt, then market-cap-TIER single-name
+    # caps (mega 10% .. micro 0.25%) in place of the flat name_cap. Div tilt slightly
+    # over-weights steady payers; tier caps let mega-caps concentrate and pin micro-caps. ---
+    if sizing_tilt:
+        w = w * _div_tilt(sub, selected)
+        _ws = float(w.sum())
+        if _ws > 0:
+            w = w / _ws
+        tcaps = _tiered_name_caps(sub, selected)
+
+        def _namecap(ww: np.ndarray) -> np.ndarray:
+            return apply_name_cap_vec(ww, tcaps)
+    else:  # default: EXACT legacy behavior — uniform scalar name_cap
+        tcaps = np.full(len(selected), name_cap, dtype=float)
+
+        def _namecap(ww: np.ndarray) -> np.ndarray:
+            return apply_name_cap(ww, name_cap)
+
     # --- caps: name -> USD-bloc -> sector (single-name reasserted between) ---
     # Region is enforced by the risk gate below (which converges + clamps to cash on
     # an infeasible book), not here, so a trailing name cap cannot silently undo it.
     is_bloc = np.array([currency_of(t) in USD_BLOC for t in selected])
     sec_arr = sub.reindex(selected)["SECTOR"].astype(str).to_numpy()
     region_arr = np.array([region_of(t) for t in selected])
-    w = apply_name_cap(w, name_cap)
+    w = _namecap(w)
     w = cap_bloc(w, is_bloc, usd_bloc_cap)
-    w = apply_name_cap(w, name_cap)  # keep single-name cap after bloc redistribution
+    w = _namecap(w)  # keep single-name cap(s) after bloc redistribution
     w = cap_groups(w, sec_arr, sector_cap)
-    w = apply_name_cap(w, name_cap)
+    w = _namecap(w)
 
     gross_risk = float(w.sum())  # capped risk-book gross (≈ 1.0)
 
@@ -559,7 +618,7 @@ def build_portfolio(
             _rg = region_of(_t)
             _region_totals[_rg] = _region_totals.get(_rg, 0.0) + float(_wt)
         _max_region = max(_region_totals.values(), default=0.0)
-        _name_cap_breach = bool(_max_name > name_cap + _TOL)
+        _name_cap_breach = bool((w_shape > tcaps + _TOL).any())  # per-name tier caps
         _sector_cap_breach = bool(_max_sector > sector_cap + _TOL)
         _usd_bloc_breach = bool(_usd_frac > usd_bloc_cap + _TOL)
         _region_cap_breach = bool(_max_region > region_cap + _TOL)
@@ -656,7 +715,8 @@ def build_portfolio(
         gate_diag["usd_bloc"] = usd_bloc_book
         _b = diagnostics["binding"]
         _b["region_cap"] = bool(_max_region > region_cap + _TOL)
-        _b["name_cap"] = bool(max_name > name_cap + _TOL)
+        _cap_ceiling = _MCAP_TIER_CAPS[0][1] if sizing_tilt else name_cap  # mega tier 0.10 vs flat
+        _b["name_cap"] = bool(max_name > _cap_ceiling + _TOL)
         _b["sector_cap"] = bool(_max_sector > sector_cap + _TOL)
         _b["usd_bloc_cap"] = bool(usd_bloc_book > usd_bloc_cap + _TOL)
     return {

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -507,8 +507,8 @@ def enrich_features(
     from trade_modules.v3.fundamentals import live_fundamentals_factors  # noqa: PLC0415
 
     ff = live_fundamentals_factors(list(feats.index))
-    feats["gp_assets"] = ff["gp_assets"].reindex(feats.index)
-    feats["sue"] = ff["sue"].reindex(feats.index)
+    for _c in ("gp_assets", "sue", "net_issuance", "earn_stability"):
+        feats[_c] = ff[_c].reindex(feats.index)
 
     feats.index.name = "ticker"
     return feats

--- a/trade_modules/v3/fundamentals.py
+++ b/trade_modules/v3/fundamentals.py
@@ -89,10 +89,15 @@ def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) ->
     """Vectorized cross-section of the balance-sheet / cash-flow PIT factors.
 
     ``fasof`` = point-in-time fundamentals as of date T (from ``read_asof(T)``);
-    ``fprior`` = fundamentals as of ~T−1yr (for asset growth); ``price`` = the price
-    at T per ticker (to form market cap = price × sharesbas). All aligned to
-    ``fasof.index``. Returns the four raw factors (book_to_price, asset_growth,
-    gp_assets, accruals) — SUE is series-based and handled separately.
+    ``fprior`` = fundamentals as of ~T−1yr (for asset / earnings / revenue growth);
+    ``price`` = the price at T per ticker (to form market cap = price × sharesbas). All
+    aligned to ``fasof.index``. Returns the durable-premia factors plus the
+    profitability / margin / growth / leverage set: book_to_price, asset_growth,
+    gp_assets, accruals, roe, roa, gross_margin, op_margin, earn_growth, rev_growth,
+    fcf_yield, de, current_ratio, ev_ebitda. roe/roa/margins/growth are DERIVED from
+    the as-reported fields; de/current_ratio/ev_ebitda are Sharadar precomputed
+    passthroughs (null in ARQ for roe/roa, hence those are derived). SUE is
+    series-based and handled separately.
     """
     idx = fasof.index
 
@@ -105,7 +110,15 @@ def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) ->
 
     eq, assets, gp = col(fasof, "equity"), col(fasof, "assets"), col(fasof, "gp")
     ni, cf, shares = col(fasof, "netinc"), col(fasof, "ncfo"), col(fasof, "sharesbas")
-    assets_prior = col(fprior, "assets")
+    rev, opinc, fcf = col(fasof, "revenue"), col(fasof, "opinc"), col(fasof, "fcf")
+    de, curr, evebitda = col(fasof, "de"), col(fasof, "currentratio"), col(fasof, "evebitda")
+    eps, divy = col(fasof, "eps"), col(fasof, "divyield")
+    assets_prior, eps_prior, rev_prior, shares_prior = (
+        col(fprior, "assets"),
+        col(fprior, "eps"),
+        col(fprior, "revenue"),
+        col(fprior, "sharesbas"),
+    )
     px = pd.to_numeric(pd.Series(price).reindex(idx), errors="coerce")
 
     mktcap = px * shares
@@ -115,6 +128,26 @@ def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) ->
             "asset_growth": (assets / assets_prior - 1.0).where(assets_prior > 0),
             "gp_assets": (gp / assets).where(assets != 0),
             "accruals": ((ni - cf) / assets).where(assets != 0),
+            # profitability / margins (derived — roe/roa are null in Sharadar ARQ)
+            "roe": (ni / eq).where(eq > 0),
+            "roa": (ni / assets).where(assets > 0),
+            "gross_margin": (gp / rev).where(rev > 0),
+            "op_margin": (opinc / rev).where(rev > 0),
+            # year-over-year growth (guard positive base so the ratio is meaningful)
+            "earn_growth": (eps / eps_prior - 1.0).where(eps_prior > 0),
+            "rev_growth": (rev / rev_prior - 1.0).where(rev_prior > 0),
+            # net share issuance: YoY change in shares outstanding (+ = dilution/bad,
+            # - = buyback/good). Scored negative in the combiner. Pontiff-Woodgate / Daniel-Titman.
+            "net_issuance": (shares / shares_prior - 1.0).where(shares_prior > 0),
+            # cash-flow yield (negative FCF is a real signal → not guarded away)
+            "fcf_yield": (fcf / mktcap).where(mktcap > 0),
+            # Sharadar precomputed passthroughs, guarded to sane ranges: negative D/E
+            # (from negative equity) and non-positive EV/EBITDA (negative EBITDA) are
+            # distress artifacts that would rank as "cheap/safe" under the low-is-good sign.
+            "de": de.where(de >= 0),
+            "current_ratio": curr.where(curr > 0),
+            "ev_ebitda": evebitda.where(evebitda > 0),
+            "div_yield": divy.where(divy >= 0),
         }
     )
 
@@ -132,8 +165,8 @@ def live_fundamentals_factors(tickers, *, store_path: str | None = None) -> pd.D
     sp = store_path or STORE_PATH
     idx = pd.Index([str(t) for t in tickers], name="ticker")
     out = pd.DataFrame(index=idx)
-    out["gp_assets"] = pd.Series(index=idx, dtype=float)
-    out["sue"] = pd.Series(index=idx, dtype=float)
+    for c in ("gp_assets", "sue", "net_issuance", "earn_stability"):
+        out[c] = pd.Series(index=idx, dtype=float)
 
     fasof = read_asof(list(idx), "2099-12-31", store_path=sp)  # latest filing per ticker
     if not fasof.empty:
@@ -143,6 +176,28 @@ def live_fundamentals_factors(tickers, *, store_path: str | None = None) -> pd.D
 
     hist = read_history(list(idx), "2099-12-31", store_path=sp)
     if not hist.empty:
-        sue = hist.sort_values("datekey").groupby("ticker")["eps"].apply(srw_sue)
-        out["sue"] = pd.to_numeric(sue, errors="coerce").reindex(idx)
+        h = hist.sort_values("datekey")
+        out["sue"] = pd.to_numeric(
+            h.groupby("ticker")["eps"].apply(srw_sue), errors="coerce"
+        ).reindex(idx)
+
+        def _net_iss(s) -> float:  # YoY change in shares outstanding (dilution + / buyback -)
+            v = pd.to_numeric(pd.Series(s), errors="coerce").dropna()
+            return (
+                float(v.iloc[-1] / v.iloc[-5] - 1.0) if len(v) >= 5 and v.iloc[-5] > 0 else math.nan
+            )
+
+        def _estab(s) -> float:  # -(coefficient of variation of trailing EPS): high = stable
+            v = pd.to_numeric(pd.Series(s), errors="coerce").dropna().tail(8)
+            if len(v) < 4:
+                return math.nan
+            m = abs(float(v.mean()))
+            return float(-(v.std() / (m + 1e-6)))
+
+        out["net_issuance"] = pd.to_numeric(
+            h.groupby("ticker")["sharesbas"].apply(_net_iss), errors="coerce"
+        ).reindex(idx)
+        out["earn_stability"] = pd.to_numeric(
+            h.groupby("ticker")["eps"].apply(_estab), errors="coerce"
+        ).reindex(idx)
     return out

--- a/trade_modules/v3/fundamentals_store.py
+++ b/trade_modules/v3/fundamentals_store.py
@@ -25,6 +25,9 @@ STORE_PATH: str = str(Path("~/.weirdapps-trading/v3_fundamentals_store.parquet")
 KEYS = ["ticker", "datekey", "reportperiod"]
 # Numeric as-reported fields we derive factors from (Sharadar SF1 names, ARQ dimension).
 # sharesbas + marketcap let us build book-to-price at ANY date (equity / (price*shares)).
+# The lower block are Sharadar's precomputed metrics (populated in ARQ) for the quality /
+# leverage / liquidity / cash-flow factors; roe/roa are null in ARQ so we DERIVE those from
+# netinc/equity/assets in fundamentals.py instead.
 NUM_FIELDS = [
     "assets",
     "equity",
@@ -35,6 +38,12 @@ NUM_FIELDS = [
     "eps",
     "sharesbas",
     "marketcap",
+    "de",
+    "currentratio",
+    "evebitda",
+    "fcf",
+    "opinc",
+    "divyield",
 ]
 STORE_COLS = KEYS + NUM_FIELDS
 


### PR DESCRIPTION
## v3 factor-model overhaul

Owner-reviewed, evidence-grounded next iteration of the v3 factor model.

**Alpha (combine.py):** add `net_issuance` (10yr β-neut t2.95) + `earn_stability` (t2.36); value recipe → P/S + forward-P/E + P/B (drop pe_trailing/ev_ebitda); quality += net_issuance; growth = earn_growth + earn_stability; momentum = pct_52w_high. Cluster weights re-derived (quality 0.42-led; low-vol → 0 = sizing); V+Q cap 0.55→0.60.

**PIT fundamentals:** `factor_panel` extended (roe/roa/margins/growth/leverage/EV-EBITDA/div_yield/net_issuance); `live_fundamentals_factors` += net_issuance + earn_stability (US-only, graceful NaN); SF1 store += de/currentratio/evebitda/fcf/opinc/divyield.

**Sizing (opt-in `sizing_tilt`):** market-cap-tier single-name caps (mega 10% → micro 0.25%) via `apply_name_cap_vec` + dividend up-size tilt (>6% = value-trap, no up-size). Default off → legacy behavior unchanged.

**Backtests/generators:** all factors in the fundamentals backtest + **beta_mat fix** (min_periods half-window — was 25 dates / 0 in 2026, silently degraded β-neutralization) + z-panel dump; factor backtest best-window (10yr/5mo) + decision table + per-metric proposals; new `v3_factor_redundancy`, `v3_master_taxonomy`, `v3_next_iteration_memo`.

**Overlay:** `BALANCED_WEIGHTS` → locked taxonomy; `V3_OUT_DIR` override.

**Tests:** combine/construct/fundamentals updated to new contracts; touched-module suite 134 green.

Governance: weights frozen / earn-in — no forward-validated alpha claimed on ~1 regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
