### PR TITLE
feat(v3): scheduled mail = compact summary body + browser snapshot attached

### DIFF
--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -57,7 +57,7 @@ from trade_modules.v3.features import enrich_features  # noqa: E402
 from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
 from trade_modules.v3.overlay import build_overlay  # noqa: E402
 from trade_modules.v3.report import compute_regime, render_report  # noqa: E402
-from trade_modules.v3.report_email import render_email_report  # noqa: E402
+from trade_modules.v3.report_email import render_email_report, render_summary  # noqa: E402
 
 PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
 BUY_CSV = "yahoofinance/output/buy.csv"
@@ -675,6 +675,15 @@ def main() -> None:
     with open(email_out, "w", encoding="utf-8") as fh:
         fh.write(email_html)
     print(f"overlay email  -> {email_out}")
+
+    # Compact summary body for the scheduled mail: the wrapper mails THIS as the body
+    # and attaches the full browser report above (which renders identically to the trio
+    # snapshot). Called after render_email_report so each action carries its _full_name.
+    summary_html = render_summary(meta, actions, portfolio=view)
+    summary_out = os.path.join(_OUT_DIR, f"{stamp}_v3_overlay_summary.html")
+    with open(summary_out, "w", encoding="utf-8") as fh:
+        fh.write(summary_html)
+    print(f"overlay summary -> {summary_out}")
 
     # Always emit the offline synthetic preview alongside the live report.
     write_preview()

--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -27,17 +27,17 @@ V3_FLOOR_CORE=0 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
 V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 \
   .venv/bin/python scripts/v3_overlay_report.py
 
-# 3) Email the freshest report — the Outlook-safe EMAIL edition (table-based,
-#    inline styles), not the browser HTML which the Outlook body sanitizer breaks.
-#    This edition is now at FULL info-parity with the browser attachment (conviction
-#    heatmap + full per-stock factor cards + trade levels). It is the ONLY thing this
-#    scheduled job mails. The other two of the trio are on-demand (sent WITH the snapshot
-#    only when the owner asks for "all three files"): the pipeline map (v3_pipeline_map.py)
-#    and the MASTER TAXONOMY (v3_master_taxonomy.py — factors x dimensions x weights;
-#    replaced the old factor-backtest file as the 3rd member 2026-07-21).
-REPORT="$(ls -t "$HOME/Downloads/"*_v3_overlay_email.html 2>/dev/null | head -1 || true)"
-if [ -z "${REPORT:-}" ]; then
-  echo "ERROR: no v3 overlay email report produced" >&2
+# 3) Email the scheduled Factor Snapshot. BODY = the compact Outlook-safe summary
+#    (regime, buy/keep/sell counts, deployment, vol, one-line action table). The FULL
+#    browser Factor Snapshot — IDENTICAL to the trio's attachment (conviction heatmap +
+#    per-stock factor cards + trade levels) — rides along as an HTML ATTACHMENT: it
+#    can't be the email body because its modern CSS breaks the Outlook sanitizer.
+#    (Owner choice 2026-07-22: "attach + short summary".) The other two of the trio
+#    (v3_pipeline_map.py + v3_master_taxonomy.py) stay on-demand.
+SUMMARY="$(ls -t "$HOME/Downloads/"*_v3_overlay_summary.html 2>/dev/null | head -1 || true)"
+SNAPSHOT="$(ls -t "$HOME/Downloads/"*_v3_overlay_report.html 2>/dev/null | head -1 || true)"
+if [ -z "${SUMMARY:-}" ] || [ -z "${SNAPSHOT:-}" ]; then
+  echo "ERROR: no v3 overlay summary/report produced" >&2
   exit 1
 fi
 
@@ -46,7 +46,8 @@ SUBJECT="trading model v3 · factor snapshot $(TZ=Europe/Athens date '+%Y-%m-%d 
 ~/scripts/outlook-cli send-mail \
   --to dimitrios.plessas@nbg.gr \
   --subject "$SUBJECT" \
-  --html "$REPORT" \
+  --html "$SUMMARY" \
+  --attach "$SNAPSHOT" \
   --send-now --no-signature
 
-echo "OK: emailed $(basename "$REPORT") ($(wc -c < "$REPORT" | tr -d ' ') bytes)"
+echo "OK: emailed summary $(basename "$SUMMARY") + attached $(basename "$SNAPSHOT")"

--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -176,6 +176,28 @@ def _view() -> dict:
     }
 
 
+def test_render_summary_is_compact_and_outlook_safe():
+    html = rem.render_summary(_meta(), _actions(), portfolio=_view())
+    # Header: regime + counts + deployment.
+    assert "RISK_ON" in html
+    assert "buy" in html and "sell" in html
+    assert "84" in html  # deployment gross_after 0.84 -> 84.0%
+    # Action rows carry ticker + action.
+    assert "AAA" in html and "BUY" in html
+    assert "BBB" in html and "SELL" in html
+    # Compact: none of the heavy structural sections (the words may appear in the
+    # "full snapshot attached" note, but the actual heatmap rows / factor cards must not).
+    assert "hm-row" not in html  # no heatmap rows
+    assert "All factors" not in html  # no per-stock factor-card details
+    assert "ac-strip" not in html and "cluster-strip" not in html  # no card internals
+    # Outlook-safe: no unsupported CSS.
+    for bad in ("display:flex", "display:grid", "<details", ":hover", "@keyframes"):
+        assert bad not in html
+    # Points at the attached full snapshot; well-formed doc.
+    assert "attach" in html.lower()
+    assert html.startswith("<!DOCTYPE") and "</html>" in html
+
+
 def test_render_email_is_outlook_safe():
     html = rem.render_email_report(
         _scores(),

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -740,3 +740,132 @@ def render_email_report(
         f"Trading Model v3 &middot; generated on the VPS &middot; {date}</td></tr>"
         "</table></td></tr></table></body></html>"
     )
+
+
+def render_summary(
+    meta: dict,
+    actions: list,
+    *,
+    portfolio: dict | None = None,
+) -> str:
+    """Compact Outlook-safe summary body for the scheduled 4h mail.
+
+    Masthead + regime / buy-keep-sell counts / deployment / vol, then a
+    one-line-per-name action table (BUY/ADD/TRIM/SELL). The FULL browser Factor
+    Snapshot (heatmap, per-stock factor cards, trade levels) rides along as the
+    attachment. Call after :func:`render_email_report` so each action already carries
+    ``_full_name``; falls back to the eToro name / ticker otherwise.
+    """
+    meta = meta or {}
+    actions = actions or []
+    diag = ((portfolio or {}).get("diagnostics") or {}).get("gate") or {}
+    by_action: dict[str, list] = {k: [] for k in ACTION_ORDER}
+    for a in actions:
+        by_action.setdefault(a.get("action"), []).append(a)
+    c = {k: len(v) for k, v in by_action.items()}
+    keep = c.get("ADD", 0) + c.get("TRIM", 0) + c.get("HOLD", 0)
+    regime = _esc(str(meta.get("regime", "")).upper())
+    gen = _esc(meta.get("generated_utc", ""))
+    date = _esc(meta.get("date", ""))
+    dep = _pct1(diag.get("gross_after"))
+    vol = _pct1(diag.get("vol_after"))
+
+    head = (
+        f'<div style="font-family:{FONT};font-size:10.5px;font-weight:700;letter-spacing:1.4px;'
+        f'text-transform:uppercase;color:{ACCENT};">Trading Model v3</div>'
+        f'<div style="font-family:{FONT};font-size:25px;font-weight:800;color:{INK};'
+        f'line-height:1.08;margin-top:3px;">Factor Snapshot</div>'
+        f'<div style="border-top:2px solid {INK};width:44px;font-size:0;line-height:0;'
+        f'margin:12px 0;">&nbsp;</div>'
+        f'<div style="font-family:{FONT};font-size:12.5px;color:{INK2};line-height:1.7;">'
+        f'Regime <b style="color:{INK};">{regime}</b> &middot; '
+        f'<b style="color:{BULL};">{c.get("BUY", 0)}</b> buy &middot; {keep} keep &middot; '
+        f'<b style="color:{BEAR};">{c.get("SELL", 0)}</b> sell &middot; '
+        f'deployment <b style="color:{INK};">{dep}</b> &middot; vol {vol}</div>'
+        f'<div style="font-family:{FONT};font-size:11px;color:{MUTED};margin-top:3px;">{gen}</div>'
+    )
+
+    def _th(label: str, align: str = "left", pr: str = "8px") -> str:
+        return (
+            f'<td style="padding:0 {pr} 7px 0;font-family:{FONT};font-size:10px;font-weight:700;'
+            f"text-transform:uppercase;letter-spacing:.5px;color:{MUTED};"
+            f'text-align:{align};">{label}</td>'
+        )
+
+    def _conv(a: dict) -> float:
+        """Conviction as a float; NaN when absent/unparseable (renders as a dot)."""
+        try:
+            return float(a.get("conviction"))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return float("nan")
+
+    def _sort_key(a: dict) -> float:
+        v = _conv(a)
+        return -abs(v) if v == v else 0.0  # NaN sorts last
+
+    trs = []
+    for act in ("BUY", "ADD", "TRIM", "SELL"):
+        color = ACTION_META[act][0]
+        for a in sorted(by_action.get(act, []), key=_sort_key):
+            tkr = _esc(a.get("ticker", ""))
+            nm = _esc(a.get("_full_name") or a.get("name") or a.get("ticker", ""))
+            cur, tgt = _pct1(a.get("current_pct")), _pct1(a.get("target_pct"))
+            cvf = _conv(a)
+            conv_s = f"{cvf:+.2f}" if cvf == cvf else "&middot;"  # NaN -> dot
+            bt = f"border-top:1px solid {LINE};"
+            trs.append(
+                "<tr>"
+                f'<td style="padding:7px 8px 7px 0;{bt}"><span style="font-family:{FONT};'
+                f'font-size:11px;font-weight:800;color:{color};">{act}</span></td>'
+                f'<td style="padding:7px 8px;{bt}font-family:{MONO};font-size:12px;'
+                f'font-weight:700;color:{INK};">{tkr}</td>'
+                f'<td style="padding:7px 8px;{bt}font-family:{FONT};font-size:12px;'
+                f'color:{INK2};">{nm}</td>'
+                f'<td style="padding:7px 8px;{bt}font-family:{MONO};font-size:12px;'
+                f'color:{INK2};white-space:nowrap;">{cur} &#8594; {tgt}</td>'
+                f'<td style="padding:7px 0 7px 8px;{bt}font-family:{MONO};font-size:12px;'
+                f'color:{INK2};text-align:right;">{conv_s}</td>'
+                "</tr>"
+            )
+    table = (
+        (
+            '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
+            'style="border-collapse:collapse;margin-top:18px;"><tr>'
+            + _th("")
+            + _th("Ticker")
+            + _th("Name")
+            + _th("Current &#8594; Target")
+            + _th("Conv", "right", "0")
+            + "</tr>"
+            + "".join(trs)
+            + "</table>"
+        )
+        if trs
+        else ""
+    )
+
+    note = (
+        f'<div style="font-family:{FONT};font-size:11.5px;color:{INK2};margin-top:18px;'
+        f'padding-top:12px;border-top:1px solid {LINE};line-height:1.6;">The full '
+        f"<b>Factor Snapshot</b> &mdash; conviction heatmap, per-stock factor cards and trade "
+        f"levels &mdash; is <b>attached</b> as HTML; open it in a browser for the complete view. "
+        f"{c.get('HOLD', 0)} held name{'s' if c.get('HOLD', 0) != 1 else ''} maintained.</div>"
+    )
+
+    body = head + table + note
+    return (
+        '<!DOCTYPE html><html><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        "<title>Trading Model v3 · Factor Snapshot</title></head>"
+        f'<body style="margin:0;padding:0;background:{WARM};">'
+        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
+        f'style="border-collapse:collapse;background:{WARM};"><tr>'
+        f'<td align="center" style="padding:22px 12px;">'
+        f'<table role="presentation" width="{CONTENT_W}" cellpadding="0" cellspacing="0" border="0" '
+        f'style="border-collapse:collapse;width:{CONTENT_W}px;max-width:100%;">'
+        f'<tr><td bgcolor="{CANVAS}" style="background:{CANVAS};border:1px solid {LINE};'
+        f'border-radius:14px;padding:30px 32px;">{body}</td></tr>'
+        f'<tr><td style="padding:14px 4px;font-family:{FONT};font-size:10px;color:{MUTED};'
+        f'text-align:center;">Trading Model v3 &middot; generated on the VPS &middot; {date}</td></tr>'
+        "</table></td></tr></table></body></html>"
+    )


### PR DESCRIPTION
Owner request: make the 4h scheduled mail match the browser Factor Snapshot (the trio attachment). That HTML can't be an Outlook email body (its flex/grid/animations break the sanitizer), so — per the chosen option (**attach + short summary**) — the scheduled mail now:

- **Body:** a compact, Outlook-safe summary — masthead + regime, buy/keep/sell counts, deployment, vol, and a one-line-per-name action table (BUY/ADD/TRIM/SELL, ticker · name · current→target · conviction).
- **Attachment:** the full browser Factor Snapshot (`*_v3_overlay_report.html`) — byte-identical to the trio's snapshot (heatmap + per-stock factor cards + trade levels), opens perfectly in a browser.

New `render_summary()` in `report_email` (reuses the palette/helpers; no flex/grid/details/hover). `v3_overlay_report` emits `{stamp}_v3_overlay_summary.html`; `run-v3-report.sh` sends summary-as-body + attaches the browser report. TDD: `test_render_summary_is_compact_and_outlook_safe`; 5 email tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)