### PR TITLE
chore(v3): scheduled overlay uses cap_exempt (retire floor-at-current)

### DIFF
--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -23,13 +23,15 @@ git pull --ff-only --quiet 2>/dev/null \
   || echo "WARN: account snapshot failed - report falls back to portfolio.csv weights"
 
 # 2) Overlay report with the locked decision-support config.
-#    V3_FLOOR_CORE=1 (owner 2026-07-22): floor the mega-cap AI core at its CURRENT
-#    weight (<=10%/name) so the ERC vol gate can't trim the winners (NVDA 8.6% etc.)
-#    down into low-vol names. Protects the thesis sleeve's size against the vol lever.
+#    V3_CAP_MODE=cap_exempt (owner 2026-07-22): the vol gate exempts mega-caps
+#    (sigmoid on log-market-cap) from the ERC vol trim, so the winners (NVDA/GOOG/…)
+#    aren't sold into low-vol names — but they stay CONVICTION-sized and tier-capped
+#    (<=10%/name), free to shrink if a name fades. Replaced the old V3_FLOOR_CORE hard
+#    floor-at-current (a ratchet that froze the accidental weight, conviction-blind).
 #    V3_USE_PRICE_STORE=1 (owner 2026-07-22): read prices from the append-only price
 #    store (refreshed daily by refresh-prices) + live-fetch only names it misses — so a
 #    per-run yfinance throttle no longer unscores core holdings (the "-" bug).
-V3_FLOOR_CORE=1 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
+V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_exempt \
 V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 V3_USE_PRICE_STORE=1 \
   .venv/bin/python scripts/v3_overlay_report.py
 


### PR DESCRIPTION
Replaces the `V3_FLOOR_CORE=1` hard floor-at-current with `V3_CAP_MODE=cap_exempt` in the 4h Factor Snapshot cron. cap_exempt's sigmoid exempts mega-caps from the ERC vol trim (winners aren't sold into low-vol names) while keeping them conviction-sized + tier-capped (≤10%/name) — so a fading mega-cap can still be trimmed, unlike the floor. Verified: 8 mega-caps kept / 0 sold, book vol 8.9%. Vol ceiling 35% unchanged as backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)