### PR TITLE
fix(v3): restore mega-cap core floor (equal-weight base trimmed winners to 3.4%)

### DIFF
--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -23,15 +23,16 @@ git pull --ff-only --quiet 2>/dev/null \
   || echo "WARN: account snapshot failed - report falls back to portfolio.csv weights"
 
 # 2) Overlay report with the locked decision-support config.
-#    V3_CAP_MODE=cap_exempt (owner 2026-07-22): the vol gate exempts mega-caps
-#    (sigmoid on log-market-cap) from the ERC vol trim, so the winners (NVDA/GOOG/…)
-#    aren't sold into low-vol names — but they stay CONVICTION-sized and tier-capped
-#    (<=10%/name), free to shrink if a name fades. Replaced the old V3_FLOOR_CORE hard
-#    floor-at-current (a ratchet that froze the accidental weight, conviction-blind).
+#    V3_FLOOR_CORE=1 (owner 2026-07-22): the equal-risk base sizes EVERY name to ~3.4%,
+#    which trims the held mega-cap core (NVDA 8.9%, GOOG 8.7%, MSFT 7.5%, …) down to 3.4%.
+#    The floor holds each held mega-cap at its CURRENT weight (<=10%/name) so the core
+#    keeps its size; funded by trimming non-core. NOTE: cap_exempt ALONE did NOT protect
+#    size (it only exempts the vol lever, not the equal-weight base) — the winners still
+#    fell to 3.4%. The floor is what preserves mega-cap exposure.
 #    V3_USE_PRICE_STORE=1 (owner 2026-07-22): read prices from the append-only price
 #    store (refreshed daily by refresh-prices) + live-fetch only names it misses — so a
 #    per-run yfinance throttle no longer unscores core holdings (the "-" bug).
-V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_exempt \
+V3_FLOOR_CORE=1 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
 V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 V3_USE_PRICE_STORE=1 \
   .venv/bin/python scripts/v3_overlay_report.py
 


### PR DESCRIPTION
NVDA/GOOG and the other held mega-caps were trimming to ~3.4% — the v3 equal-risk base sizes every name ~equally, and cap_exempt (#177) only exempts the vol lever, not the equal-weight base. Re-enable `V3_FLOOR_CORE=1` + revert to `cap_ordered`: held mega-caps stay at current weight (≤10%/name). Reverses #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)