### PR TITLE
feat(v3): derive mega-cap core from market cap (general, not a ticker list)

### DIFF
--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -52,7 +52,7 @@ from trade_modules.riskfirst.fx import USD_BLOC, currency_of  # noqa: E402
 from trade_modules.v3.actions import build_actions  # noqa: E402
 from trade_modules.v3.combine import compute_scores  # noqa: E402
 from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
-from trade_modules.v3.construct import region_of  # noqa: E402
+from trade_modules.v3.construct import mega_core_by_cap, region_of  # noqa: E402
 from trade_modules.v3.features import enrich_features  # noqa: E402
 from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
 from trade_modules.v3.overlay import build_overlay  # noqa: E402
@@ -82,8 +82,10 @@ BALANCED_WEIGHTS: dict[str, float] = {
     "lowvol": 0.00,
 }
 
-# Mega-cap "core" whose kept-vs-sold status is always reported.
-MEGA_CORE: list[str] = ["NVDA", "GOOG", "MSFT", "AAPL", "AMZN", "AVGO", "TSM", "META"]
+# The mega-cap "core" is derived at RUNTIME from market cap (>= the $200B mega tier)
+# via mega_core_by_cap() — NOT a hardcoded ticker list. Any holding qualifies for the
+# core floor / no-force-sell protection purely by its size, so the rule generalizes as
+# the book changes instead of pinning specific named assets.
 
 # Overridable via env so the same runner produces any confirmed config.
 _VOL_CEILING = float(os.environ.get("V3_VOL_CEILING", "0.18"))
@@ -588,21 +590,23 @@ def main() -> None:
             f"({managed_weight:.1%}); model deployment -> {gross_target:.0%}"
         )
 
-    # --- Owner thesis overlay: floor the AI core at its current weight (capped by the
-    #     single-name limit) so the conviction gate can't trim the sleeve below where
-    #     the owner holds it. Off by default; V3_FLOOR_CORE=1 for the owner config. ---
+    # --- Mega-cap core (GENERAL, market-cap-driven — NOT a ticker list): any HELD name
+    #     in the $200B+ mega tier. Floored at its current weight (capped by the single-name
+    #     limit) so the ERC vol gate can't trim the winners below where the owner holds
+    #     them, and never force-sold. Off by default; V3_FLOOR_CORE=1 for the owner config.
+    mega_core = mega_core_by_cap(current_weights, scores)
     core_floor = None
     if _FLOOR_CORE:
         cf = {
             t: min(float(current_weights[t]), _NAME_CAP)
-            for t in MEGA_CORE
+            for t in mega_core
             if t in current_weights.index
         }
         core_floor = pd.Series(cf, dtype=float) if cf else None
         if core_floor is not None:
             print(
-                f"AI-core floor ON: {len(core_floor)} names floored at current "
-                f"(<= {_NAME_CAP:.0%}/name), sleeve target {core_floor.sum():.1%}"
+                f"mega-cap core floor ON: {len(core_floor)} held names >= $200B floored at "
+                f"current (<= {_NAME_CAP:.0%}/name), sleeve target {core_floor.sum():.1%}"
             )
 
     # --- Overlay construction (keep book, sell weak, add strongest) ---
@@ -615,7 +619,7 @@ def main() -> None:
         sector_cap=_SECTOR_CAP,
         usd_bloc_cap=_USD_BLOC_CAP,
         vol_ceiling=_VOL_CEILING,
-        core_list=MEGA_CORE,
+        core_list=mega_core,
         cap_mode=_CAP_MODE,
         sell_negative_noncore=_SELL_NEG,
         noncore_sell_floor=_NONCORE_SELL_FLOOR,

--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -934,3 +934,36 @@ def test_div_tilt_moderate_upsizes_extreme_yield_flagged():
     assert abs(t[0] - 1.0) < 1e-9
     assert abs(t[1] - 1.5) < 1e-9  # 4% -> +50%
     assert abs(t[2] - 1.0) < 1e-9  # > 6% -> value-trap flag, no up-size
+
+
+def test_mega_core_by_cap_is_market_cap_driven_not_a_ticker_list():
+    """The mega-cap core is derived from MARKET CAP (>= the mega tier boundary),
+    not a hardcoded ticker list: held names in the mega tier qualify; held smaller
+    caps, unheld mega-caps, and NaN-cap names do not."""
+    from trade_modules.v3.construct import _MCAP_TIER_CAPS, mega_core_by_cap
+
+    mega = _MCAP_TIER_CAPS[0][0]  # $200B mega-tier boundary
+    scored = pd.DataFrame(
+        {"cap": [3e12, 5e11, 5e10, 8e8, float("nan"), 1e12]},
+        index=["BIG1", "BIG2", "MIDX", "SMALLX", "NOCAP", "UNHELD_BIG"],
+    )
+    current = pd.Series(
+        {"BIG1": 0.09, "BIG2": 0.05, "MIDX": 0.03, "SMALLX": 0.01, "NOCAP": 0.02}
+    )  # UNHELD_BIG intentionally absent from the book
+
+    core = mega_core_by_cap(current, scored, threshold=mega)
+
+    assert set(core) == {"BIG1", "BIG2"}  # only HELD names with cap >= $200B
+    assert "MIDX" not in core and "SMALLX" not in core  # below the mega tier
+    assert "NOCAP" not in core  # NaN market cap
+    assert "UNHELD_BIG" not in core  # mega-cap but not currently held
+
+
+def test_mega_core_by_cap_handles_missing_cap_column_and_empty_book():
+    """Degrades gracefully: no 'cap' column or an empty book -> empty core."""
+    from trade_modules.v3.construct import mega_core_by_cap
+
+    no_cap = pd.DataFrame({"conviction": [1.0]}, index=["X"])
+    assert mega_core_by_cap(pd.Series({"X": 0.1}), no_cap) == []
+    scored = pd.DataFrame({"cap": [3e12]}, index=["X"])
+    assert mega_core_by_cap(pd.Series(dtype=float), scored) == []

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -414,6 +414,37 @@ def _div_tilt(scored: pd.DataFrame, selected: list[str]) -> np.ndarray:
     return np.where(dv > 0.06, 1.0, 1.0 + 0.5 * np.clip(dv / 0.04, 0.0, 1.0))
 
 
+def mega_core_by_cap(
+    current_weights: pd.Series,
+    scored: pd.DataFrame,
+    *,
+    threshold: float = _MCAP_TIER_CAPS[0][0],
+) -> list[str]:
+    """Held names whose market cap is in the mega tier (GENERAL — cap-driven, not a list).
+
+    Returns the currently-held tickers whose ``cap`` is at or above ``threshold``
+    (default the top ``_MCAP_TIER_CAPS`` boundary, $200B). This is the general
+    replacement for a hardcoded mega-cap whitelist: ANY holding qualifies for the
+    core floor / no-force-sell protection purely by its market cap, so the rule
+    loosens uniformly as new mega-caps enter the book and tightens as caps fall.
+
+    Only HELD names are returned (the floor protects existing positions from the ERC
+    vol trim). NaN / missing caps and a missing ``cap`` column are treated as
+    non-mega (excluded), degrading gracefully to an empty core.
+    """
+    if current_weights is None or len(current_weights) == 0:
+        return []
+    if scored is None or "cap" not in getattr(scored, "columns", []):
+        return []
+    caps = pd.to_numeric(scored["cap"], errors="coerce")
+    out: list[str] = []
+    for t in current_weights.index:
+        c = caps.get(t, float("nan"))
+        if c == c and float(c) >= float(threshold):  # not NaN and in the mega tier
+            out.append(str(t))
+    return out
+
+
 def build_portfolio(
     scored: pd.DataFrame,
     prices: pd.DataFrame,


### PR DESCRIPTION
Owner: 'don't plug those 8 specific assets — general rule so mega caps can reach 10%.' Replaces the hardcoded `MEGA_CORE` whitelist with `mega_core_by_cap()`: any held name ≥ $200B (the mega tier) is floored at current (≤10%/name) + never force-sold, by market cap alone. Generalizes as the book changes. TDD: 2 new tests. 66 construct/overlay tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)