### PR TITLE
feat(v3): store-first price reads (price store as the overlay backbone)

### DIFF
--- a/scripts/v3_price_store_update.py
+++ b/scripts/v3_price_store_update.py
@@ -12,6 +12,7 @@ No module-level yahoofinance.core.config import (lazy imports in main()).
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -21,14 +22,24 @@ ETORO_CSV = "yahoofinance/output/etoro.csv"
 
 
 def main() -> None:
+    ap = argparse.ArgumentParser(description="Grow the v3 append-only price store.")
+    ap.add_argument(
+        "--period",
+        default="2y",
+        help="yfinance lookback to fetch + append each run (e.g. 2y for the daily "
+        "refresh — enough for mom_12_1/realized_vol; 5y for the initial backtest-depth "
+        "populate). Append-only + newest-wins, so older bars are retained.",
+    )
+    args = ap.parse_args()
+
     from trade_modules.v3.price_store import append_bars, store_coverage  # noqa: PLC0415
     from trade_modules.v3.prices import load_eur_close  # noqa: PLC0415
     from trade_modules.v3.universe import load_universe  # noqa: PLC0415
 
     tickers = load_universe(ETORO_CSV)
-    print(f"universe: {len(tickers)} names")
+    print(f"universe: {len(tickers)} names (period={args.period})")
 
-    eur = load_eur_close(tickers, period="5y")
+    eur = load_eur_close(tickers, period=args.period)
     added = append_bars(eur)
     cov = store_coverage()
     print(

--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -26,8 +26,11 @@ git pull --ff-only --quiet 2>/dev/null \
 #    V3_FLOOR_CORE=1 (owner 2026-07-22): floor the mega-cap AI core at its CURRENT
 #    weight (<=10%/name) so the ERC vol gate can't trim the winners (NVDA 8.6% etc.)
 #    down into low-vol names. Protects the thesis sleeve's size against the vol lever.
+#    V3_USE_PRICE_STORE=1 (owner 2026-07-22): read prices from the append-only price
+#    store (refreshed daily by refresh-prices) + live-fetch only names it misses — so a
+#    per-run yfinance throttle no longer unscores core holdings (the "-" bug).
 V3_FLOOR_CORE=1 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
-V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 \
+V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 V3_USE_PRICE_STORE=1 \
   .venv/bin/python scripts/v3_overlay_report.py
 
 # 3) Email the scheduled Factor Snapshot. BODY = the compact Outlook-safe summary

--- a/tests/unit/trade_modules/test_v3_fetch.py
+++ b/tests/unit/trade_modules/test_v3_fetch.py
@@ -76,6 +76,40 @@ def test_single_batch_returns_all_tickers():
     assert calls[0] == tickers
 
 
+def test_store_first_reads_store_and_live_fetches_only_missing(monkeypatch):
+    """use_store=True: names in the price store come from it; only store-MISSING names
+    are live-downloaded (the daily refresh keeps the store full -> no throttle)."""
+    stored = _make_close(["A", "B"])
+
+    def fake_read_close(tickers, **kw):
+        cols = [t for t in ["A", "B"] if t in set(tickers)]
+        return stored[cols] if cols else pd.DataFrame()
+
+    monkeypatch.setattr("trade_modules.v3.price_store.read_close", fake_read_close)
+    live_calls: list[list[str]] = []
+
+    def fake_dl(batch, period):
+        live_calls.append(list(batch))
+        return _make_close(batch)
+
+    out = robust_fetch_prices(["A", "B", "C"], pause=0, downloader=fake_dl, use_store=True)
+    assert live_calls == [["C"]]  # only the store-missing name hit the network
+    assert set(out.columns) == {"A", "B", "C"}  # store + live merged
+
+
+def test_store_off_by_default_does_not_read_store(monkeypatch):
+    """use_store=False (default): the store is never read; all names are live-fetched."""
+
+    def boom(*a, **k):
+        raise AssertionError("store must not be read when use_store is off")
+
+    monkeypatch.setattr("trade_modules.v3.price_store.read_close", boom)
+    out = robust_fetch_prices(
+        ["A", "C"], pause=0, downloader=lambda b, p: _make_close(b), use_store=False
+    )
+    assert set(out.columns) == {"A", "C"}
+
+
 def test_batching_correct_chunk_sizes():
     """7 tickers @ batch_size=3 → 3 calls with correct chunk sizes."""
     tickers = [f"T{i}" for i in range(7)]

--- a/trade_modules/v3/fetch.py
+++ b/trade_modules/v3/fetch.py
@@ -6,9 +6,19 @@ and retries on network/rate-limit errors with exponential back-off.
 
 from __future__ import annotations
 
+import os
 import time
 
 import pandas as pd
+
+
+def _use_price_store(explicit: bool | None) -> bool:
+    """Store-first is opt-in: an explicit ``use_store`` wins, else the
+    ``V3_USE_PRICE_STORE`` env flag (unset/``0`` -> off, so backtests + tests are
+    unchanged; the overlay/cron sets it to 1)."""
+    if explicit is not None:
+        return explicit
+    return os.environ.get("V3_USE_PRICE_STORE", "") not in ("", "0")
 
 
 def _default_downloader(batch: list[str], period: str) -> pd.DataFrame:
@@ -77,6 +87,7 @@ def robust_fetch_prices(
     pause: float = 1.0,
     retries: int = 3,
     downloader=None,
+    use_store: bool | None = None,
 ) -> pd.DataFrame:
     """Fetch adjusted Close prices in batches with retry and exponential back-off.
 
@@ -106,6 +117,36 @@ def robust_fetch_prices(
         All-NaN columns are dropped.  Returns an empty DataFrame if every
         batch fails.
     """
+    # Store-first (opt-in via ``use_store`` / V3_USE_PRICE_STORE): read the append-only
+    # price store and live-fetch ONLY the names it is missing. The daily price-store
+    # refresh keeps the store full, so a normal overlay run does ~no live download — no
+    # yfinance throttle, so core names never drop out of scoring on a transient miss.
+    if _use_price_store(use_store) and tickers:
+        try:
+            from trade_modules.v3.price_store import read_close  # noqa: PLC0415
+
+            stored = read_close(list(tickers))
+        except Exception:  # noqa: BLE001 — a bad/absent store must never break the fetch
+            stored = pd.DataFrame()
+        have = set(stored.columns) if stored is not None and not stored.empty else set()
+        missing = [t for t in tickers if t not in have]
+        if not missing:
+            return stored
+        live = robust_fetch_prices(
+            missing,
+            period=period,
+            batch_size=batch_size,
+            pause=pause,
+            retries=retries,
+            downloader=downloader,
+            use_store=False,
+        )
+        if stored is None or stored.empty:
+            return live
+        if live is None or live.empty:
+            return stored
+        return stored.join(live, how="outer")
+
     if downloader is None:
         downloader = _default_downloader
 


### PR DESCRIPTION
Fixes the '-' unscored-core bug at the source. The overlay live-fetched prices every run (raw `yf.download`); yfinance throttling randomly returned nothing for a subset → `mom_12_1`/`realized_vol` NaN → those names failed the eligibility data-quality gate → unscored (NVDA/GOOG/MSFT/AMZN showed '-').

- `robust_fetch_prices` gains an opt-in **store-first** path (`use_store`/`V3_USE_PRICE_STORE`): read the append-only `v3_price_store`, live-fetch **only** names it misses, merge. Default OFF (backtests/tests unchanged); the overlay/cron set it ON.
- `v3_price_store_update` gains `--period` (2y daily top-up; 5y initial populate; append-only + newest-wins retains older bars).
- The daily **price-refresh** job (plessas-trading) keeps the store full, so a normal overlay run does ~no live download → no throttle → core never drops out of scoring.

TDD: store-first reads store + live-fetches only missing; store-off default reads nothing. 22 fetch/store tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)