### PR TITLE
fix(v3): enforce market-cap tier caps in the overlay (small-cap sizing)

### DIFF
--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -119,6 +119,9 @@ def _polymarket_signal() -> float | None:
 
 
 _CAP_MODE: str | None = os.environ.get("V3_CAP_MODE") or None
+# Owner sizing: enforce market-cap tier caps (mega 10% .. micro 0.25%) per name so
+# small-caps aren't sized like mega-caps. Default ON; set V3_TIER_CAPS=0 to disable.
+_TIER_CAPS: bool = os.environ.get("V3_TIER_CAPS", "1") != "0"
 
 
 # Owner rule (2026-07-13): sell negative-conviction NON-core names, protect the AI
@@ -613,6 +616,7 @@ def main() -> None:
         noncore_sell_floor=_NONCORE_SELL_FLOOR,
         protect_core=_PROTECT_CORE,
         core_floor=core_floor,
+        tier_name_caps=_TIER_CAPS,
     )
     view = overlay_portfolio_view(overlay, scores)
     actions = build_actions(overlay["weights"], current_weights, scores, nav=nav)

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -73,6 +73,27 @@ def test_classification_bottom_dataless_ineligible_sold_middling_kept():
     assert d["buy_threshold"] == pytest.approx(float(elig_conv.quantile(0.85)))
 
 
+def test_tier_name_caps_hold_small_caps_to_their_market_cap_tier():
+    """tier_name_caps=True sizes each name by its market-cap tier: a high-conviction
+    $0.5B small-cap is capped at 0.5% instead of the flat name_cap. Off = legacy."""
+    tks = ["MEGA", "BIG", "SMALL"]
+    sc = _scored(tks, [2.0, 1.8, 1.9])
+    sc["cap"] = [3.0e12, 5.0e10, 0.5e9]  # $3T mega (10%), $50B large (6%), $0.5B small (0.5%)
+    current = pd.Series(dtype=float)  # empty book -> all three are buys
+    kw = {
+        "max_new": 8,
+        "buy_pctile": 0.0,  # all positive-conviction names qualify as buys
+        "gross_target": 0.95,
+        "name_cap": 0.10,
+        "sector_cap": 0.99,
+        "usd_bloc_cap": 0.99,
+    }
+    on = build_overlay(sc, current, pd.DataFrame(), tier_name_caps=True, **kw)["weights"]
+    off = build_overlay(sc, current, pd.DataFrame(), tier_name_caps=False, **kw)["weights"]
+    assert on.get("SMALL", 0.0) <= 0.005 + 1e-6  # $0.5B -> 0.5% tier
+    assert off.get("SMALL", 0.0) > on.get("SMALL", 0.0)  # tiers trimmed the small-cap
+
+
 def test_sell_negative_noncore_deadband_is_noncore_and_protect_core_spares_percentile():
     """Two distinct owner rules on the core sleeve.
 

--- a/tests/unit/trade_modules/test_v3_risk_gate.py
+++ b/tests/unit/trade_modules/test_v3_risk_gate.py
@@ -123,6 +123,36 @@ def test_caps_to_convergence_all_within_tol():
     assert abs(gated.sum() - 0.90) < _TOL  # feasible caps -> deployment preserved
 
 
+def test_name_caps_enforce_per_name_tier_caps():
+    """A per-name cap vector (market-cap tiers) caps each name at its OWN ceiling:
+    oversized small-caps are trimmed to their tier while a large-cap with headroom
+    absorbs the freed weight. Without the vector, the flat name_cap leaves the
+    small-caps grossly oversized — the small-cap sizing bug."""
+    tickers = ["MEGA", "SMALL", "MICRO"]
+    currencies = ["USD"] * 3
+    sectors = ["TECH"] * 3
+    w = pd.Series([0.30, 0.35, 0.35], index=tickers)  # SMALL/MICRO grossly oversized
+    cov = _cov(np.full(3, 0.15), corr=0.2)  # calm -> vol lever inert
+    tiers = pd.Series([0.90, 0.02, 0.01], index=tickers)  # mega ~uncapped; small/micro tiny
+    kw = {
+        "sectors": sectors,
+        "currencies": currencies,
+        "vol_ceiling": 0.50,
+        "name_cap": 0.90,
+        "sector_cap": 0.99,
+        "usd_bloc_cap": 0.99,
+    }
+    # Control: no tier caps -> the flat 0.90 name_cap lets SMALL stay oversized.
+    base, _ = apply_risk_gate(w, cov, **kw)
+    assert base["SMALL"] > 0.30
+    # With tier caps -> each name within its own tier; small-caps trimmed hard.
+    gated, diag = apply_risk_gate(w, cov, name_caps=tiers, **kw)
+    assert gated["SMALL"] <= 0.02 + _TOL
+    assert gated["MICRO"] <= 0.01 + _TOL
+    assert gated["MEGA"] > w["MEGA"]  # absorbed the redistributed weight
+    assert "tier_caps" in diag["levers_fired"]
+
+
 # --------------------------------------------------------------------------- #
 # (c) lever order — de-weight before gross cut
 # --------------------------------------------------------------------------- #

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -32,7 +32,13 @@ from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
-from trade_modules.v3.construct import _norm_name, _root_of, dedup_dual_listings, region_of
+from trade_modules.v3.construct import (
+    _norm_name,
+    _root_of,
+    _tiered_name_caps,
+    dedup_dual_listings,
+    region_of,
+)
 from trade_modules.v3.risk_gate import apply_risk_gate
 
 # A holding/target weight at or below this is treated as flat (not held).
@@ -213,6 +219,7 @@ def build_overlay(
     max_short_interest: float | None = 20.0,
     min_current_ratio: float | None = 1.0,
     max_de: float | None = None,
+    tier_name_caps: bool = False,
 ) -> dict:
     """Build a minimal keep/sell/buy overlay on the live book, then risk-gate it.
 
@@ -372,6 +379,13 @@ def build_overlay(
             cap_mode=cap_mode,
             caps=caps_ser,
             managed_vol_ceiling=managed_vol_ceiling,
+            # Owner sizing: cap each name at its market-cap tier (mega 10% .. micro 0.25%)
+            # so small-caps can't be sized like mega-caps regardless of conviction.
+            name_caps=(
+                pd.Series(_tiered_name_caps(scored, target_names), index=target_names)
+                if tier_name_caps and scored is not None
+                else None
+            ),
         )
 
         # Deliberate thesis overlay: FLOOR core names at a chosen minimum (their

--- a/trade_modules/v3/risk_gate.py
+++ b/trade_modules/v3/risk_gate.py
@@ -36,7 +36,12 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from trade_modules.riskfirst.construct import apply_name_cap, cap_groups, portfolio_vol
+from trade_modules.riskfirst.construct import (
+    apply_name_cap,
+    apply_name_cap_vec,
+    cap_groups,
+    portfolio_vol,
+)
 from trade_modules.riskfirst.fx import USD_BLOC, cap_bloc
 
 # Parametric-normal 95% Expected Shortfall multiplier: E[Z | Z > z_.95].
@@ -57,6 +62,7 @@ def _clamp_caps(
     name_thr: float,
     bloc_thr: float,
     sector_thr: float,
+    name_caps: np.ndarray | None = None,
     region_arr: np.ndarray | None = None,
     region_thr: float | None = None,
 ) -> np.ndarray:
@@ -70,7 +76,9 @@ def _clamp_caps(
     region -> bloc, all downward, so every later clamp preserves the earlier ones.
     ``region_arr`` / ``region_thr`` are opt-in (None -> region not enforced).
     """
-    w = np.minimum(np.asarray(w, dtype=float).copy(), name_thr)  # per-name -> cash
+    w = np.asarray(w, dtype=float).copy()
+    # Per-name cap: a market-cap tier vector when supplied, else the flat scalar.
+    w = np.minimum(w, name_caps) if name_caps is not None else np.minimum(w, name_thr)
     for lab in dict.fromkeys(sec_arr.tolist()):
         mask = sec_arr == lab
         s = float(w[mask].sum())
@@ -97,10 +105,15 @@ def _caps_to_convergence(
     bloc_thr: float,
     sector_thr: float,
     max_iter: int,
+    name_caps: np.ndarray | None = None,
     region_arr: np.ndarray | None = None,
     region_thr: float | None = None,
 ) -> tuple[np.ndarray, int]:
     """Iterate {name -> USD-bloc -> sector} caps until the weights stop moving.
+
+    ``name_caps`` (per-name absolute cap vector, e.g. market-cap tiers) takes
+    precedence over the scalar ``name_thr`` when supplied — the name step then
+    redistributes each name's excess to headroom via :func:`apply_name_cap_vec`.
 
     Thresholds are ABSOLUTE (``cap * gross``), which for a book whose gross equals
     the caller's deployment target is exactly the proportional cap, and — unlike
@@ -116,7 +129,11 @@ def _caps_to_convergence(
     for _ in range(max_iter):
         iters += 1
         prev = w.copy()
-        w = apply_name_cap(w, name_thr)
+        w = (
+            apply_name_cap_vec(w, name_caps)
+            if name_caps is not None
+            else apply_name_cap(w, name_thr)
+        )
         w = cap_bloc(w, is_bloc, bloc_thr)
         w = cap_groups(w, sec_arr, sector_thr)
         if _has_region:
@@ -130,6 +147,7 @@ def _caps_to_convergence(
         name_thr=name_thr,
         bloc_thr=bloc_thr,
         sector_thr=sector_thr,
+        name_caps=name_caps,
         region_arr=region_arr if _has_region else None,
         region_thr=region_thr if _has_region else None,
     )
@@ -336,6 +354,7 @@ def apply_risk_gate(
     managed_vol_ceiling: float = 0.18,
     regions=None,
     region_cap: float | None = None,
+    name_caps: pd.Series | np.ndarray | None = None,
 ) -> tuple[pd.Series, dict]:
     """Enforce the vol ceiling + concentration caps on a constructed book.
 
@@ -620,6 +639,37 @@ def apply_risk_gate(
             levers_fired.append("gross_cut")
     else:
         raise ValueError(f"Unknown cap_mode: {cap_mode!r}")
+
+    # --- 3b. per-name market-cap tier caps (owner sizing) --------------------- #
+    # Final joint {name-tier -> bloc -> sector} convergence. Tier caps only SHRINK
+    # oversized (small-cap) names, so vol is non-increasing and the ceiling enforced
+    # above still holds; each name's excess redistributes to headroom (apply_name_cap_vec)
+    # so the book stays deployed rather than dropping the trim to cash.
+    if name_caps is not None:
+        _nc_ser = (
+            name_caps
+            if isinstance(name_caps, pd.Series)
+            else pd.Series(list(name_caps), index=index)
+        )
+        _nc = pd.to_numeric(_nc_ser.reindex(index), errors="coerce").to_numpy()
+        # cap = min(flat name_cap, tier cap); NaN tier -> flat name_cap. Absolute basis (x gross).
+        _nc = np.where(np.isfinite(_nc), np.minimum(_nc, name_cap), name_cap) * g_target
+        _w_pre_tier = w.copy()
+        w, ci = _caps_to_convergence(
+            w,
+            sec_arr,
+            is_bloc,
+            name_thr=name_thr,
+            bloc_thr=bloc_thr,
+            sector_thr=sector_thr,
+            max_iter=max_iter,
+            name_caps=_nc,
+            region_arr=region_arr,
+            region_thr=region_thr,
+        )
+        caps_iter_total += ci
+        if np.max(np.abs(w - _w_pre_tier)) > _STABLE_TOL:
+            levers_fired.append("tier_caps")
 
     # Invariant: the gate only vetoes/shrinks. Cap-excess redistribution (incl. the
     # initial concentration-caps pass) is conviction-blind and can nudge a disliked


### PR DESCRIPTION
**Bug:** the Factor Snapshot suggested small-caps at mega-cap sizes — **Wickes (£419M) at 8.4%**, Karooooo ($2B) at 2.3%, plus several mid-caps above their 2% tier.

**Root cause:** the overlay caps every name at the flat `name_cap` (0.10) and relies on `cap_ordered`, which is a **vol-ceiling lever** (trims smallest-cap first *only when over the vol ceiling*), not a per-name size cap. The market-cap tier caps (mega 10% .. micro 0.25%) existed only in `build_portfolio`'s opt-in `sizing_tilt`, never the overlay path.

**Fix:** add an optional per-name `name_caps` vector to `apply_risk_gate` — a **final** joint name(tier)→bloc→sector convergence after the vol levers, reusing the tested `apply_name_cap_vec`. Tiers only *shrink* oversized names, so the vol ceiling still holds; each name's excess redistributes to headroom so the book stays deployed. `build_overlay` gains `tier_name_caps` (→ `_tiered_name_caps`); `v3_overlay_report` enables it (`V3_TIER_CAPS`, default on).

TDD: gate-level test (per-name tiers enforced + redistribution) and overlay wiring test; 41 gate/overlay tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)