### PR TITLE
feat(v3): mega-core threshold configurable, default $1T (fewer, larger core)

### DIFF
--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -142,6 +142,10 @@ _SELL_NEG = _envflag("V3_SELL_NEGATIVE_NONCORE")
 _NONCORE_SELL_FLOOR = float(os.environ.get("V3_NONCORE_SELL_FLOOR", "0.0"))  # sell deadband
 _PROTECT_CORE = _envflag("V3_PROTECT_CORE")
 _FLOOR_CORE = _envflag("V3_FLOOR_CORE", "0")  # floor AI core at current (thesis overlay)
+# Mega-cap core = held names with market cap >= this (default $1T -> the true giants;
+# owner 2026-07-22). A higher threshold = fewer, larger core names, each with room to
+# run to the single-name cap; lower = broader protection, biggest names smaller.
+_MEGA_CORE_MIN_CAP = float(os.environ.get("V3_MEGA_CORE_MIN_CAP", "1e12"))
 _MANAGED_SLEEVES = [
     s.strip()
     for s in os.environ.get("V3_MANAGED_SLEEVES", "GLD,UVXY,LYXGRE.DE").split(",")
@@ -591,10 +595,11 @@ def main() -> None:
         )
 
     # --- Mega-cap core (GENERAL, market-cap-driven — NOT a ticker list): any HELD name
-    #     in the $200B+ mega tier. Floored at its current weight (capped by the single-name
-    #     limit) so the ERC vol gate can't trim the winners below where the owner holds
-    #     them, and never force-sold. Off by default; V3_FLOOR_CORE=1 for the owner config.
-    mega_core = mega_core_by_cap(current_weights, scores)
+    #     at/above V3_MEGA_CORE_MIN_CAP (default $1T — the true giants; owner 2026-07-22).
+    #     Floored at its current weight (capped by the single-name limit) so the ERC vol
+    #     gate can't trim the winners below where the owner holds them, and never force-sold.
+    #     Fewer, larger core names (higher threshold) each get room to run to the cap.
+    mega_core = mega_core_by_cap(current_weights, scores, threshold=_MEGA_CORE_MIN_CAP)
     core_floor = None
     if _FLOOR_CORE:
         cf = {
@@ -605,8 +610,9 @@ def main() -> None:
         core_floor = pd.Series(cf, dtype=float) if cf else None
         if core_floor is not None:
             print(
-                f"mega-cap core floor ON: {len(core_floor)} held names >= $200B floored at "
-                f"current (<= {_NAME_CAP:.0%}/name), sleeve target {core_floor.sum():.1%}"
+                f"mega-cap core floor ON: {len(core_floor)} held names >= "
+                f"${_MEGA_CORE_MIN_CAP / 1e12:.1f}T floored at current "
+                f"(<= {_NAME_CAP:.0%}/name), sleeve target {core_floor.sum():.1%}"
             )
 
     # --- Overlay construction (keep book, sell weak, add strongest) ---

--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -32,7 +32,11 @@ git pull --ff-only --quiet 2>/dev/null \
 #    V3_USE_PRICE_STORE=1 (owner 2026-07-22): read prices from the append-only price
 #    store (refreshed daily by refresh-prices) + live-fetch only names it misses — so a
 #    per-run yfinance throttle no longer unscores core holdings (the "-" bug).
-V3_FLOOR_CORE=1 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
+#    V3_MEGA_CORE_MIN_CAP=1e12 (owner 2026-07-22): the mega-cap core is derived from
+#    market cap (held names >= $1T — the true giants), NOT a hardcoded ticker list, so
+#    the floor generalizes with the book. $1T (vs the $200B mega tier) = fewer, larger
+#    core names, each with room to run to the 10% cap (banks/mid-mega left to the model).
+V3_FLOOR_CORE=1 V3_MEGA_CORE_MIN_CAP=1e12 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
 V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 V3_USE_PRICE_STORE=1 \
   .venv/bin/python scripts/v3_overlay_report.py
 

--- a/tests/unit/trade_modules/test_v3_construct.py
+++ b/tests/unit/trade_modules/test_v3_construct.py
@@ -967,3 +967,14 @@ def test_mega_core_by_cap_handles_missing_cap_column_and_empty_book():
     assert mega_core_by_cap(pd.Series({"X": 0.1}), no_cap) == []
     scored = pd.DataFrame({"cap": [3e12]}, index=["X"])
     assert mega_core_by_cap(pd.Series(dtype=float), scored) == []
+
+
+def test_mega_core_by_cap_threshold_narrows_to_fewer_larger_names():
+    """A higher threshold selects FEWER, larger names (owner's '$1T fewer, larger core'):
+    a $500B held name qualifies at $200B but drops out at $1T."""
+    from trade_modules.v3.construct import mega_core_by_cap
+
+    scored = pd.DataFrame({"cap": [3e12, 5e11]}, index=["GIANT", "HALFT"])
+    current = pd.Series({"GIANT": 0.08, "HALFT": 0.05})
+    assert set(mega_core_by_cap(current, scored, threshold=200e9)) == {"GIANT", "HALFT"}
+    assert set(mega_core_by_cap(current, scored, threshold=1e12)) == {"GIANT"}


### PR DESCRIPTION
Owner chose 'fewer, larger core (≥$1T)'. New `V3_MEGA_CORE_MIN_CAP` env (default 1e12) threads to `mega_core_by_cap`: the core is the true giants, each with room to run to the 10% cap; banks/mid-mega ($200B–$1T) left to the model. Still general (cap-driven, no list). Runner sets it. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)