### PR TITLE
fix(v3): show company names for ineligible holdings in Suggested Actions

### DIFF
--- a/tests/unit/trade_modules/test_v3_report.py
+++ b/tests/unit/trade_modules/test_v3_report.py
@@ -236,6 +236,32 @@ def test_render_excludes_ineligible_and_shows_footnote():
     assert "non-equity or insufficient data" in html
 
 
+def test_render_action_card_shows_name_for_ineligible_holding():
+    """A HELD position that is ineligible (e.g. the value-trap gate → SELL) must
+    still show its company NAME in Suggested Actions. The action lookup has to use
+    the FULL scores frame, not the eligible-only subset — otherwise ineligible
+    holdings render with a blank name (the Tokyo-stocks regression)."""
+    scores = _scores_with_etf()
+    scores.loc["GLD", "is_portfolio"] = True  # held, and ineligible → a SELL
+    assert not bool(scores.loc["GLD", "eligible"])  # sanity: ineligible
+    actions = [
+        {
+            "ticker": "GLD",
+            "action": "SELL",
+            "conviction": float("nan"),
+            "current_pct": 0.05,
+            "target_pct": 0.0,
+            "delta_pct": -0.05,
+            "delta_usd": -5000.0,
+        }
+    ]
+    html = render_report(scores, {"regime": "NEUTRAL"}, actions=actions)
+    # GLD is excluded from the overview/candidate sections (ineligible), so its
+    # name can only appear via the SELL action card — proving the action lookup
+    # resolved the ineligible holding's row.
+    assert "SPDR Gold" in html
+
+
 def test_render_shows_trade_levels():
     scores = _scores()
     scores["entry"] = [200.0, 400.0, 10.0]

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -1681,7 +1681,14 @@ def render_report(
             "Suggested Actions",
             "Risk-gated target book vs current holdings · grouped by action",
         ) + _actions_block_cards(
-            actions, scored, conv_scale, bool(meta.get("current_weights_approx"))
+            # Full `scores` (not the eligible-only `scored`): Suggested Actions include
+            # SELLs of INELIGIBLE holdings (e.g. value-trap-gated names). Those rows exist
+            # in the full frame with their native eToro name; resolving against `scored`
+            # would drop them to row=None and render a blank name (the Tokyo-stocks bug).
+            actions,
+            scores,
+            conv_scale,
+            bool(meta.get("current_weights_approx")),
         )
         sec_idx += 1
 


### PR DESCRIPTION
**Bug:** Tokyo holdings (9201.T JAL, 7269.T Suzuki, 6702.T Fujitsu) rendered with a **blank name** in the trio's Factor Snapshot, while others (8001.T ITOCHU, 7012.T Kawasaki) were fine.

**Root cause:** `render_report` filters `scores` to eligible rows (`scored = scores[elig]`) and passed **that filtered frame** to the Suggested-Actions cards. Holdings made **ineligible** — by the overhaul's value-trap gate (fwd P/E > 1.10× trailing → SELL) or insufficient data — aren't in `scored`, so their action card got `row=None` → `name="&nbsp;"`. Every holding *is* in the full `scores` frame with its native eToro name (from etoro.csv), so the fix is to resolve action rows against **full `scores`**. Candidate/overview cards still correctly use eligible-only.

Covers both causes (eligibility gate AND rate-limit/no-data), since `compute_scores` flags rather than drops.

TDD: new `test_render_action_card_shows_name_for_ineligible_holding` (RED → GREEN); 29/29 report tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)