### PR TITLE
feat(v3): conviction floor + portfolio-aware buy selection

### DIFF
--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -122,6 +122,11 @@ _CAP_MODE: str | None = os.environ.get("V3_CAP_MODE") or None
 # Owner sizing: enforce market-cap tier caps (mega 10% .. micro 0.25%) per name so
 # small-caps aren't sized like mega-caps. Default ON; set V3_TIER_CAPS=0 to disable.
 _TIER_CAPS: bool = os.environ.get("V3_TIER_CAPS", "1") != "0"
+# Owner 2026-07-22 selection overlay: an absolute conviction floor for new buys (only
+# show genuinely strong names, not just top-percentile-of-a-weak-day) + portfolio-aware
+# selection (skip at-cap sectors; tilt buys toward under-weight sectors/markets).
+_MIN_CONVICTION: float = float(os.environ.get("V3_MIN_CONVICTION", "1.0"))
+_PORTFOLIO_AWARE: bool = os.environ.get("V3_PORTFOLIO_AWARE", "1") != "0"
 
 
 # Owner rule (2026-07-13): sell negative-conviction NON-core names, protect the AI
@@ -617,6 +622,8 @@ def main() -> None:
         protect_core=_PROTECT_CORE,
         core_floor=core_floor,
         tier_name_caps=_TIER_CAPS,
+        min_conviction=_MIN_CONVICTION,
+        portfolio_aware=_PORTFOLIO_AWARE,
     )
     view = overlay_portfolio_view(overlay, scores)
     actions = build_actions(overlay["weights"], current_weights, scores, nav=nav)

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -504,6 +504,52 @@ def test_analyst_mom_veto_excludes_downgraded_buy():
     assert "U01" in d["bought"]  # thin coverage -> not vetoed
 
 
+def test_conviction_floor_trims_marginal_percentile_buys():
+    """A name can clear the buy percentile yet be below the absolute conviction floor
+    -> not bought. Floor trims the weakest buys (protects weak-universe days)."""
+    _tks, _convs, sc = _universe20()  # conviction linspace +2.0 .. -2.0
+    current = pd.Series({"U19": 0.3})  # hold the worst so the top names are candidates
+    # buy_pctile=0.0 isolates the floor from the percentile (top-5 vs floor>=1.5 -> top-3).
+    base = build_overlay(sc, current, pd.DataFrame(), max_new=5, buy_pctile=0.0)["diagnostics"]
+    floored = build_overlay(
+        sc, current, pd.DataFrame(), max_new=5, buy_pctile=0.0, min_conviction=1.5
+    )["diagnostics"]
+    assert len(floored["bought"]) < len(base["bought"])  # floor removed marginal buys
+    for t in floored["bought"]:
+        assert float(sc.loc[t, "conviction"]) >= 1.5  # every survivor clears the floor
+
+
+def test_portfolio_aware_skips_at_cap_sector():
+    """A buy candidate whose sector is already AT the sector cap in the current book is
+    skipped (the risk gate would zero it) — buys flow to names with room instead."""
+    _tks, _convs, sc = _universe20()
+    sc["sector"] = "Energy"
+    sc.loc[["U01", "U02", "U00"], "sector"] = "Technology"  # incl. the strongest (U00)
+    current = pd.Series({"U01": 0.35, "U02": 0.35})  # held Tech (high conv -> kept) => Tech at cap
+    d = build_overlay(
+        sc, current, pd.DataFrame(), max_new=3, portfolio_aware=True, sector_cap=0.35
+    )["diagnostics"]
+    assert "U00" not in d["bought"]  # Tech is at cap -> strongest Tech candidate skipped
+    assert all(sc.loc[t, "sector"] == "Energy" for t in d["bought"])  # buys go to Energy
+
+
+def test_portfolio_aware_tiebreaker_prefers_underweight_sector():
+    """Between two near-conviction candidates, the one in the less-crowded sector is
+    ranked ahead — conviction stays primary, crowding only breaks near-ties."""
+    sc = _scored(
+        ["A", "B", "C", "D"],
+        [1.5, 1.4, 1.8, 1.7],
+        sectors=["Technology", "Energy", "Technology", "Financial Services"],
+    )
+    current = pd.Series({"C": 0.4, "D": 0.4})  # held, high conv -> kept: book 50% Tech / 50% Fin
+    base = build_overlay(sc, current, pd.DataFrame(), max_new=1, buy_pctile=0.0)["diagnostics"]
+    assert base["bought"] == ["A"]  # plain top-conviction
+    pa = build_overlay(
+        sc, current, pd.DataFrame(), max_new=1, buy_pctile=0.0, portfolio_aware=True, sector_cap=0.9
+    )["diagnostics"]
+    assert pa["bought"] == ["B"]  # A (crowded Tech) penalized below B (empty Energy)
+
+
 def test_trajectory_guard_excludes_rising_forward_pe_buy():
     """A buy whose forward P/E is materially above trailing (earn_trajectory = PET/PEF
     below ~0.95, i.e. fwd P/E > 1.05x trailing -> earnings expected to fall) is screened;

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -209,6 +209,74 @@ def _screen_buy_candidates(
     return kept, out
 
 
+# Portfolio-aware buy selection (owner 2026-07-22): tilt the SHOWN buys toward what the
+# book needs, not just standalone score. Crowding = current-book group weight / group cap;
+# the tilt strengths are in conviction units, kept small so conviction stays primary.
+_DIV_TILT_SECTOR = 0.5
+_DIV_TILT_REGION = 0.3
+_SELECT_REGION_CAP = 0.65
+
+
+def _portfolio_aware_order(
+    cand_list: list[str],
+    scored: pd.DataFrame,
+    current: pd.Series,
+    conv: pd.Series,
+    *,
+    sector_cap: float,
+    region_cap: float,
+) -> tuple[list[str], list[str]]:
+    """Re-order buy candidates by portfolio FIT, not standalone conviction.
+
+    Using the current book's sector + region exposure (as a fraction of the invested
+    book): (1) SKIP a candidate whose sector or region is already at its cap — the risk
+    gate would zero it at sizing anyway, so surfacing it is a wasted recommendation;
+    (2) re-rank the rest by conviction minus a mild crowding penalty
+    (``_DIV_TILT_* * group_weight / group_cap``) so buys tilt toward UNDER-weight
+    sectors/markets. Conviction stays primary — the penalty only re-orders near-ties,
+    never buys a weak name to diversify. Returns (reordered_kept, skipped).
+    """
+    if scored is None or not cand_list:
+        return cand_list, []
+    held = [t for t in current.index if float(current.get(t, 0.0)) > _EPS]
+    invested = float(sum(float(current[t]) for t in held)) or 1.0
+
+    def _sector_of(t: str) -> str:
+        if "sector" in scored.columns and t in scored.index and pd.notna(scored.at[t, "sector"]):
+            return str(scored.at[t, "sector"]).upper()
+        return "UNKNOWN"
+
+    def _grp_weights(labeler) -> dict:
+        w: dict = {}
+        for t in held:
+            g = labeler(t)
+            w[g] = w.get(g, 0.0) + float(current[t]) / invested
+        return w
+
+    sec_w = _grp_weights(_sector_of)
+    reg_w = _grp_weights(region_of)
+
+    kept: list[str] = []
+    skipped: list[str] = []
+    adj: dict[str, float] = {}
+    for t in cand_list:
+        sc = sec_w.get(_sector_of(t), 0.0)
+        rc = reg_w.get(region_of(t), 0.0)
+        # Hard skip only on SECTOR (the gate-enforced cap; sectors are diverse so this
+        # rarely binds). Region is NOT hard-capped at sizing — a US-heavy book is ~100%
+        # one region, so a region skip would drop every US buy; region stays a soft tilt.
+        if sc >= sector_cap:
+            skipped.append(t)
+            continue
+        penalty = _DIV_TILT_SECTOR * min(1.0, sc / sector_cap) + _DIV_TILT_REGION * min(
+            1.0, rc / region_cap
+        )
+        adj[t] = float(conv.get(t, 0.0)) - penalty
+        kept.append(t)
+    kept.sort(key=lambda t: -adj[t])
+    return kept, skipped
+
+
 def _sector_labels(names: list[str], scored: pd.DataFrame) -> list[str]:
     """Uppercased sector label per name ("UNKNOWN" when missing)."""
     if scored is None or "sector" not in scored.columns:
@@ -244,6 +312,8 @@ def build_overlay(
     min_analyst_mom: float | None = -3.0,  # owner 2026-07-22: veto buys the Street is downgrading
     min_analyst_n: int = 4,  # ...only when coverage is meaningful (>=4 analysts)
     min_earn_trajectory: float | None = 1.0 / 1.05,  # veto buys w/ fwd P/E > 1.05x trailing
+    min_conviction: float | None = None,  # absolute conviction floor for a new buy (owner)
+    portfolio_aware: bool = False,  # tilt buy selection toward under-weight sectors/markets
     tier_name_caps: bool = False,
 ) -> dict:
     """Build a minimal keep/sell/buy overlay on the live book, then risk-gate it.
@@ -347,7 +417,10 @@ def build_overlay(
     screened_out: list[str] = []
     if not np.isnan(buy_threshold) and max_new > 0:
         cand = elig_conv[[t for t in elig_conv.index if t not in held_set]]
-        cand = cand[cand >= buy_threshold].sort_values(ascending=False)
+        # Absolute conviction floor (owner 2026-07-22): a buy must clear BOTH the
+        # percentile AND the floor, so a weak universe yields fewer buys, not 8 mediocre.
+        buy_floor = buy_threshold if min_conviction is None else max(buy_threshold, min_conviction)
+        cand = cand[cand >= buy_floor].sort_values(ascending=False)
         # FIX A: never buy the same company twice, nor a dual listing of a name
         # already in the book (dedup the candidate pool + drop held companies).
         cand_list = _dedup_buy_candidates(list(cand.index), held, scored)
@@ -362,6 +435,18 @@ def build_overlay(
             min_analyst_n=min_analyst_n,
             min_earn_trajectory=min_earn_trajectory,
         )
+        # Owner 2026-07-22: tilt selection toward what the book NEEDS — skip at-cap
+        # sectors/markets and re-rank by conviction minus a mild crowding penalty.
+        if portfolio_aware:
+            cand_list, _div_skipped = _portfolio_aware_order(
+                cand_list,
+                scored,
+                cur,
+                conv_all,
+                sector_cap=sector_cap,
+                region_cap=_SELECT_REGION_CAP,
+            )
+            screened_out = screened_out + _div_skipped
         bought = cand_list[: int(max_new)]
 
     # Pre-gate target: keeps anchored at current weight; buys funded from the freed


### PR DESCRIPTION
Two owner-approved selection upgrades (both default-ON, env-toggleable, so we can A/B vs plain top-8):

**1. Absolute conviction floor** (`V3_MIN_CONVICTION=1.0`) — a new buy must clear the buy percentile **and** an absolute conviction floor. Calibrated from the live distribution (buys today are +1.12..+1.88, p85≈+0.84), so +1.0 is *tail insurance*: on a weak day it yields fewer buys instead of forcing 8 mediocre ones; today it doesn't bite.

**2. Portfolio-aware selection** (`V3_PORTFOLIO_AWARE=1`) — stop ranking buys purely standalone:
- **skip** a candidate whose sector is already at the sector cap (35%) — the risk gate would zero it at sizing, so surfacing it is a wasted rec;
- **re-rank** the rest by conviction minus a mild sector+region crowding penalty (crowding = current-book group weight / cap) so buys tilt toward *under-weight* sectors/markets.
- Conviction stays primary — crowding only breaks near-ties, never buys a weak name to diversify. Region is a **soft tilt only** (a US-heavy book is ~100% one region, so a hard region skip would drop every US buy). Sizing-side diversification (sector/bloc/region caps, ERC) is unchanged.

Grounded in today's book (Tech 19.7% heaviest, Healthcare 2.1% lightest): the tiebreaker deprioritizes KARO (Tech) and favors the under-weight sleeves. TDD: floor-trims, at-cap skip, diversification tiebreaker; 26 overlay tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)