### PR TITLE
fix(v3): fund core floor from weakest non-core first (spare strong satellites)

### DIFF
--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -563,3 +563,30 @@ def test_trajectory_guard_excludes_rising_forward_pe_buy():
     assert "U00" not in d["bought"]
     assert "U00" in d.get("screened_out", [])
     assert set(d["bought"]) == {"U01", "U02"}
+
+
+def test_fund_floor_weakest_first_spares_strong_satellites():
+    """The core floor is funded by cutting the WEAKEST-conviction non-core names
+    first (to zero if needed); a high-conviction satellite is spared."""
+    from trade_modules.v3.overlay import _fund_floor_weakest_first
+
+    weights = pd.Series({"WEAK": 0.05, "MID": 0.05, "STRONG": 0.05})
+    conv = pd.Series({"WEAK": -0.5, "MID": 0.5, "STRONG": 1.88})
+    out = _fund_floor_weakest_first(weights, conv, raised=0.06)
+
+    assert out["WEAK"] == 0.0  # weakest cut fully first
+    assert abs(out["MID"] - 0.04) < 1e-9  # then partially cut the next-weakest
+    assert out["STRONG"] == 0.05  # strong satellite untouched
+    assert abs((weights.sum() - out.sum()) - 0.06) < 1e-9  # freed exactly `raised`
+
+
+def test_fund_floor_weakest_first_treats_nan_conviction_as_weakest():
+    """A NaN-conviction (ineligible/dataless) non-core name is cut before a scored one."""
+    from trade_modules.v3.overlay import _fund_floor_weakest_first
+
+    weights = pd.Series({"NANC": 0.05, "STRONG": 0.05})
+    conv = pd.Series({"NANC": float("nan"), "STRONG": 1.0})
+    out = _fund_floor_weakest_first(weights, conv, raised=0.03)
+
+    assert abs(out["NANC"] - 0.02) < 1e-9  # NaN cut first
+    assert out["STRONG"] == 0.05  # spared

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -285,6 +285,37 @@ def _sector_labels(names: list[str], scored: pd.DataFrame) -> list[str]:
     return [s if s else "UNKNOWN" for s in ser.tolist()]
 
 
+def _fund_floor_weakest_first(
+    weights: pd.Series, conviction: pd.Series, raised: float
+) -> pd.Series:
+    """Free ``raised`` of weight from the non-core book by cutting the WEAKEST-conviction
+    names FIRST (to zero if needed), sparing the strongest.
+
+    The core floor lifts the giants back to their target; that weight has to come from
+    somewhere. Funding it by scaling ALL non-core proportionally is conviction-blind — it
+    shaves a high-conviction satellite (e.g. a +1.9 name) the same as a weak one. Instead we
+    sort non-core by conviction ASCENDING (NaN / dataless = weakest, cut first) and draw the
+    funding from the bottom up, so strong satellites survive while the model's least-liked
+    non-core names are the ones sacrificed. Returns new weights over the same index; the total
+    removed equals ``raised`` (gross preserved). Caller ensures ``sum(weights) >= raised``.
+    """
+    out = weights.astype(float).copy()
+
+    def _key(t: str) -> float:
+        c = conviction.get(t)
+        return float(c) if (c is not None and pd.notna(c)) else float("-inf")
+
+    need = float(raised)
+    for t in sorted(out.index, key=_key):  # weakest conviction first
+        if need <= 1e-12:
+            break
+        w = float(out[t])
+        cut = min(w, need)
+        out[t] = w - cut
+        need -= cut
+    return out
+
+
 def build_overlay(
     scored: pd.DataFrame,
     current_weights,
@@ -502,9 +533,10 @@ def build_overlay(
         )
 
         # Deliberate thesis overlay: FLOOR core names at a chosen minimum (their
-        # current weights, pre-capped by name_cap), scaling non-core proportionally
-        # so gross holds. The conviction gate trims middling-conviction core; this
-        # re-expresses the owner's high-conviction AI view as a VISIBLE post-gate floor.
+        # current weights, pre-capped by name_cap), funding the lift from the WEAKEST
+        # non-core names first (sparing high-conviction satellites like EXEL) so gross
+        # holds. The conviction gate trims middling-conviction core; this re-expresses
+        # the owner's high-conviction AI view as a VISIBLE post-gate floor.
         if core_floor is not None and len(final):
             floors = pd.to_numeric(core_floor, errors="coerce").dropna()
             floors = floors[floors > 0.0]
@@ -518,10 +550,13 @@ def build_overlay(
             if raised > 1e-9:
                 noncore = [t for t in final.index if t not in floors.index]
                 nc_sum = float(final.reindex(noncore).sum())
-                if nc_sum > raised:  # scale non-core down to fund the floor
-                    scale = (nc_sum - raised) / nc_sum
+                if nc_sum > raised:  # fund the floor from the WEAKEST non-core first,
+                    # sparing high-conviction satellites (see _fund_floor_weakest_first)
+                    nc_funded = _fund_floor_weakest_first(
+                        final.reindex(noncore).astype(float), conv_all, raised
+                    )
                     for t in noncore:
-                        final[t] = float(final[t]) * scale
+                        final[t] = float(nc_funded[t])
                 else:  # non-core cannot fully fund the floor -> haircut the lifts to
                     # what it frees, then zero it, so gross is PRESERVED (never inflated).
                     haircut = nc_sum / raised  # raised > 1e-9 above, so safe


### PR DESCRIPTION
The mega-core floor funded itself by scaling all non-core proportionally (conviction-blind), so a +1.88 satellite like EXEL was cut like a weak name → surfaced as SELL. `_fund_floor_weakest_first` draws funding from the lowest-conviction non-core first, sparing strong satellites; gross preserved. TDD 2 tests, 69 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)