### PR TITLE
fix(fx): resolve Nordic listing currencies (.ST/.OL/.CO)

### DIFF
--- a/tests/unit/trade_modules/test_riskfirst_fx.py
+++ b/tests/unit/trade_modules/test_riskfirst_fx.py
@@ -7,7 +7,13 @@ HKD is USD-pegged, so it counts in the USD bloc.
 import numpy as np
 import pytest
 
-from trade_modules.riskfirst.fx import bloc_exposure, cap_bloc, currency_of, hedge_advisory
+from trade_modules.riskfirst.fx import (
+    USD_BLOC,
+    bloc_exposure,
+    cap_bloc,
+    currency_of,
+    hedge_advisory,
+)
 
 
 def test_currency_inference():
@@ -16,6 +22,16 @@ def test_currency_inference():
     assert currency_of("SAP.DE") == "EUR"
     assert currency_of("0700.HK") == "HKD"
     assert currency_of("7012.T") == "JPY"
+    # Nordic listings float against the EUR -> resolve to their OWN currency so the
+    # USD cap/ADV normalization applies the right rate (Investor AB is ~$115B, not $1.3T).
+    assert currency_of("INVE-A.ST") == "SEK"
+    assert currency_of("EQNR.OL") == "NOK"
+    assert currency_of("NOVO-B.CO") == "DKK"
+    # genuine eurozone listings stay EUR
+    assert currency_of("ASML.AS") == "EUR"
+    assert currency_of("NESTE.HE") == "EUR"
+    # all of them remain OUTSIDE the USD bloc (bloc classification unchanged)
+    assert not any(currency_of(t) in USD_BLOC for t in ("INVE-A.ST", "EQNR.OL", "NOVO-B.CO"))
 
 
 def test_bloc_exposure_counts_usd_and_hkd():

--- a/trade_modules/riskfirst/fx.py
+++ b/trade_modules/riskfirst/fx.py
@@ -13,21 +13,32 @@ from __future__ import annotations
 
 import numpy as np
 
+# Genuine eurozone listings (share the EUR rate). Nordic exchanges are NOT here:
+# SEK/NOK float and DKK is only EUR-pegged, so their market-cap / ADV USD normalization
+# needs their OWN rate — mapping them to EUR overstated Nordic caps ~7-11x (Investor AB
+# read as $1.3T instead of ~$115B, so its market-cap tier cap was mega instead of large).
 _EUR_SUFFIXES = {
     ".DE",
     ".PA",
     ".MI",
     ".AS",
     ".MC",
-    ".OL",
-    ".ST",
-    ".CO",
     ".HE",
     ".LS",
     ".BR",
     ".VI",
 }
-_SUFFIX_CCY = {".L": "GBP", ".HK": "HKD", ".T": "JPY", ".SW": "CHF", ".TO": "CAD", ".AX": "AUD"}
+_SUFFIX_CCY = {
+    ".L": "GBP",
+    ".HK": "HKD",
+    ".T": "JPY",
+    ".SW": "CHF",
+    ".TO": "CAD",
+    ".AX": "AUD",
+    ".ST": "SEK",  # Stockholm
+    ".OL": "NOK",  # Oslo
+    ".CO": "DKK",  # Copenhagen (EUR-pegged, but its own rate for cap normalization)
+}
 
 # Currencies that move with (or are pegged to) the US dollar for a EUR investor.
 USD_BLOC = frozenset({"USD", "HKD"})


### PR DESCRIPTION
Follow-on to #170 (tier caps). With tiers enforced, INVE-A.ST (Investor AB) still appeared as an **8.4% buy** — because `currency_of` mapped Stockholm/Oslo/Copenhagen (.ST/.OL/.CO) to **EUR**, so their market caps were USD-normalized at 1.08 instead of SEK/NOK/DKK (~0.095), overstating Nordic caps **7-11×**. Investor AB read as $1.3T (mega, 10% cap) instead of ~$115B (large, 6%), so its buy escaped the tier cap.

Map `.ST→SEK`, `.OL→NOK`, `.CO→DKK` (all already in `_USD_RATE`). USD-bloc classification is unchanged (SEK/NOK/DKK remain non-USD, exactly like EUR). The v2 `fx_sizing.currency_for_ticker` is a separate function and untouched. TDD: currency_of Nordic assertions; 85 fx/construct/overlay tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)