### PR TITLE
feat(v3): auto-refresh the PIT fundamentals store (self-healing --catch-up)

### DIFF
--- a/scripts/v3_fundamentals_update.py
+++ b/scripts/v3_fundamentals_update.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from trade_modules.v3.fundamentals_store import (  # noqa: E402
     NUM_FIELDS,
+    STORE_PATH,
     append_records,
     store_coverage,
 )
@@ -94,6 +95,25 @@ def _fetch(key: str, tickers: list[str], since: str | None) -> pd.DataFrame:
     return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=_COLUMNS)
 
 
+def _catch_up_since(
+    *, buffer_days: int = 90, backfill_since: str = "2015-01-01", store_path: str = STORE_PATH
+) -> str:
+    """Self-healing ``--since`` for the scheduled daily sync: the store's newest
+    ``datekey`` minus ``buffer_days`` (re-pull recent filings idempotently — the buffer
+    heals a missed run and picks up late/amended filings inside the window). Falls back
+    to ``backfill_since`` when the store is empty.
+
+    Note: this is ``datekey``-based, so a restatement of an OLDER period (same datekey,
+    new value) is only re-fetched while it stays inside the buffer window, and a brand-new
+    universe ticker gets only its recent history; a periodic full
+    ``--from-universe --since <backfill>`` refresh remains the way to capture those.
+    """
+    last = store_coverage(store_path=store_path).get("last")
+    if not last:
+        return backfill_since
+    return (pd.Timestamp(last) - pd.Timedelta(days=buffer_days)).strftime("%Y-%m-%d")
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Ingest Sharadar SF1 into the PIT fundamentals store.")
     g = ap.add_mutually_exclusive_group(required=True)
@@ -101,6 +121,12 @@ def main() -> None:
     g.add_argument("--from-universe", action="store_true", help="use the etoro.csv universe")
     g.add_argument("--from-file", help="read tickers from a file (one per line)")
     ap.add_argument("--since", help="only filings with datekey >= this (YYYY-MM-DD)")
+    ap.add_argument(
+        "--catch-up",
+        action="store_true",
+        help="incremental self-healing sync: derive --since from the store's newest "
+        "datekey minus a buffer (overrides --since). Use this for the scheduled job.",
+    )
     args = ap.parse_args()
 
     key = _api_key()
@@ -122,11 +148,11 @@ def main() -> None:
         print("ERROR: no tickers to fetch.", file=sys.stderr)
         sys.exit(1)
 
-    print(
-        f"fetching SF1 (ARQ) for {len(tickers)} tickers"
-        + (f" since {args.since}" if args.since else "")
-    )
-    df = _fetch(key, tickers, args.since)
+    since = _catch_up_since() if args.catch_up else args.since
+    if args.catch_up:
+        print(f"catch-up: derived --since {since} from store coverage")
+    print(f"fetching SF1 (ARQ) for {len(tickers)} tickers" + (f" since {since}" if since else ""))
+    df = _fetch(key, tickers, since)
     print(f"fetched {len(df)} filing rows")
     added = append_records(df)
     cov = store_coverage()

--- a/tests/unit/scripts/test_v3_fundamentals_update.py
+++ b/tests/unit/scripts/test_v3_fundamentals_update.py
@@ -1,0 +1,97 @@
+"""Unit tests for scripts/v3_fundamentals_update.py — the catch-up (self-healing
+incremental) --since computation used by the scheduled daily fundamentals sync.
+
+Loaded via importlib to match tests/unit/scripts/test_refresh_etoro_universe.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent.parent / "scripts" / "v3_fundamentals_update.py"
+_spec = importlib.util.spec_from_file_location("v3_fundamentals_update", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+v3_fundamentals_update = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(v3_fundamentals_update)
+
+_catch_up_since = v3_fundamentals_update._catch_up_since
+append_records = v3_fundamentals_update.append_records
+
+
+def _seed(store: str, last_datekey: str) -> None:
+    append_records(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": "AAA",
+                    "datekey": last_datekey,
+                    "reportperiod": "2026-03-31",
+                    "assets": 1.0,
+                }
+            ]
+        ),
+        store_path=store,
+    )
+
+
+class TestCatchUpSince:
+    def test_uses_store_last_minus_buffer(self, tmp_path):
+        store = str(tmp_path / "f.parquet")
+        _seed(store, "2026-07-20")
+        got = _catch_up_since(buffer_days=90, store_path=store)
+        assert got == (pd.Timestamp("2026-07-20") - pd.Timedelta(days=90)).strftime("%Y-%m-%d")
+
+    def test_default_buffer_heals_multiweek_outage(self, tmp_path):
+        store = str(tmp_path / "f.parquet")
+        _seed(store, "2026-07-20")
+        # The default buffer must reach well before the last datekey so a missed run
+        # (node offline for weeks) is filled on the next run — not left as a hole.
+        got = pd.Timestamp(_catch_up_since(store_path=store))
+        assert got < pd.Timestamp("2026-07-20") - pd.Timedelta(days=30)
+
+    def test_empty_store_returns_backfill_default(self, tmp_path):
+        store = str(tmp_path / "none.parquet")
+        assert _catch_up_since(store_path=store) == "2015-01-01"
+
+    def test_empty_store_custom_backfill(self, tmp_path):
+        store = str(tmp_path / "none.parquet")
+        assert _catch_up_since(backfill_since="2010-06-01", store_path=store) == "2010-06-01"
+
+
+class TestMainCatchUp:
+    def test_catch_up_overrides_since_from_store(self, monkeypatch):
+        """`--catch-up --from-universe` fetches the universe at the store-derived since."""
+        monkeypatch.setenv("NDL_API_KEY", "k")
+        captured: dict = {}
+
+        def fake_fetch(key, tickers, since):
+            captured["since"] = since
+            captured["tickers"] = tickers
+            return pd.DataFrame()
+
+        monkeypatch.setattr(v3_fundamentals_update, "_universe_tickers", lambda: ["AAPL", "MSFT"])
+        monkeypatch.setattr(
+            v3_fundamentals_update,
+            "store_coverage",
+            lambda *a, **k: {
+                "last": "2026-07-20",
+                "n_rows": 1,
+                "n_tickers": 1,
+                "first": "2016-01-01",
+            },
+        )
+        monkeypatch.setattr(v3_fundamentals_update, "_fetch", fake_fetch)
+        monkeypatch.setattr(v3_fundamentals_update, "append_records", lambda df: 0)
+        monkeypatch.setattr(
+            "sys.argv", ["v3_fundamentals_update.py", "--from-universe", "--catch-up"]
+        )
+
+        v3_fundamentals_update.main()
+
+        assert captured["tickers"] == ["AAPL", "MSFT"]
+        assert captured["since"] == (pd.Timestamp("2026-07-20") - pd.Timedelta(days=90)).strftime(
+            "%Y-%m-%d"
+        )


### PR DESCRIPTION
Adds a store-aware `--catch-up` mode to `v3_fundamentals_update.py`: it derives `--since` from the store's newest datekey minus a 90-day buffer, so a scheduled daily ingest fills any gap **idempotently** and self-heals a missed run.

This is the code half of automating the SF1 PIT fundamentals store refresh on both nodes (Mac + VPS). The store powers the v3 **quality** cluster (the heaviest, 0.42) read live on every factor snapshot; until now it was hand-copied. The ops half (runner + systemd/launchd units) lands in plessas-trading.

- New: `_catch_up_since()` (buffer/backfill-fallback), `--catch-up` CLI flag.
- Tests: 5 new (buffer math, empty-store backfill fallback, main() wiring). Verified live on the Mac: derived since 2026-04-21, appended 10 new filings, idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)