### PR TITLE
feat(v3): analyst-momentum + trajectory buy vetoes; micro-cap tier to $1B

### DIFF
--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -910,15 +910,19 @@ def test_apply_name_cap_vec_per_name_caps_preserve_total():
 
 
 def test_tiered_name_caps_by_market_cap():
-    """Market-cap-tier single-name caps: mega 0.10 down to micro 0.0025; unknown -> 0.06."""
+    """Market-cap-tier single-name caps: mega 0.10 down to micro 0.0025; unknown -> 0.06.
+
+    The small/micro boundary is $1B (owner 2026-07-22): a $0.5B name (WIX/NRDS range)
+    caps at 0.0025, a $1B name at 0.005.
+    """
     from trade_modules.v3.construct import _tiered_name_caps
 
     scored = pd.DataFrame(
-        {"cap": [5e11, 5e10, 5e9, 1e9, 1e8, np.nan]},
-        index=["MEGA", "LARGE", "MID", "SMALL", "MICRO", "UNK"],
+        {"cap": [5e11, 5e10, 5e9, 1e9, 5e8, 1e8, np.nan]},
+        index=["MEGA", "LARGE", "MID", "SMALL", "TINY", "MICRO", "UNK"],
     )
     caps = _tiered_name_caps(scored, list(scored.index))
-    assert list(caps) == [0.10, 0.06, 0.02, 0.005, 0.0025, 0.06]
+    assert list(caps) == [0.10, 0.06, 0.02, 0.005, 0.0025, 0.0025, 0.06]
 
 
 def test_div_tilt_moderate_upsizes_extreme_yield_flagged():

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -485,3 +485,35 @@ def test_fixnow_screen_tolerates_missing_data_and_spares_holdings():
     sc2.loc["U10", "short_interest"] = 90.0  # held + very high SI
     held = build_overlay(sc2, current, pd.DataFrame(), max_new=2)["diagnostics"]
     assert "U10" not in held["sold"] and "U10" in held["kept"]
+
+
+def test_analyst_mom_veto_excludes_downgraded_buy():
+    """A strong non-held candidate with strongly negative analyst momentum (AM <= -3)
+    and enough coverage (n_analysts >= 4) is screened from buys; a thin-coverage name
+    with the same AM is NOT vetoed (needs a meaningful analyst count)."""
+    _tks, _convs, sc = _universe20()
+    sc["analyst_mom"] = np.nan
+    sc["n_analysts"] = np.nan
+    sc.loc["U00", ["analyst_mom", "n_analysts"]] = [-3.0, 6.0]  # -3 from 6 analysts -> veto
+    sc.loc["U01", ["analyst_mom", "n_analysts"]] = [-5.0, 2.0]  # strong neg but thin -> kept
+    current = pd.Series({"U10": 0.3})
+
+    d = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert "U00" not in d["bought"]  # vetoed on analyst momentum
+    assert "U00" in d.get("screened_out", [])
+    assert "U01" in d["bought"]  # thin coverage -> not vetoed
+
+
+def test_trajectory_guard_excludes_rising_forward_pe_buy():
+    """A buy whose forward P/E is materially above trailing (earn_trajectory = PET/PEF
+    below ~0.95, i.e. fwd P/E > 1.05x trailing -> earnings expected to fall) is screened;
+    a positive-trajectory candidate is bought instead."""
+    _tks, _convs, sc = _universe20()
+    sc["earn_trajectory"] = np.nan
+    sc.loc["U00", "earn_trajectory"] = 0.90  # fwd P/E ~11% above trailing -> value-trap-ish
+    current = pd.Series({"U10": 0.3})
+
+    d = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]
+    assert "U00" not in d["bought"]
+    assert "U00" in d.get("screened_out", [])
+    assert set(d["bought"]) == {"U01", "U02"}

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -385,8 +385,8 @@ _MCAP_TIER_CAPS = [
     (200e9, 0.10),  # mega  > $200B
     (20e9, 0.06),  # large $20-200B
     (2e9, 0.02),  # mid   $2-20B
-    (0.3e9, 0.005),  # small $0.3-2B
-    (0.0, 0.0025),  # micro < $0.3B
+    (1e9, 0.005),  # small $1-2B
+    (0.0, 0.0025),  # micro < $1B (owner 2026-07-22: sub-$1B too small -> 0.25% cap)
 ]
 _UNKNOWN_MCAP_CAP = 0.06  # unknown market cap -> large-tier cap (not specially punished)
 

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -76,6 +76,7 @@ _NATIVE_NUM = {
     "PP": "price_perf",
     "SI": "short_interest",
     "AM": "analyst_mom",
+    "#A": "n_analysts",  # analyst count — coverage floor for the analyst-momentum buy veto
     "EG": "earn_growth",
     "DV": "div_yield",
     "UP%": "upside",

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -154,6 +154,9 @@ def _screen_buy_candidates(
     max_short_interest: float | None,
     min_current_ratio: float | None,
     max_de: float | None,
+    min_analyst_mom: float | None = None,
+    min_analyst_n: int = 4,
+    min_earn_trajectory: float | None = None,
 ) -> tuple[list[str], list[str]]:
     """FIX-NOW 2026-07-18 (D4/D8): drop squeeze-risky / distressed names from the BUY
     pool. Applied to buys ONLY — never force-sells a holding.
@@ -161,9 +164,16 @@ def _screen_buy_candidates(
     A candidate is screened out when ANY active criterion trips:
       * short_interest (% of float) > ``max_short_interest``  — squeeze/borrow risk;
       * current_ratio < ``min_current_ratio``                 — distress (illiquid);
-      * de > ``max_de``                                       — distress (over-levered).
+      * de > ``max_de``                                       — distress (over-levered);
+      * analyst_mom <= ``min_analyst_mom`` AND n_analysts >= ``min_analyst_n`` — the
+        Street is actively downgrading the name with meaningful coverage (owner
+        2026-07-22). Asymmetric: we reject active downgrades but never *require*
+        positive coverage (that would anti-select momentum winners);
+      * earn_trajectory (= trailing/forward P/E) < ``min_earn_trajectory`` — forward
+        P/E materially above trailing, i.e. earnings expected to FALL (value-trap tilt;
+        owner 2026-07-22). Use ``1/1.05`` to block a > 1.05x forward/trailing rise.
     A criterion whose param is ``None`` is off; an absent column or NaN value never
-    excludes (missing data is not treated as distress). Returns (kept, screened_out).
+    excludes (missing data is not treated as a red flag). Returns (kept, screened_out).
     """
     if scored is None or not cand_list:
         return cand_list, []
@@ -180,10 +190,22 @@ def _screen_buy_candidates(
     out: list[str] = []
     for t in cand_list:
         si, cr, de = _val(t, "short_interest"), _val(t, "current_ratio"), _val(t, "de")
+        am, na, traj = _val(t, "analyst_mom"), _val(t, "n_analysts"), _val(t, "earn_trajectory")
         squeeze = max_short_interest is not None and pd.notna(si) and si > max_short_interest
         illiquid = min_current_ratio is not None and pd.notna(cr) and cr < min_current_ratio
         levered = max_de is not None and pd.notna(de) and de > max_de
-        (out if (squeeze or illiquid or levered) else kept).append(t)
+        downgraded = (
+            min_analyst_mom is not None
+            and pd.notna(am)
+            and am <= min_analyst_mom
+            and pd.notna(na)
+            and na >= min_analyst_n
+        )
+        value_trap = (
+            min_earn_trajectory is not None and pd.notna(traj) and traj < min_earn_trajectory
+        )
+        excluded = squeeze or illiquid or levered or downgraded or value_trap
+        (out if excluded else kept).append(t)
     return kept, out
 
 
@@ -219,6 +241,9 @@ def build_overlay(
     max_short_interest: float | None = 20.0,
     min_current_ratio: float | None = 1.0,
     max_de: float | None = None,
+    min_analyst_mom: float | None = -3.0,  # owner 2026-07-22: veto buys the Street is downgrading
+    min_analyst_n: int = 4,  # ...only when coverage is meaningful (>=4 analysts)
+    min_earn_trajectory: float | None = 1.0 / 1.05,  # veto buys w/ fwd P/E > 1.05x trailing
     tier_name_caps: bool = False,
 ) -> dict:
     """Build a minimal keep/sell/buy overlay on the live book, then risk-gate it.
@@ -333,6 +358,9 @@ def build_overlay(
             max_short_interest=max_short_interest,
             min_current_ratio=min_current_ratio,
             max_de=max_de,
+            min_analyst_mom=min_analyst_mom,
+            min_analyst_n=min_analyst_n,
+            min_earn_trajectory=min_earn_trajectory,
         )
         bought = cand_list[: int(max_new)]
 


### PR DESCRIPTION
Owner overlay after reviewing the buy list name-by-name (all three are BUY-side only — never force-sell a holding):

- **Analyst-momentum veto:** block a new buy when `analyst_mom <= -3` and `>=4` analysts cover it → removes **CARG** (−3/6) and **DVA** (−12/8). Asymmetric by design: we reject names the Street is *actively downgrading* but never *require* positive coverage (that's what caused the momentum anti-selection we avoided earlier).
- **Trajectory guard:** block a new buy when `earn_trajectory < 1/1.05` (forward P/E > 1.05× trailing → earnings expected to fall) → removes **THC** (~1.08×). The harder 1.10× value-trap gate on *held* names is unchanged.
- **Micro-cap tier boundary $0.3B → $1B:** sub-$1B names cap at 0.25% (WIX ~$537M, NRDS $600M were at 0.5%). Note: WIX shows "423M" but that's £423M ≈ $537M — a literal $500M floor wouldn't catch it, so the boundary is $1B.

Adds `n_analysts` (#A) feature for the coverage floor. TDD: analyst-veto + trajectory-guard overlay tests, updated tier test; 107 construct/overlay/combine/fundamentals tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)