### PR TITLE
config(vps): enable AI-core floor to protect mega-caps from the vol gate

### DIFF
--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -23,7 +23,10 @@ git pull --ff-only --quiet 2>/dev/null \
   || echo "WARN: account snapshot failed - report falls back to portfolio.csv weights"
 
 # 2) Overlay report with the locked decision-support config.
-V3_FLOOR_CORE=0 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
+#    V3_FLOOR_CORE=1 (owner 2026-07-22): floor the mega-cap AI core at its CURRENT
+#    weight (<=10%/name) so the ERC vol gate can't trim the winners (NVDA 8.6% etc.)
+#    down into low-vol names. Protects the thesis sleeve's size against the vol lever.
+V3_FLOOR_CORE=1 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
 V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 \
   .venv/bin/python scripts/v3_overlay_report.py
 


### PR DESCRIPTION
Owner request: protect the mega-cap AI core's size against the risk gate. The ERC/vol lever was trimming the high-vol winners (NVDA 8.6%→3.4%, GOOG 8.8%→3.4%, MSFT 7.6%→3.4%, AMZN 6.2%→3.4%) and redistributing into low-vol names (UCG 1.45%→5%). Flipping `V3_FLOOR_CORE=1` floors each MEGA_CORE name at min(current weight, 10%) after the gate, so the vol lever can't cut the thesis sleeve below where it's held. One-line config flag (mechanism already built + tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)