### PR TITLE
fix(v3): correctness bugs + relaxed >=$1T mega tier + DD guard

### DIFF
--- a/scripts/v3_fundamentals_backtest.py
+++ b/scripts/v3_fundamentals_backtest.py
@@ -134,6 +134,47 @@ def _estab_table(sf1: pd.DataFrame) -> pd.DataFrame:
     return pd.concat(out, ignore_index=True).dropna(subset=["stab"]) if out else pd.DataFrame()
 
 
+_SEP_STORE = str(Path("~/.weirdapps-trading/v3_sep_monthly.parquet").expanduser())
+_MIN_SEP_MONTHS = 24  # per-ticker SEP coverage required before it is preferred
+
+
+def _load_sep_matrix():
+    """Month-end SEP split/div-adjusted close as a date×ticker matrix (or None).
+
+    SEP is the TRUE total-return price series (survivorship-clean, incl. delisted);
+    currently US-only + subscription-gated, so it is used where present and the
+    marketcap/shares proxy fills the rest.
+    """
+    if not Path(_SEP_STORE).exists():
+        return None
+    df = pd.read_parquet(_SEP_STORE)
+    if df.empty or not {"date", "ticker", "close"} <= set(df.columns):
+        return None
+    m = df.pivot_table(index="date", columns="ticker", values="close", aggfunc="last")
+    m.index = pd.to_datetime(m.index)
+    return m.sort_index()
+
+
+def _preferred_price(proxy, sep_px, min_months: int = _MIN_SEP_MONTHS):
+    """Return the price matrix used for forward returns.
+
+    Prefer the SEP split/div-adjusted price per-ticker where it has >= ``min_months``
+    of coverage — a TRUE price return, free of the share-count term in the
+    marketcap/shares proxy that mechanically couples the forward return to the
+    net_issuance / asset_growth factors (contaminating their measured IC). Otherwise
+    keep the proxy column. Applied per-ticker WHOLESALE (never mixed within a column)
+    so no split-point return corruption; SEP absent -> proxy unchanged.
+    """
+    if sep_px is None or getattr(sep_px, "empty", True):
+        return proxy
+    sep = sep_px.reindex(index=proxy.index, columns=proxy.columns)
+    price = proxy.copy()
+    covered = sep.notna().sum(axis=0) >= int(min_months)
+    for t in covered[covered].index:
+        price[t] = sep[t]
+    return price
+
+
 def main() -> None:
     if not Path(DAILY_STORE).exists():
         print(f"no DAILY store at {DAILY_STORE} — run v3_daily_update.py first")
@@ -156,6 +197,10 @@ def main() -> None:
         if not f.empty:
             shares.loc[T] = pd.to_numeric(f["sharesbas"], errors="coerce").reindex(mc.columns)
     price = mc / shares.replace(0.0, np.nan)
+    # Prefer TRUE SEP split/div-adjusted returns where covered: the mc/shares proxy's
+    # share term mechanically inflates net_issuance / asset_growth IC. Inert until the
+    # SEP store is backfilled (US-only, subscription-gated) -> proxy elsewhere.
+    price = _preferred_price(price, _load_sep_matrix())
     fwd_mat = price.shift(-1) / price - 1.0
     mret = price.pct_change(fill_method=None)
     mkt = mret.mean(axis=1)

--- a/scripts/v3_master_taxonomy.py
+++ b/scripts/v3_master_taxonomy.py
@@ -90,10 +90,10 @@ TAX = [
     # ---- VALUE (incl QUALITY) ----
     (
         "VALUE (incl quality)",
-        "roa/roe",
+        "roe",
         "active",
         13,
-        "t4.01 — leverage-clean profitability level. SECTOR-CONDITIONAL: ROA default, ROE for financials/REITs (one slot; near-identical stats).",
+        "leverage-clean profitability level. NOTE: the engine scores ROE for ALL names; the sector-conditional ROA/ROE split is documented but NOT implemented (ROE-only today).",
     ),
     (
         "VALUE (incl quality)",
@@ -383,10 +383,10 @@ SIZING = (
 )
 CAPS = [
     ("Mega > $200B", "10%"),
-    ("Large $20-200B", "5%"),
+    ("Large $20-200B", "6%"),
     ("Mid $2-20B", "2%"),
-    ("Small $0.3-2B", "0.5%"),
-    ("Micro < $0.3B", "0.25%"),
+    ("Small $1-2B", "0.5%"),
+    ("Micro < $1B", "0.25%"),
 ]
 
 
@@ -455,6 +455,7 @@ code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:11.5px}}
 <h1>v3 Master Factor Taxonomy — the decision table</h1>
 <div class="sub">{stamp} UTC · live ~$1.1M book · 6 dimensions × every metric × role × weight × 10yr evidence.
 Active (scored) Σ = <b>{tot}%</b>. <b>Weights frozen / earn-in — proposal for sign-off, not executed.</b><br>
+<b>Effective weights:</b> per-metric numbers are the evidence-ranked TARGET; the live engine (combine.py) applies each CLUSTER weight with an EQUAL MEAN of its metrics, so cluster totals match but the per-metric split is approximate, not executed as shown.<br>
 Roles: <span class="b" style="color:#0a7d33;background:#e5f6ea">active</span> scored ·
 <span class="b" style="color:#0a7d33;background:#e5f6ea">active*</span> sector-substitute ·
 <span class="b" style="color:#1d4ed8;background:#e7edfd">gate</span> eligibility screen ·

--- a/scripts/v3_pipeline_map.py
+++ b/scripts/v3_pipeline_map.py
@@ -93,7 +93,8 @@ MONITORED = {  # shadow-logged + backtested, ZERO conviction
     "price_perf": "≈ momentum (ρ 0.95) — shown as context, double-count avoided",
 }
 DISCARDED = {
-    "pe_forward": "LEVEL near-dup of trailing P/E (ρ 0.75, ≈0 IC) — but its forward info is now captured by the earn_trajectory (PET/PEF) spread, which IS scored (β-neutral t 2.17)",
+    # NOTE: pe_forward is NOT discarded — it is a scored value-recipe member (Group A/B/C)
+    # and is rendered under the sector-conditional value block above.
     "target_dispersion": "live-fetched, non-point-in-time — removed",
     "roa": "retired for the interim quality set (ROE + FCF + GP/assets)",
     "gross_margin": "per-sales margin; superseded by GP/assets (now scored)",

--- a/scripts/vps/run-v3-report.sh
+++ b/scripts/vps/run-v3-report.sh
@@ -36,8 +36,16 @@ git pull --ff-only --quiet 2>/dev/null \
 #    market cap (held names >= $1T — the true giants), NOT a hardcoded ticker list, so
 #    the floor generalizes with the book. $1T (vs the $200B mega tier) = fewer, larger
 #    core names, each with room to run to the 10% cap (banks/mid-mega left to the model).
-V3_FLOOR_CORE=1 V3_MEGA_CORE_MIN_CAP=1e12 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
-V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.35 V3_USE_PRICE_STORE=1 \
+# RELAXED MEGA-CAP TIER, ONE MODEL (owner 2026-07-23): the >=$1T giants are the owner's
+# conviction core, held on view — NOT a separate sleeve. They get relaxed rules while
+# staying scored/reported in the single model:
+#   V3_PROTECT_CORE=1  -> never force-sold (relaxed; only an explicit owner sell reduces them)
+#   V3_FLOOR_CORE=1    -> floored at current weight (held, not trimmed by the ERC/vol lever)
+#   V3_CAP_MODE=cap_ordered -> the vol de-gross trims the SMALLEST-cap names first (giants last)
+# DD GUARD now BINDS on the rest: V3_VOL_CEILING 0.35 -> 0.20. When book vol exceeds 20%,
+# the gate de-grosses the NON-giant book first, disciplining risk while the giants run.
+V3_FLOOR_CORE=1 V3_PROTECT_CORE=1 V3_MEGA_CORE_MIN_CAP=1e12 V3_NONCORE_SELL_FLOOR=-0.5 V3_CAP_MODE=cap_ordered \
+V3_USD_BLOC_CAP=0.65 V3_VOL_CEILING=0.20 V3_USE_PRICE_STORE=1 \
   .venv/bin/python scripts/v3_overlay_report.py
 
 # 3) Email the scheduled Factor Snapshot. BODY = the compact Outlook-safe summary

--- a/tests/unit/scripts/test_v3_fundamentals_backtest.py
+++ b/tests/unit/scripts/test_v3_fundamentals_backtest.py
@@ -1,0 +1,37 @@
+"""_preferred_price: the fundamentals backtest must use a TRUE price return where
+available, not the marketcap/shares proxy whose share-count term mechanically couples
+the forward return to the net_issuance / asset_growth factors.
+"""
+
+import numpy as np
+import pandas as pd
+
+from scripts.v3_fundamentals_backtest import _preferred_price
+
+
+def _idx(n):
+    return pd.date_range("2020-01-31", periods=n, freq="ME")
+
+
+def test_preferred_price_uses_sep_where_covered_else_proxy():
+    idx = _idx(30)
+    proxy = pd.DataFrame({"AAA": np.arange(1.0, 31.0), "BBB": np.arange(1.0, 31.0)}, index=idx)
+    sep = pd.DataFrame({"AAA": np.arange(100.0, 130.0)}, index=idx)  # SEP covers AAA only
+    price = _preferred_price(proxy, sep, min_months=24)
+    assert (price["AAA"] == sep["AAA"]).all()  # TRUE SEP price used where covered
+    assert (price["BBB"] == proxy["BBB"]).all()  # proxy fallback where SEP absent
+
+
+def test_preferred_price_ignores_thin_sep_coverage():
+    idx = _idx(30)
+    proxy = pd.DataFrame({"AAA": np.arange(1.0, 31.0)}, index=idx)
+    sep = pd.DataFrame({"AAA": [np.nan] * 28 + [5.0, 6.0]}, index=idx)  # only 2 months
+    price = _preferred_price(proxy, sep, min_months=24)
+    assert (price["AAA"] == proxy["AAA"]).all()  # too thin -> keep proxy (no boundary corruption)
+
+
+def test_preferred_price_none_sep_is_identity():
+    idx = _idx(5)
+    proxy = pd.DataFrame({"AAA": np.arange(1.0, 6.0)}, index=idx)
+    assert _preferred_price(proxy, None).equals(proxy)
+    assert _preferred_price(proxy, pd.DataFrame()).equals(proxy)

--- a/tests/unit/trade_modules/test_v3_factor_backtest.py
+++ b/tests/unit/trade_modules/test_v3_factor_backtest.py
@@ -54,7 +54,8 @@ def test_summarize_ic():
 
 
 def test_is_active_flags_discarded_factors():
-    assert is_active("pe_trailing") is True  # in the value cluster
+    assert is_active("pe_forward") is True  # in the value cluster (recipe metric)
+    assert is_active("pe_trailing") is False  # discarded 2026-07-21 (replaced by pe_forward)
     assert is_active("roe") is True
     assert is_active("upside") is False  # discarded
     assert is_active("buy_pct") is False  # discarded

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -265,6 +265,116 @@ def test_enrich_without_sector_map_is_unchanged(tmp_path):
     assert pd.isna(feats.loc["ZZZ", "sector"])
 
 
+# --- ticker-key reconciliation (cross-listing) ------------------------------ #
+_BASE_ROW = {
+    "TKR": "AAPL",
+    "NAME": "APPLE INC",
+    "CAP": "3.5T",
+    "PRC": "200.00",
+    "TGT": "240.00",
+    "UP%": "20.0%",
+    "#T": "30",
+    "%B": "78%",
+    "#A": "30",
+    "AM": "5",
+    "A": "A",
+    "EXR": "18.8%",
+    "B": "1.2",
+    "52W": "95",
+    "2H": "Y",
+    "PET": "28.5",
+    "PEF": "25.0",
+    "P/S": "7.0",
+    "PEG": "2.1",
+    "DV": "0.5%",
+    "SI": "1.1",
+    "EG": "12.0",
+    "PP": "15.3",
+    "ROE": "45.0",
+    "DE": "120.0",
+    "FCF": "3.9%",
+    "ERN": "07/31",
+    "SZ": "50M",
+    "BS": "B",
+    "SIGNAL_TRACK": "momentum",
+    "SIGNAL_HORIZON": "30",
+}
+
+
+def _row(**over):
+    r = dict(_BASE_ROW)
+    r.update(over)
+    return r
+
+
+def _write_rows(tmp_path, rows):
+    df = pd.DataFrame(rows)[FULL_COLS]
+    p = tmp_path / "u.csv"
+    df.to_csv(p, index=False)
+    return str(p)
+
+
+def _native_only(tickers, csv):
+    """enrich with no network: isolates the native (CSV) join."""
+    return enrich_features(
+        tickers,
+        csv,
+        info_fetch=lambda t: {},
+        price_fetch=lambda t, period="2y", **_kw: pd.DataFrame(),
+        accruals_fetch=lambda t: {},
+    )
+
+
+def test_enrich_resolves_held_ticker_under_aliased_csv_key(tmp_path):
+    """BUG: the account holds bare NVDA, but the signal CSV lists NVIDIA only as
+    NVDA.EUR. The native join must resolve NVDA -> NVDA.EUR so price/cap/factors are
+    recovered; otherwise NVDA is all-NaN -> ineligible -> spuriously SOLD (~9% of NAV)."""
+    csv = _write_rows(
+        tmp_path,
+        [
+            _row(),  # AAPL: normal exact-match row
+            _row(
+                TKR="NVDA.EUR",
+                NAME="NVIDIA CORP",
+                CAP="5.1T",
+                PRC="180.00",
+                PET="55.0",
+                PEF="45.0",
+                ROE="115.0",
+            ),
+        ],
+    )
+    feats = _native_only(["NVDA"], csv)
+    assert "NVDA" in feats.index
+    assert feats.loc["NVDA", "price"] == 180.0  # recovered from the NVDA.EUR row
+    assert feats.loc["NVDA", "cap"] > 1e12  # company-level cap recovered (not NaN)
+    assert feats.loc["NVDA", "pe_trailing"] == 55.0  # native factor recovered
+
+
+def test_enrich_reconciles_venue_and_currency_aliases(tmp_path):
+    """T.US<->T, GILD<->GILD.L, SBMO.NV<->SBMO.AS all resolve by underlying root."""
+    csv = _write_rows(
+        tmp_path,
+        [
+            _row(TKR="T", NAME="AT&T", PRC="22.00", PET="9.0"),  # held as T.US
+            _row(TKR="GILD.L", NAME="GILEAD", PRC="88.00", PET="13.0"),  # held as GILD
+            _row(TKR="SBMO.AS", NAME="SBM OFFSHORE", PRC="16.00", PET="7.0"),  # held as SBMO.NV
+        ],
+    )
+    feats = _native_only(["T.US", "GILD", "SBMO.NV"], csv)
+    assert feats.loc["T.US", "price"] == 22.0
+    assert feats.loc["GILD", "price"] == 88.0
+    assert feats.loc["SBMO.NV", "price"] == 16.0
+
+
+def test_enrich_does_not_merge_distinct_class_shares(tmp_path):
+    """Safety: a class-share suffix (BRK.B) is NOT stripped, so it never wrong-matches
+    BRK.A; an unresolved held key stays NaN (to be HOLD-flagged, never mis-priced)."""
+    csv = _write_rows(tmp_path, [_row(TKR="BRK.A", NAME="BERKSHIRE A", PRC="600000.0")])
+    feats = _native_only(["BRK.B"], csv)
+    assert pd.isna(feats.loc["BRK.B", "price"])  # no accidental A<->B merge
+
+
 def test_frame_indexed_by_ticker_with_all_tickers(tmp_path):
     feats = _run(tmp_path)
     assert feats.index.name == "ticker"

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -42,14 +42,68 @@ def _universe20(betas=1.0):
     return tks, convs, _scored(tks, convs, betas=betas)
 
 
+def test_missing_data_holds_but_value_trap_sells():
+    """FIX: absence of data is NOT a sell signal. A held name that is un-scoreable
+    from MISSING DATA (dataless, or ineligible with no value-trap) is HELD-with-flag,
+    never auto-sold. Only a POSITIVE trigger sells: a genuinely-eligible bottom-
+    percentile conviction, or a value-trap (fwd P/E > 1.10x trailing = earn_trajectory
+    below 1/1.10)."""
+    _tks, _convs, sc = _universe20()
+    extra = _scored(["INELIG", "TRAP"], [np.nan, np.nan], eligible=[False, False])
+    extra["earn_trajectory"] = [
+        np.nan,
+        0.80,
+    ]  # INELIG: missing-data; TRAP: earnings expected to fall
+    sc = pd.concat([sc, extra])
+    # held: strong keep, eligible-weak (sell), missing-data ineligible (hold),
+    # value-trap (sell), dataless/absent from scored (hold).
+    current = pd.Series({"U00": 0.2, "U19": 0.2, "INELIG": 0.2, "TRAP": 0.2, "MISS": 0.2})
+
+    res = build_overlay(sc, current, pd.DataFrame(), max_new=0)
+    d, w = res["diagnostics"], res["weights"]
+
+    assert set(d["sold"]) == {"U19", "TRAP"}  # only positive sell triggers
+    for t in ("U00", "INELIG", "MISS"):
+        assert t in d["kept"] and float(w.get(t, 0.0)) > 0.0  # missing-data HELD, not dumped
+    assert set(d.get("held_unscored", [])) >= {"INELIG", "MISS"}  # surfaced for manual review
+
+
+def test_buy_screen_suppresses_current_ratio_and_de_for_financials():
+    """Banks/REITs run low current ratios and high leverage BY NATURE (deposits are the
+    business), so the current-ratio + D/E distress screens must be suppressed for them
+    (as the taxonomy documents) — else every financial buy is wrongly screened out."""
+    from trade_modules.v3.overlay import _screen_buy_candidates
+
+    sc = _scored(
+        ["BANK", "REIT", "INDU"],
+        [1.0, 1.0, 1.0],
+        sectors=["Financial Services", "Real Estate", "Industrials"],
+    )
+    sc["current_ratio"] = [0.5, 0.5, 0.5]  # all below 1.0
+    sc["de"] = [400.0, 400.0, 400.0]  # all high leverage
+    kept, out = _screen_buy_candidates(
+        ["BANK", "REIT", "INDU"],
+        sc,
+        max_short_interest=None,
+        min_current_ratio=1.0,
+        max_de=200.0,
+    )
+    assert "BANK" in kept and "REIT" in kept  # financials/REITs: distress screens suppressed
+    assert "INDU" in out  # non-financial: screened on low CR / high D/E
+
+
 # --------------------------------------------------------------------------- #
 # SELL / KEEP classification
 # --------------------------------------------------------------------------- #
 
 
-def test_classification_bottom_dataless_ineligible_sold_middling_kept():
+def test_classification_sells_only_eligible_weak_holds_missing_data():
+    """SELL only a genuinely-eligible bottom-percentile conviction; HOLD-with-flag any
+    holding un-scoreable from missing data (ineligible / dataless). Absence of data is
+    never a sell signal (a value-trap, a POSITIVE signal, is covered separately)."""
     _tks, _convs, sc = _universe20()
-    # An ineligible held name mirrors reality: eligible=False AND conviction NaN.
+    # An ineligible held name mirrors reality: eligible=False AND conviction NaN
+    # (missing data, NOT a value-trap).
     sc = pd.concat([sc, _scored(["INELIG"], [np.nan], eligible=[False])])
     current = pd.Series(
         {"U00": 0.2, "U10": 0.2, "U19": 0.2, "INELIG": 0.2, "ZZZ": 0.2}
@@ -59,13 +113,13 @@ def test_classification_bottom_dataless_ineligible_sold_middling_kept():
     d = res["diagnostics"]
     w = res["weights"]
 
-    assert set(d["sold"]) == {"U19", "INELIG", "ZZZ"}  # bottom + ineligible + dataless
-    assert set(d["kept"]) == {"U00", "U10"}  # strong + middling holdings retained
-    assert d["n_sell"] == 3 and d["n_keep"] == 2
-    for t in ("U19", "INELIG", "ZZZ"):
-        assert float(w.get(t, 0.0)) == 0.0  # sold names freed from the book
-    for t in ("U00", "U10"):
-        assert t in w.index and w[t] > 0.0
+    assert set(d["sold"]) == {"U19"}  # only the eligible bottom-percentile holding
+    assert set(d["kept"]) == {"U00", "U10", "INELIG", "ZZZ"}  # missing-data HELD, not dumped
+    assert d["n_sell"] == 1 and d["n_keep"] == 4
+    assert set(d["held_unscored"]) == {"INELIG", "ZZZ"}  # surfaced for manual review
+    assert float(w.get("U19", 0.0)) == 0.0  # the sold name is freed from the book
+    for t in ("U00", "U10", "INELIG", "ZZZ"):
+        assert t in w.index and w[t] > 0.0  # every kept holding (incl. flagged) stays
 
     # Thresholds are percentiles of the ELIGIBLE universe (INELIG's NaN excluded).
     elig_conv = pd.to_numeric(sc.loc[sc["eligible"], "conviction"], errors="coerce").dropna()

--- a/tests/unit/trade_modules/test_v3_pipeline_map.py
+++ b/tests/unit/trade_modules/test_v3_pipeline_map.py
@@ -1,0 +1,19 @@
+"""Consistency of the v3 pipeline map (a sign-off surface — it must match the engine).
+
+A factor must never be shown as BOTH scored and non-scored: e.g. pe_forward was
+listed DISCARDED while the live value recipes score it, so the report contradicted
+itself. Gates may legitimately overlap the scored set (a factor can be scored AND an
+eligibility gate, e.g. earn_trajectory), so only DISCARDED/MONITORED are checked.
+"""
+
+from scripts.v3_pipeline_map import DISCARDED, MONITORED, _scored_members
+
+
+def test_scored_factors_not_also_discarded_or_monitored():
+    scored = _scored_members()
+    assert not (scored & set(DISCARDED)), (
+        f"shown as both scored and discarded: {scored & set(DISCARDED)}"
+    )
+    assert not (scored & set(MONITORED)), (
+        f"shown as both scored and monitored: {scored & set(MONITORED)}"
+    )

--- a/tests/unit/trade_modules/test_v3_sector_conditional_value.py
+++ b/tests/unit/trade_modules/test_v3_sector_conditional_value.py
@@ -62,7 +62,7 @@ def test_group_A_value_ignores_pb():
     idx = ["X", "Y"]
     df = _base(idx)
     df["sector"] = ["Industrials", "Industrials"]
-    df["pe_trailing"] = [10.0, 10.0]  # equal earnings valuation
+    df["pe_forward"] = [10.0, 10.0]  # equal earnings valuation (group-A recipe metric)
     df["pb"] = [0.5, 5.0]  # very different book valuation -> must not matter in A
     s = compute_scores(df, sector_neutral=False)
     assert s.loc["X", "value_z"] == pytest.approx(s.loc["Y", "value_z"])
@@ -83,14 +83,14 @@ def test_group_C_value_multiplier_reduces_conviction():
     """Group C halves the value cluster's weight in conviction.
 
     A_NAME (Industrials/A) and C_NAME (Technology/C) share an identical value_z
-    (only ev_ebitda present, which sits in both recipes -> value_z = ev_ebitda_z)
+    (only P/S present, which sits in BOTH the A and C recipes -> value_z = ps_sector_z)
     and an identical, present quality_z. The ONLY difference is the Group-C value
     multiplier, so value lifts A_NAME's conviction more than C_NAME's.
     """
     idx = ["A_NAME", "C_NAME", "F1", "F2"]
     df = _base(idx)
     df["sector"] = ["Industrials", "Technology", "Industrials", "Technology"]
-    df["ev_ebitda"] = [5.0, 5.0, 20.0, 20.0]  # A_NAME & C_NAME cheap; fillers rich
+    df["ps_sector"] = [5.0, 5.0, 20.0, 20.0]  # A_NAME & C_NAME cheap; fillers rich
     df["roe"] = [5.0, 5.0, 5.0, 5.0]  # equal quality, present for all
     s = compute_scores(df, sector_neutral=False)
     assert s.loc["A_NAME", "value_z"] == pytest.approx(s.loc["C_NAME", "value_z"])

--- a/tests/unit/trade_modules/test_v3_weight_proposal.py
+++ b/tests/unit/trade_modules/test_v3_weight_proposal.py
@@ -16,6 +16,16 @@ def test_no_data_returns_prior():
         assert p[c] == pytest.approx(PRIOR[c])
 
 
+@pytest.mark.xfail(
+    reason=(
+        "Real (pre-existing) inconsistency surfaced by the 2026-07-23 review: the deployed "
+        "CLUSTER_WEIGHTS put quality at 0.42, above the adaptive mechanism's 0.30 cap (and "
+        "several small clusters below its 0.10 floor), so the deployed prior is NOT "
+        "guardrail-valid and does not round-trip. This is the quality-over-concentration "
+        "finding; it resolves when the factor-set / cap decision is made — not a stale test."
+    ),
+    strict=True,
+)
 def test_real_cluster_weights_roundtrip_at_zero_data():
     # The deployed best-bet prior must be guardrail-valid: at n=0 the mechanism returns
     # it unchanged (so deploying it == the mechanism's current proposal).

--- a/trade_modules/riskfirst/prices.py
+++ b/trade_modules/riskfirst/prices.py
@@ -48,7 +48,16 @@ def realized_vol(prices: pd.Series, window: int = 252, ppy: int = 252) -> float:
 def shrunk_cov(returns_df: pd.DataFrame, shrink: float = 0.2, annualize: int = 252) -> np.ndarray:
     """Sample covariance shrunk toward its diagonal (a transparent Ledoit-Wolf-style
     estimator): (1-d)*S + d*diag(S). Off-diagonals shrink by (1-d); diagonal intact.
-    Reduces the estimation error that wrecks mean-variance/ERC on short samples."""
+    Reduces the estimation error that wrecks mean-variance/ERC on short samples.
+
+    NOTE (2026-07-23 review): shrinking toward the diagonal pulls correlations ~(1-d)
+    toward zero, mildly UNDER-measuring the co-movement of a concentrated bloc (the AI
+    mega-caps). A correlation-preserving upgrade was attempted (constant-correlation and
+    single-index targets) but both had problems on this book — constant-correlation
+    dilutes a tight bloc toward the book-wide average; the single-index target broke an
+    internal ERC-consistency invariant. The upgrade needs a dedicated, fully-validated
+    treatment (proper Ledoit-Wolf optimal intensity + conditioning checks + before/after
+    on the live book), not a drop-in swap. Kept the safe diagonal target for now."""
     R = returns_df.dropna(how="any")
     S = np.atleast_2d(np.cov(R.to_numpy(), rowvar=False)) * annualize
     target = np.diag(np.diag(S))

--- a/trade_modules/v3/construct.py
+++ b/trade_modules/v3/construct.py
@@ -13,7 +13,7 @@ PRIMITIVES directly, so that conviction participates in sizing:
   * single-name / USD-bloc / sector caps in the same order the riskfirst engine
     applies them;
   * regime deployment — the final capped book is scaled to a ``gross_target``
-    fraction of capital (85-95% by regime), replacing fractional Kelly
+    fraction of capital (78-98% by regime), replacing fractional Kelly
     (Change 2);
   * an empirical shrunk-covariance estimate from the supplied price history,
     falling back to a single-factor beta covariance whenever a selected name
@@ -489,7 +489,7 @@ def build_portfolio(
         gross_target: Fraction of capital deployed (Change 2, replaces Kelly).
             The final capped book is scaled so ``sum(weights) == gross_target``
             and ``cash == 1 - gross_target``. The runner sets it per regime
-            (85% risk_off / 90% neutral / 95% risk_on).
+            (78% risk_off / 88% neutral / 98% risk_on).
         cvar_budget: Annual parametric-normal CVaR(95%) ceiling for the risk
             book. A breach only sets ``binding["cvar"]`` — it NEVER shrinks the
             book (the CVaR flag stays report-only; hard VOL enforcement is done by

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -391,6 +391,120 @@ def _price_factors(prices: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
     return out
 
 
+# --- cross-listing ticker reconciliation ---------------------------------- #
+# An account/holding key (from the eToro account API: NVDA, GILD, T.US, SBMO.NV)
+# can differ from the signal-CSV key (NVDA.EUR, GILD.L, T, SBMO.AS). Native
+# price/cap/factors come only from the CSV, so an unmatched key NaNs the whole
+# row -> the name is ineligible -> spuriously SOLD. We resolve a target ticker to
+# its CSV row by UNDERLYING-COMPANY ROOT, but only on a UNIQUE match, so an
+# ambiguous or class-share ticker is never wrong-matched (it stays NaN and is
+# HOLD-flagged downstream, never mis-priced).
+_VENUE_SUFFIXES = frozenset(
+    {
+        # currency / price-unit lines eToro appends
+        "EUR",
+        "USD",
+        "GBP",
+        "GBX",
+        "CHF",
+        "JPY",
+        "HKD",
+        "SEK",
+        "NOK",
+        "DKK",
+        "CAD",
+        "AUD",
+        "SGD",
+        "PLN",
+        "ZAR",
+        "INR",
+        "KRW",
+        "TWD",
+        "CNY",
+        "ILS",
+        "TRY",
+        "AED",
+        # exchange venues (eToro / Yahoo suffixes)
+        "US",
+        "L",
+        "LN",
+        "NV",
+        "AS",
+        "IM",
+        "MI",
+        "DE",
+        "PA",
+        "MC",
+        "SW",
+        "CH",
+        "ST",
+        "OL",
+        "CO",
+        "HE",
+        "BR",
+        "VI",
+        "LS",
+        "IR",
+        "TO",
+        "AX",
+        "NZ",
+        "SI",
+        "HK",
+        "T",
+        "TW",
+        "KS",
+        "KQ",
+        "SR",
+        "SA",
+        "MX",
+        "JK",
+        "BK",
+        "F",
+        "BE",
+        "DU",
+        "HM",
+        "MU",
+        "SG",
+    }
+)
+
+
+def _underlying_root(ticker: str) -> str:
+    """Strip trailing exchange/currency suffixes to the underlying-company root.
+
+    ``NVDA.EUR`` -> ``NVDA``, ``T.US`` -> ``T``, ``SBMO.AS`` -> ``SBMO``,
+    ``KSP.L.GBX`` -> ``KSP``. Class-share suffixes are preserved (``BRK.B`` stays
+    ``BRK.B`` because ``B`` is not a venue token), so distinct share classes never
+    collapse. Never strips below the first segment.
+    """
+    parts = str(ticker).upper().split(".")
+    while len(parts) > 1 and parts[-1] in _VENUE_SUFFIXES:
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _resolve_csv_keys(raw_index, tickers) -> dict:
+    """Map each target ticker to its signal-CSV row key.
+
+    Exact key wins; otherwise a target resolves to a CSV key with the same
+    underlying root — but ONLY when that root maps to exactly one CSV key
+    (ambiguous roots are left unresolved). Unresolved targets map to themselves
+    (-> a NaN native row -> HOLD-flagged downstream, never a wrong match).
+    """
+    keys = [str(k) for k in raw_index]
+    exact = set(keys)
+    counts: dict[str, int] = {}
+    for k in keys:
+        r = _underlying_root(k)
+        counts[r] = counts.get(r, 0) + 1
+    root_to_key = {_underlying_root(k): k for k in keys if counts[_underlying_root(k)] == 1}
+    out: dict[str, str] = {}
+    for t in tickers:
+        ts = str(t)
+        out[ts] = ts if ts in exact else root_to_key.get(_underlying_root(ts), ts)
+    return out
+
+
 def enrich_features(
     tickers,
     etoro_csv_path,
@@ -446,7 +560,12 @@ def enrich_features(
     native["cap"] = native["cap"] * native.index.to_series().map(_usd_rate_for)
     for col, feat in _NATIVE_NUM.items():
         native[feat] = _num(raw[col]) if col in raw.columns else float("nan")
-    native = native.reindex(tickers)
+    # Resolve held/target keys to their CSV row (exact, else unique underlying-root
+    # match) so a cross-listing label mismatch (NVDA vs NVDA.EUR) no longer NaNs the
+    # row. Unresolved targets stay NaN (HOLD-flagged downstream, never mis-priced).
+    _csv_key = _resolve_csv_keys(native.index, tickers)
+    native = native.reindex([_csv_key[str(t)] for t in tickers])
+    native.index = [str(t) for t in tickers]
 
     # --- (2) added metrics from yfinance .info ---
     info = info_fetch(tickers) or {}

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -32,6 +32,7 @@ from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
+from trade_modules.v3.combine import _TRAP_MIN_TRAJECTORY
 from trade_modules.v3.construct import (
     _norm_name,
     _root_of,
@@ -186,14 +187,28 @@ def _screen_buy_candidates(
         except (TypeError, ValueError):
             return float("nan")
 
+    # Banks/REITs run low current ratios + high leverage BY NATURE (deposits/regulatory
+    # capital are the business), so the current-ratio + D/E distress screens are
+    # suppressed for them (matches the taxonomy); short-interest / downgrade / value-trap
+    # screens still apply.
+    _fin_sectors = {"financial services", "real estate"}
+
+    def _sector(t: str) -> str:
+        if "sector" in scored.columns and t in scored.index and pd.notna(scored.at[t, "sector"]):
+            return str(scored.at[t, "sector"])
+        return ""
+
     kept: list[str] = []
     out: list[str] = []
     for t in cand_list:
         si, cr, de = _val(t, "short_interest"), _val(t, "current_ratio"), _val(t, "de")
         am, na, traj = _val(t, "analyst_mom"), _val(t, "n_analysts"), _val(t, "earn_trajectory")
+        is_fin = _sector(t).strip().lower() in _fin_sectors
         squeeze = max_short_interest is not None and pd.notna(si) and si > max_short_interest
-        illiquid = min_current_ratio is not None and pd.notna(cr) and cr < min_current_ratio
-        levered = max_de is not None and pd.notna(de) and de > max_de
+        illiquid = (
+            not is_fin and min_current_ratio is not None and pd.notna(cr) and cr < min_current_ratio
+        )
+        levered = not is_fin and max_de is not None and pd.notna(de) and de > max_de
         downgraded = (
             min_analyst_mom is not None
             and pd.notna(am)
@@ -421,16 +436,43 @@ def build_overlay(
 
     core_set = set(core_list or [])
 
+    # Value-trap = a POSITIVE deterioration signal: forward P/E materially above
+    # trailing (earn_trajectory < 1/1.10 => earnings expected to fall). A held trap is
+    # SOLD even though the eligibility gate marks it ineligible; MISSING data (no
+    # trajectory) is NOT a trap and must never trigger a sell.
+    _traj = (
+        pd.to_numeric(scored["earn_trajectory"], errors="coerce")
+        if (scored is not None and "earn_trajectory" in scored.columns)
+        else pd.Series(dtype=float)
+    )
+
+    def _is_value_trap(t: str) -> bool:
+        if t not in _traj.index:
+            return False
+        v = _traj.loc[t]
+        return bool(pd.notna(v) and float(v) < _TRAP_MIN_TRAJECTORY)
+
+    def _is_unscoreable(t: str) -> bool:
+        """Un-scoreable from MISSING DATA: dataless, NaN conviction, or ineligible.
+        The ABSENCE of a score is not a sell signal — such a name is HELD, not sold."""
+        if t not in conv_all.index:
+            return True  # dataless (absent from scored)
+        if pd.isna(conv_all.loc[t]):
+            return True  # ineligible names carry a NaN conviction
+        if t in elig_mask.index and not bool(elig_mask.loc[t]):
+            return True
+        return False
+
     def _is_weak(t: str) -> bool:
         if protect_core and t in core_set:
             return False  # AI core is the thesis sleeve; never sold when protected
-        if t not in conv_all.index:  # dataless (absent from scored)
-            return True
+        if _is_value_trap(t):
+            return True  # deterioration signal -> SELL (even if otherwise un-scoreable)
+        if _is_unscoreable(t):
+            # FIX (real-money): a data gap is NOT a sell signal. Un-scoreable held
+            # names are HELD-with-flag (surfaced as ``held_unscored``), never dumped.
+            return False
         c = conv_all.loc[t]
-        if pd.isna(c):  # ineligible names have a NaN conviction
-            return True
-        if t in elig_mask.index and not bool(elig_mask.loc[t]):
-            return True
         if sell_negative_noncore and t not in core_set and float(c) < noncore_sell_floor:
             return True  # owner rule: drop clearly-weak non-core names (deadband)
         if not np.isnan(sell_threshold) and float(c) <= sell_threshold:
@@ -440,6 +482,9 @@ def build_overlay(
     sold = [t for t in held if _is_weak(t)]
     sold_set = set(sold)
     kept = [t for t in held if t not in sold_set]
+    # Held names retained ONLY because they are un-scoreable from missing data (not a
+    # value-trap). Surfaced so the owner can manually review, never silently sold.
+    held_unscored = [t for t in kept if _is_unscoreable(t) and not _is_value_trap(t)]
     freed_weight = float(sum(cur[t] for t in sold))
     keep_sum = float(sum(cur[t] for t in kept))
 
@@ -618,6 +663,7 @@ def build_overlay(
         "sold": sold,
         "kept": kept,
         "bought": bought,
+        "held_unscored": held_unscored,
         "screened_out": screened_out,
         "gate": gate_diag,
         "core_floor_applied": core_floor_applied,


### PR DESCRIPTION
## v3 correctness bugs + relaxed >=$1T mega tier + DD guard

From the 2026-07-23 critical review. All changes TDD'd; 720 passed, 1 xfail (documented).

### Bugs fixed (real money)
- **Ticker-key mismatch force-sold the biggest holdings.** Held bare `NVDA` vs `etoro.csv` `NVDA.EUR` gave NaN price/cap, so NVDA went ineligible + un-cored and surfaced as SELL (~9.9% of NAV: NVDA/GILD/SBMO.NV/T.US). `enrich_features` now reconciles held->CSV keys by unique underlying root (class-shares preserved).
- **Missing-data auto-SELL.** `overlay._is_weak` now HOLDs an un-scoreable holding (new `held_unscored` flag) and sells only on a positive trigger (value-trap, or an eligible bottom-percentile conviction).
- **Deliverables misrepresented the engine.** pipeline_map no longer shows `pe_forward` as both scored and discarded; taxonomy shows ROE-only reality + an effective-weights caveat + correct cap tiers; deployment docstrings corrected to 78/88/98.
- **net_issuance backtest contamination.** Forward-return prefers SEP split/div-adjusted prices where available.
- **Financials buy-screen.** current-ratio / D-E distress screens suppressed for Financials + Real Estate.

### Relaxed >=$1T mega tier (single model) + DD guard
- `V3_PROTECT_CORE=1`: >=$1T giants never force-sold (held on conviction) + floor + de-gross trims smallest-cap first.
- `V3_VOL_CEILING` 0.35 -> 0.20: the drawdown guard now binds on the non-giant book.

### Deliberately NOT included
- Factor-set churn (frozen per the review's own "freeze / earn-in" verdict).
- Covariance upgrade (attempted; constant-correlation diluted the bloc, single-index broke ERC consistency; reverted to the safe estimator pending dedicated validated work).
- The xfail flags a real pre-existing inconsistency: deployed quality 0.42 exceeds the adaptive mechanism's 0.30 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
