### PR TITLE
feat(v3): owner factor taxonomy 2026-07-23 — per-metric weights + PEF/PET

### DIFF
--- a/scripts/v3_cap_modes.py
+++ b/scripts/v3_cap_modes.py
@@ -46,7 +46,7 @@ from scripts.v3_full_report import (  # noqa: E402
     resolve_current_weights,
 )
 from scripts.v3_portfolio import trend_regime  # noqa: E402
-from trade_modules.v3.combine import compute_scores  # noqa: E402
+from trade_modules.v3.combine import CLUSTER_WEIGHTS, compute_scores  # noqa: E402
 from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
 from trade_modules.v3.features import enrich_features  # noqa: E402
 from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
@@ -57,14 +57,9 @@ PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
 BUY_CSV = "yahoofinance/output/buy.csv"
 ETORO_CSV = "yahoofinance/output/etoro.csv"
 
-BALANCED_WEIGHTS: dict[str, float] = {
-    "value": 0.15,
-    "quality": 0.25,
-    "momentum": 0.25,
-    "growth": 0.15,
-    "lowvol": 0.12,
-    "strength": 0.08,
-}
+# Derived from the engine SSOT (combine.METRIC_WEIGHTS -> CLUSTER_WEIGHTS) so this analysis
+# tool never drifts from the live model (owner taxonomy 2026-07-23).
+BALANCED_WEIGHTS: dict[str, float] = {c[:-2]: w for c, w in CLUSTER_WEIGHTS.items()}
 
 MEGA_CORE: list[str] = ["NVDA", "GOOG", "MSFT", "AAPL", "AMZN", "AVGO", "TSM", "META"]
 

--- a/scripts/v3_ceiling_sweep.py
+++ b/scripts/v3_ceiling_sweep.py
@@ -38,7 +38,7 @@ from scripts.v3_full_report import (  # noqa: E402
     resolve_current_weights,
 )
 from scripts.v3_portfolio import trend_regime  # noqa: E402
-from trade_modules.v3.combine import compute_scores  # noqa: E402
+from trade_modules.v3.combine import CLUSTER_WEIGHTS, compute_scores  # noqa: E402
 from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
 from trade_modules.v3.features import enrich_features  # noqa: E402
 from trade_modules.v3.fetch import robust_fetch_prices  # noqa: E402
@@ -49,14 +49,9 @@ PORTFOLIO_CSV = "yahoofinance/output/portfolio.csv"
 BUY_CSV = "yahoofinance/output/buy.csv"
 ETORO_CSV = "yahoofinance/output/etoro.csv"
 
-BALANCED_WEIGHTS: dict[str, float] = {
-    "value": 0.15,
-    "quality": 0.25,
-    "momentum": 0.25,
-    "growth": 0.15,
-    "lowvol": 0.12,
-    "strength": 0.08,
-}
+# Derived from the engine SSOT (combine.METRIC_WEIGHTS -> CLUSTER_WEIGHTS) so this analysis
+# tool never drifts from the live model (owner taxonomy 2026-07-23).
+BALANCED_WEIGHTS: dict[str, float] = {c[:-2]: w for c, w in CLUSTER_WEIGHTS.items()}
 
 MEGA_CORE: list[str] = ["NVDA", "GOOG", "MSFT", "AAPL", "AMZN", "AVGO", "TSM", "META"]
 

--- a/scripts/v3_factor_backtest.py
+++ b/scripts/v3_factor_backtest.py
@@ -208,13 +208,17 @@ def main() -> None:
                 zcols[feat] = z
                 _append_part(parts, feat, date, z, fwd, fwd_n, sec)
 
-        # earnings trajectory = trailing/forward P/E (>1 = forward cheaper = earnings
-        # expected to RISE; <1 = falling = value-trap). Recovers the PET->PEF info that
-        # was dropped when pe_forward left scoring; high is good (+1).
+        # earnings trajectory = forward/trailing P/E (PEF/PET, owner 2026-07-23): LOW =
+        # forward cheaper = earnings expected to RISE; high = value-trap. DIRECTION -1
+        # (smaller is better). The z is IDENTICAL to the old PET/PEF (reciprocal + sign
+        # cancel in rank-z), so the measured IC/t is unchanged — this only matches the
+        # engine's expression faithfully.
         if "PET" in panel.columns and "PEF" in panel.columns:
             pet, pef = _num(panel["PET"]), _num(panel["PEF"])
-            traj = (pet / pef).where((pet > 0) & (pef > 0))
-            ztraj = _sector_demean(_rank_z(traj), sec.reindex(traj.index))
+            traj = (pef / pet).where((pet > 0) & (pef > 0))
+            ztraj = _sector_demean(
+                _rank_z(traj) * DIRECTION["earn_trajectory"], sec.reindex(traj.index)
+            )
             zcols["earn_trajectory"] = ztraj
             _append_part(parts, "earn_trajectory", date, ztraj, fwd, fwd_n, sec)
 
@@ -339,7 +343,7 @@ _CLUSTER_LABEL = {
     "quality_z": "Quality",
     "momentum_z": "Momentum",
     "pead_z": "PEAD (earnings surprise)",
-    "trajectory_z": "Trajectory (PET/PEF)",
+    "trajectory_z": "Trajectory (PEF/PET)",
     "lowvol_z": "Low-vol",
     "strength_z": "Strength (analyst revisions)",
     "growth_z": "Growth",
@@ -387,7 +391,7 @@ _METRIC_DESC = {
     "ps_sector": "price ÷ sales — value for unprofitable / growth names",
     "peg": "P/E ÷ earnings growth — growth-adjusted value",
     "pe_forward": "price ÷ next-12m expected earnings",
-    "earn_trajectory": "trailing-P/E ÷ forward-P/E — >1 = earnings expected to RISE (value-trap guard)",
+    "earn_trajectory": "forward-P/E ÷ trailing-P/E — <1 = earnings expected to RISE (value-trap guard)",
     "roe": "net income ÷ shareholders' equity — return on equity",
     "roa": "net income ÷ total assets — return on assets",
     "gross_margin": "gross profit ÷ revenue",

--- a/scripts/v3_master_taxonomy.py
+++ b/scripts/v3_master_taxonomy.py
@@ -92,28 +92,28 @@ TAX = [
         "VALUE (incl quality)",
         "roe",
         "active",
-        13,
+        10,
         "leverage-clean profitability level. NOTE: the engine scores ROE for ALL names; the sector-conditional ROA/ROE split is documented but NOT implemented (ROE-only today).",
     ),
     (
         "VALUE (incl quality)",
         "gp_assets",
         "active",
-        13,
+        5,
         "t2.98 — the cleanest diversifier (ρ<0.18 to every factor). Novy-Marx quality anchor.",
     ),
     (
         "VALUE (incl quality)",
         "net_issuance",
         "active",
-        9,
+        5,
         "t2.95 — buyback(+)/dilution(−) capital-allocation quality (Pontiff-Woodgate). Bumped above P/S per evidence-order.",
     ),
     (
         "VALUE (incl quality)",
         "fcf",
         "active",
-        7,
+        5,
         "t2.80 — distinct cash-quality channel (ρ 0.26-0.45 vs profitability level).",
     ),
     (
@@ -127,7 +127,7 @@ TAX = [
         "VALUE (incl quality)",
         "pe_forward",
         "active",
-        6,
+        5,
         "OWNER CALL: full scored value factor REPLACING pe_trailing. EARN-IN — 5mo/live only, no 10yr PIT; caveat: analyst-optimism bias (worst for growth names).",
     ),
     (
@@ -200,28 +200,28 @@ TAX = [
         "GROWTH",
         "earn_growth",
         "active",
-        8,
+        5,
         "t2.67 — the scored earnings/growth slot (persistent, fits monthly cadence).",
     ),
     (
         "GROWTH",
         "sue",
         "active",
-        6,
-        "t2.02 — PEAD. Bumped to 6 (owner call). Note: event-trigger — monthly cadence captures only part of the drift.",
+        15,
+        "t2.02 — PEAD. Raised to 15 (owner 2026-07-23). Note: event-trigger — monthly cadence captures only part of the drift.",
     ),
     (
         "GROWTH",
         "trajectory_spread",
         "active",
-        5,
-        "PET/PEF spread, earn-in (5mo/no-PIT) — the forward view scored as a SPREAD (was the strongest clean signal, t2.17).",
+        15,
+        "PEF/PET (forward/trailing P/E; LOWER = earnings rising, DIRECTION -1) — raised to 15 (owner 2026-07-23). Earn-in (5mo/no-PIT); the forward view as a SPREAD, strongest clean signal (t2.17).",
     ),
     (
         "GROWTH",
         "earn_stability",
         "active",
-        4,
+        5,
         "t2.36 — QMJ 'safety' (low earnings coefficient-of-variation). DISTINCT (ρ≤0.18 to all). Borderline/probation.",
     ),
     (
@@ -236,7 +236,7 @@ TAX = [
         "MOMENTUM",
         "pct_52w_high",
         "active",
-        14,
+        10,
         "t3.77 — strongest single momentum (George-Hwang). The ONE momentum slot.",
     ),
     (
@@ -295,8 +295,8 @@ TAX = [
         "EXPECTATIONS",
         "analyst_mom",
         "active",
-        5,
-        "EPS-revision momentum — bumped to 5 (owner call). EARN-IN: no 10yr PIT, KILL on 3mo negative live-IC. yfinance ~5mo git-panel + growing.",
+        10,
+        "EPS-revision momentum — raised to 10 (owner 2026-07-23). EARN-IN: no 10yr PIT, KILL on 3mo negative live-IC. yfinance ~5mo git-panel + growing.",
     ),
     (
         "EXPECTATIONS",
@@ -455,7 +455,7 @@ code{{background:#f2f3f5;padding:1px 5px;border-radius:4px;font-size:11.5px}}
 <h1>v3 Master Factor Taxonomy — the decision table</h1>
 <div class="sub">{stamp} UTC · live ~$1.1M book · 6 dimensions × every metric × role × weight × 10yr evidence.
 Active (scored) Σ = <b>{tot}%</b>. <b>Weights frozen / earn-in — proposal for sign-off, not executed.</b><br>
-<b>Effective weights:</b> per-metric numbers are the evidence-ranked TARGET; the live engine (combine.py) applies each CLUSTER weight with an EQUAL MEAN of its metrics, so cluster totals match but the per-metric split is approximate, not executed as shown.<br>
+<b>Effective weights:</b> the per-metric weights ARE now executed — combine.py applies each metric's weight (METRIC_WEIGHTS) as the intra-cluster split (owner taxonomy 2026-07-23), replacing the old equal-mean approximation. Value is the one composite cluster (sector-conditional P/S · fwd-P/E · P/B recipe).<br>
 Roles: <span class="b" style="color:#0a7d33;background:#e5f6ea">active</span> scored ·
 <span class="b" style="color:#0a7d33;background:#e5f6ea">active*</span> sector-substitute ·
 <span class="b" style="color:#1d4ed8;background:#e7edfd">gate</span> eligibility screen ·

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -50,7 +50,7 @@ from scripts.v3_full_report import (  # noqa: E402  (pure helpers, reused)
 from scripts.v3_portfolio import trend_regime  # noqa: E402  (pure, unit-tested)
 from trade_modules.riskfirst.fx import USD_BLOC, currency_of  # noqa: E402
 from trade_modules.v3.actions import build_actions  # noqa: E402
-from trade_modules.v3.combine import compute_scores  # noqa: E402
+from trade_modules.v3.combine import CLUSTER_WEIGHTS, compute_scores  # noqa: E402
 from trade_modules.v3.conditioning import resolve_deployment  # noqa: E402
 from trade_modules.v3.construct import mega_core_by_cap, region_of  # noqa: E402
 from trade_modules.v3.features import enrich_features  # noqa: E402
@@ -68,19 +68,11 @@ ETORO_CSV = "yahoofinance/output/etoro.csv"
 _OUT_DIR = os.path.expanduser(os.environ.get("V3_OUT_DIR", "~/Downloads"))
 PREVIEW_OUT = os.path.join(_OUT_DIR, "v3_overlay_preview.html")
 
-# 2026-07-21 (owner review): locked master-taxonomy cluster weights (sum of the per-metric
-# weights per cluster). Quality-led (absorbs net_issuance), value = P/S+P/B+pe_forward,
-# growth = earn_growth+earn_stability, low-vol → 0 (beta/realized_vol are SIZING, not alpha).
-BALANCED_WEIGHTS: dict[str, float] = {
-    "value": 0.16,
-    "quality": 0.42,
-    "momentum": 0.14,
-    "growth": 0.12,
-    "pead": 0.06,
-    "trajectory": 0.05,
-    "strength": 0.05,
-    "lowvol": 0.00,
-}
+# Owner taxonomy (2026-07-23): the LIVE cluster weights are DERIVED from the single source of
+# truth in combine.METRIC_WEIGHTS (via CLUSTER_WEIGHTS), expressed with short keys for the
+# overlay's explicit cluster_weights arg. Deriving here (not re-hardcoding) keeps the live
+# report in lockstep with the engine and the per-metric taxonomy — it can never drift.
+BALANCED_WEIGHTS: dict[str, float] = {c[:-2]: w for c, w in CLUSTER_WEIGHTS.items()}
 
 # The mega-cap "core" is derived at RUNTIME from market cap (>= the $200B mega tier)
 # via mega_core_by_cap() — NOT a hardcoded ticker list. Any holding qualifies for the

--- a/scripts/v3_pipeline_map.py
+++ b/scripts/v3_pipeline_map.py
@@ -63,7 +63,7 @@ LABEL = {
     "gp_assets": "Gross profit / assets",
     "sue": "Earnings surprise (SUE)",
     "asset_growth": "Asset growth (CMA)",
-    "earn_trajectory": "Earnings trajectory (PET/PEF)",
+    "earn_trajectory": "Earnings trajectory (PEF/PET)",
 }
 _DIRTXT = {1: "high = good", -1: "low = good"}
 

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -116,9 +116,9 @@ def test_no_quote_type_column_means_all_eligible():
 
 
 def test_value_trap_gate_excludes_forward_pe_far_above_trailing():
-    """Owner rule (2026-07-20): forward P/E > 1.10x trailing (earn_trajectory < 1/1.10)
-    = value trap -> INELIGIBLE, so a trap never surfaces as a BUY and a held trap trips
-    the overlay's weak-name SELL. Names at/below the threshold stay eligible."""
+    """Owner rule: forward P/E > 1.10x trailing (earn_trajectory = PEF/PET > 1.10) = value
+    trap -> INELIGIBLE, so a trap never surfaces as a BUY and a held trap trips the overlay's
+    weak-name SELL. Names at/below the threshold stay eligible."""
     idx = ["GOOD", "FLAT", "TRAP"]
     df = _base(idx)
     df["quote_type"] = ["EQUITY", "EQUITY", "EQUITY"]
@@ -127,9 +127,9 @@ def test_value_trap_gate_excludes_forward_pe_far_above_trailing():
     df["roe"] = [30.0, 20.0, 25.0]
     df["mom_12_1"] = [0.20, 0.15, 0.10]
     df["realized_vol"] = [0.20, 0.22, 0.25]
-    # earn_trajectory = PET/PEF: GOOD 1.11 (forward cheaper), FLAT 1.0 (=trailing, not a
-    # trap), TRAP 3.2/46 = 0.07 (forward 14x trailing = earnings collapsing).
-    df["earn_trajectory"] = [1.11, 1.0, 3.2 / 46.0]
+    # earn_trajectory = PEF/PET: GOOD 0.90 (forward cheaper), FLAT 1.0 (=trailing, not a
+    # trap), TRAP 46/3.2 = 14.4 (forward 14x trailing = earnings collapsing).
+    df["earn_trajectory"] = [0.90, 1.0, 46.0 / 3.2]
 
     scores = compute_scores(df, sector_neutral=False)
 
@@ -372,20 +372,20 @@ def test_growth_cluster_registered_direction_positive():
     ]
 
 
-def test_trajectory_cluster_registered_direction_positive():
-    """Earnings-trajectory (PET/PEF) is a scored cluster: high ratio = forward cheaper =
-    earnings expected to rise, DIRECTION +1. Recovers the PET->PEF info dropped when
-    pe_forward left scoring; strongest survivorship-clean signal (beta-neutral t 2.17)."""
+def test_trajectory_cluster_registered_direction_negative():
+    """Earnings-trajectory (PEF/PET, owner 2026-07-23): LOW ratio = forward cheaper =
+    earnings expected to rise, DIRECTION -1 (smaller is better). Inverted from the old
+    PET/PEF so "< 1 is good"; strongest survivorship-clean signal (beta-neutral t 2.17)."""
     from trade_modules.v3.combine import CLUSTERS, DIRECTION
 
     assert CLUSTERS["trajectory_z"] == ["earn_trajectory"]
-    assert DIRECTION["earn_trajectory"] == +1
+    assert DIRECTION["earn_trajectory"] == -1
 
 
 def test_trajectory_z_rising_earnings_ranks_above_falling():
-    """High PET/PEF (earnings rising) ranks above a falling-earnings peer (kept, +1)."""
+    """Low PEF/PET (earnings rising, forward cheaper) ranks above a falling-earnings peer."""
     df = _base(["RISING", "FLAT", "FALLING"])
-    df["earn_trajectory"] = [2.0, 1.0, 0.5]  # PET/PEF: >1 rising, <1 falling
+    df["earn_trajectory"] = [0.5, 1.0, 2.0]  # PEF/PET: <1 rising (fwd cheaper), >1 falling
     scores = compute_scores(df, sector_neutral=False)
     assert scores.loc["RISING", "trajectory_z"] > scores.loc["FLAT", "trajectory_z"]
     assert scores.loc["FLAT", "trajectory_z"] > scores.loc["FALLING", "trajectory_z"]
@@ -488,20 +488,14 @@ def test_backward_compat_none_equals_explicit_default_weights():
     df["roe"] = [40.0, 25.0, 15.0, 5.0]
     df["pct_52w_high"] = [0.30, 0.10, -0.05, -0.20]
 
+    from trade_modules.v3.combine import CLUSTER_WEIGHTS
+
     default = compute_scores(df, sector_neutral=False)
     explicit = compute_scores(
         df,
         sector_neutral=False,
-        cluster_weights={
-            "value": 0.16,
-            "quality": 0.42,
-            "momentum": 0.14,
-            "growth": 0.12,
-            "pead": 0.06,
-            "trajectory": 0.05,
-            "strength": 0.05,
-            "lowvol": 0.00,
-        },
+        # the default expressed with short keys — reproduces None exactly (drift-proof).
+        cluster_weights={c[:-2]: w for c, w in CLUSTER_WEIGHTS.items()},
     )
     assert np.allclose(
         default["conviction"].to_numpy(dtype=float),
@@ -575,18 +569,20 @@ def test_quality_is_roe_fcf_gp_assets():
             assert dead not in members, f"{dead} must not be scored in quality"
 
 
-def test_master_taxonomy_weights_2026_07_21():
-    """Master-taxonomy cluster weights (owner-locked 2026-07-21): quality-led (absorbs
-    net_issuance t2.95), low-vol -> 0 (beta/realized_vol moved to SIZING, not scored alpha),
-    value = P/S+P/B+pe_forward, growth = earn_growth+earn_stability above the analyst earn-in
-    sleeve, PEAD + trajectory retained. Value+Quality within the 0.60 cap; sum = 1."""
+def test_master_taxonomy_weights_2026_07_23():
+    """Owner taxonomy (2026-07-23), DERIVED from METRIC_WEIGHTS: quality-led 0.25 (ROE the
+    0.10 lead), SUE + PEF/PET the raised expectation signals (0.15 each), analyst_mom /
+    momentum / growth 0.10, value 0.15, low-vol -> 0 (sizing). V+Q within the 0.60 cap; Σ=1."""
     from trade_modules.v3.combine import CLUSTER_WEIGHTS as w
 
     assert w["quality_z"] == max(w.values()), "quality is the evidence leader"
-    assert w["pead_z"] > 0 and w["trajectory_z"] > 0, "PEAD + trajectory participate"
+    assert w["quality_z"] == pytest.approx(0.25)
+    assert w["pead_z"] == pytest.approx(0.15) and w["trajectory_z"] == pytest.approx(0.15)
+    assert w["momentum_z"] == pytest.approx(0.10) and w["strength_z"] == pytest.approx(0.10)
+    assert w["growth_z"] == pytest.approx(0.10) and w["value_z"] == pytest.approx(0.15)
     assert w["lowvol_z"] == 0.0, "low-vol -> 0 (moved to sizing, not alpha)"
     assert (w["value_z"] + w["quality_z"]) <= 0.60 + 1e-9, "value+quality within the 0.60 cap"
-    assert w["growth_z"] > w["strength_z"], "growth satellite above the analyst earn-in sleeve"
+    assert sum(w.values()) == pytest.approx(1.0)
     assert abs(sum(w.values()) - 1.0) < 1e-9
 
 

--- a/tests/unit/trade_modules/test_v3_features.py
+++ b/tests/unit/trade_modules/test_v3_features.py
@@ -447,10 +447,11 @@ def test_percent_and_numeric_coercion(tmp_path):
 
 
 def test_earn_trajectory_math(tmp_path):
-    """earn_trajectory = trailing/forward P/E (>1 = forward cheaper = earnings rising)."""
+    """earn_trajectory = forward/trailing P/E (PEF/PET, owner 2026-07-23): <1 = forward
+    cheaper = earnings expected to RISE (direction -1, smaller is better)."""
     feats = _run(tmp_path)
-    assert abs(feats.loc["AAPL", "earn_trajectory"] - 28.5 / 25.0) < 1e-9
-    assert abs(feats.loc["MSFT", "earn_trajectory"] - 35.0 / 30.0) < 1e-9
+    assert abs(feats.loc["AAPL", "earn_trajectory"] - 25.0 / 28.5) < 1e-9
+    assert abs(feats.loc["MSFT", "earn_trajectory"] - 30.0 / 35.0) < 1e-9
 
 
 def test_target_dispersion_math(tmp_path):

--- a/tests/unit/trade_modules/test_v3_metric_weights.py
+++ b/tests/unit/trade_modules/test_v3_metric_weights.py
@@ -1,0 +1,88 @@
+"""TDD — per-metric weighting inside clusters (owner taxonomy 2026-07-23).
+
+The engine historically applied an EQUAL mean of the member metric-z's inside each
+cluster, so an unequal per-metric weight (e.g. ROE at 2x the other quality metrics)
+was invisible. These tests pin the new contract: ``METRIC_WEIGHTS`` is the SSOT of
+per-metric conviction weight, ``CLUSTER_WEIGHTS`` is DERIVED from it (cluster = sum of
+its members' weights; value is the one composite cluster), and a cluster-z is the
+``METRIC_WEIGHTS``-weighted mean of the members PRESENT for a row (renormalized over
+present, so a missing metric is never a penalty — same rule as the value recipe).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trade_modules.v3.combine import (
+    CLUSTER_WEIGHTS,
+    CLUSTERS,
+    METRIC_WEIGHTS,
+    compute_scores,
+)
+
+
+def _base(index):
+    """Feature frame with every cluster metric NaN; tests set only what they need."""
+    cols = set()
+    for members in CLUSTERS.values():
+        cols.update(members)
+    df = pd.DataFrame({c: [np.nan] * len(index) for c in cols}, index=index)
+    df["sector"] = ["__NA__"] * len(index)
+    return df
+
+
+def test_cluster_weights_are_derived_from_metric_weights():
+    """Each non-value cluster weight == the sum of its members' METRIC_WEIGHTS; value is
+    the single composite cluster (its internal split is VALUE_GROUP_RECIPES)."""
+    assert CLUSTER_WEIGHTS["quality_z"] == pytest.approx(0.25)  # roe .10 + fcf/gp/ni .05
+    assert CLUSTER_WEIGHTS["growth_z"] == pytest.approx(0.10)  # earn_growth + earn_stability
+    assert CLUSTER_WEIGHTS["momentum_z"] == pytest.approx(0.10)  # pct_52w_high
+    assert CLUSTER_WEIGHTS["pead_z"] == pytest.approx(0.15)  # sue
+    assert CLUSTER_WEIGHTS["trajectory_z"] == pytest.approx(0.15)  # earn_trajectory (PEF/PET)
+    assert CLUSTER_WEIGHTS["strength_z"] == pytest.approx(0.10)  # analyst_mom
+    assert CLUSTER_WEIGHTS["value_z"] == pytest.approx(0.15)  # composite
+    assert CLUSTER_WEIGHTS["lowvol_z"] == pytest.approx(0.0)  # sizing only
+
+
+def test_cluster_weights_sum_to_one():
+    assert sum(CLUSTER_WEIGHTS.values()) == pytest.approx(1.0)
+
+
+def test_metric_weights_plus_value_sum_to_one():
+    assert sum(METRIC_WEIGHTS.values()) + CLUSTER_WEIGHTS["value_z"] == pytest.approx(1.0)
+
+
+def test_roe_carries_double_the_intra_quality_weight_of_fcf():
+    """ROE (0.10) is weighted 2x FCF (0.05) inside quality. With ROE and FCF perfectly
+    anti-correlated across three names (gp_assets / net_issuance absent), the ROE-strong
+    name must win quality_z — under the OLD equal mean the two extremes would TIE at 0."""
+    idx = ["HI_ROE", "MID", "HI_FCF"]
+    df = _base(idx)
+    df["roe"] = [3.0, 2.0, 1.0]  # HI_ROE best ROE, HI_FCF worst
+    df["fcf"] = [1.0, 2.0, 3.0]  # ...and the reverse for FCF
+    s = compute_scores(df, sector_neutral=False)
+    assert s.loc["HI_ROE", "quality_z"] > s.loc["HI_FCF", "quality_z"]
+
+
+def test_equal_weight_members_reduce_to_plain_mean():
+    """Growth's two members are equal-weight (0.05 each), so the weighted mean must
+    still equal the plain mean — two symmetric anti-correlated names tie at 0."""
+    idx = ["A", "B", "C"]
+    df = _base(idx)
+    df["earn_growth"] = [3.0, 2.0, 1.0]
+    df["earn_stability"] = [1.0, 2.0, 3.0]
+    s = compute_scores(df, sector_neutral=False)
+    assert s.loc["A", "growth_z"] == pytest.approx(s.loc["C", "growth_z"], abs=1e-9)
+
+
+def test_single_present_quality_metric_reproduces_its_own_z():
+    """A name with only ROE present (fcf/gp/ni NaN) gets quality_z == its ROE-z: the
+    weighted mean renormalizes over present members, so a lone metric is not diluted."""
+    idx = ["A", "B", "C"]
+    df = _base(idx)
+    df["roe"] = [40.0, 20.0, 5.0]
+    s = compute_scores(df, sector_neutral=False)
+    assert s.loc["A", "quality_z"] == pytest.approx(s.loc["A", "roe_z"], abs=1e-12)
+    assert s.loc["C", "quality_z"] == pytest.approx(s.loc["C", "roe_z"], abs=1e-12)

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -47,13 +47,13 @@ def test_missing_data_holds_but_value_trap_sells():
     from MISSING DATA (dataless, or ineligible with no value-trap) is HELD-with-flag,
     never auto-sold. Only a POSITIVE trigger sells: a genuinely-eligible bottom-
     percentile conviction, or a value-trap (fwd P/E > 1.10x trailing = earn_trajectory
-    below 1/1.10)."""
+    = PEF/PET above 1.10)."""
     _tks, _convs, sc = _universe20()
     extra = _scored(["INELIG", "TRAP"], [np.nan, np.nan], eligible=[False, False])
     extra["earn_trajectory"] = [
         np.nan,
-        0.80,
-    ]  # INELIG: missing-data; TRAP: earnings expected to fall
+        1.25,
+    ]  # INELIG: missing-data; TRAP: fwd P/E 25% above trailing -> earnings expected to fall
     sc = pd.concat([sc, extra])
     # held: strong keep, eligible-weak (sell), missing-data ineligible (hold),
     # value-trap (sell), dataless/absent from scored (hold).
@@ -605,12 +605,12 @@ def test_portfolio_aware_tiebreaker_prefers_underweight_sector():
 
 
 def test_trajectory_guard_excludes_rising_forward_pe_buy():
-    """A buy whose forward P/E is materially above trailing (earn_trajectory = PET/PEF
-    below ~0.95, i.e. fwd P/E > 1.05x trailing -> earnings expected to fall) is screened;
+    """A buy whose forward P/E is materially above trailing (earn_trajectory = PEF/PET
+    above ~1.05, i.e. fwd P/E > 1.05x trailing -> earnings expected to fall) is screened;
     a positive-trajectory candidate is bought instead."""
     _tks, _convs, sc = _universe20()
     sc["earn_trajectory"] = np.nan
-    sc.loc["U00", "earn_trajectory"] = 0.90  # fwd P/E ~11% above trailing -> value-trap-ish
+    sc.loc["U00", "earn_trajectory"] = 1.10  # fwd P/E ~10% above trailing -> value-trap-ish
     current = pd.Series({"U10": 0.3})
 
     d = build_overlay(sc, current, pd.DataFrame(), max_new=2)["diagnostics"]

--- a/tests/unit/trade_modules/test_v3_weight_proposal.py
+++ b/tests/unit/trade_modules/test_v3_weight_proposal.py
@@ -16,19 +16,11 @@ def test_no_data_returns_prior():
         assert p[c] == pytest.approx(PRIOR[c])
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Real (pre-existing) inconsistency surfaced by the 2026-07-23 review: the deployed "
-        "CLUSTER_WEIGHTS put quality at 0.42, above the adaptive mechanism's 0.30 cap (and "
-        "several small clusters below its 0.10 floor), so the deployed prior is NOT "
-        "guardrail-valid and does not round-trip. This is the quality-over-concentration "
-        "finding; it resolves when the factor-set / cap decision is made — not a stale test."
-    ),
-    strict=True,
-)
 def test_real_cluster_weights_roundtrip_at_zero_data():
     # The deployed best-bet prior must be guardrail-valid: at n=0 the mechanism returns
-    # it unchanged (so deploying it == the mechanism's current proposal).
+    # it unchanged (so deploying it == the mechanism's current proposal). Resolved by the
+    # 2026-07-23 owner taxonomy: quality 0.42->0.25 (<= the 0.30 cap) and no cluster below
+    # its floor, so the deployed prior now round-trips exactly (was xfail'd before the fix).
     from trade_modules.v3.combine import CLUSTER_WEIGHTS
 
     p = propose_weights(dict(CLUSTER_WEIGHTS), ic={}, n={})

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -54,10 +54,10 @@ DIRECTION = {
     # earnings surprise / PEAD + investment (2026-07-19)
     "sue": +1,  # standardized unexpected earnings (post-earnings drift; high is good)
     "asset_growth": -1,  # CMA / investment (low is good) — monitored, not scored
-    # earnings trajectory (2026-07-20): trailing/forward P/E ratio (high = forward cheaper
-    # = earnings expected to RISE; low = value-trap). The distinct PET->PEF information
-    # lost when raw pe_forward was pruned. Strongest survivorship-clean signal we found.
-    "earn_trajectory": +1,
+    # earnings trajectory (2026-07-23, owner: PEF/PET) = forward/trailing P/E ratio (LOW =
+    # forward cheaper = earnings expected to RISE; high = value-trap). Renamed+inverted from
+    # PET/PEF so "smaller is better" -> DIRECTION -1. Strongest survivorship-clean signal.
+    "earn_trajectory": -1,
     # net share issuance (2026-07-21): dilution bad / buyback good (Pontiff-Woodgate).
     "net_issuance": -1,
     # earnings stability (2026-07-21): low earnings coefficient-of-variation = QMJ 'safety'.
@@ -93,12 +93,12 @@ CLUSTERS = {
     # signal (beta-neutral IC t 2.06, hit 68%) + robust literature (Bernard-Thomas).
     # SUE = seasonal-random-walk standardized unexpected earnings, from SF1 actuals.
     "pead_z": ["sue"],
-    # Earnings trajectory (2026-07-20): PET/PEF = trailing/forward P/E ratio. Recovers
-    # the forward-looking information dropped when raw pe_forward was pruned (the LEVEL
-    # was a near-dup of trailing, zero IC; the SPREAD is not). Best clean signal on the
-    # panel: beta-neutral forward IC t 2.17, hit 80%, incremental to value+growth (FM
-    # t 1.71). Panel-only (Sharadar has no forward estimates) -> earn-in via the adaptive
-    # mechanism as forward IC accrues.
+    # Earnings trajectory (owner 2026-07-23): PEF/PET = forward/trailing P/E ratio (LOW =
+    # forward cheaper = earnings expected to RISE; DIRECTION -1). Recovers the forward-looking
+    # information dropped when raw pe_forward was pruned (the LEVEL was a near-dup of trailing,
+    # zero IC; the SPREAD is not). Best clean signal on the panel: beta-neutral forward IC
+    # t 2.17, hit 80%, incremental to value+growth (FM t 1.71). Panel-only (Sharadar has no
+    # forward estimates) -> earn-in via the adaptive mechanism as forward IC accrues.
     "trajectory_z": ["earn_trajectory"],
 }
 
@@ -146,42 +146,56 @@ VALUE_WEIGHT_MULT = {"A": 1.0, "B": 1.0, "C": 0.5}
 # Every metric that can appear in a value recipe needs a metric-z computed.
 _VALUE_CANDIDATES = sorted({m for r in VALUE_GROUP_RECIPES.values() for m in r})
 
-# FIX-NOW 2026-07-18 (D14/D6b/D11/D7): equal-risk core, NO discretionary tilt, and
-# NO Value+Quality cap-as-floor. Core (value/quality/momentum/lowvol) equal; growth a
-# reduced satellite; strength (analyst_mom only) a small cap. Sum = 1.0. Weight
-# ESTIMATION is frozen (no MVO/IC-fit on the ~5-mo panel — forecast-combination puzzle);
-# the ic_weights path stays available for the later sizing tier. (True equal-VOL
-# standardization of the cluster z's is a fast-follow refinement; this sets the
-# equal-risk nominal shares and removes the 0.55 VQ floor.)
-# BEST-BET PRIOR 2026-07-19 (grounded in our survivorship-clean backtest + literature,
-# Bayesian-anchored). Quality-led (GP/assets = best clean IC + Novy-Marx); value +
-# momentum held as durable decades-premia (regime-weak now, not chased-dropped); PEAD
-# added (best clean signal + robust); low-vol trimmed 0.21->0.10 (our clean data showed
-# its standalone alpha was a beta artifact -> risk-diversifier only); growth trimmed
-# (short-leg-of-value). CMA + accruals EXCLUDED (no clean alpha). The adaptive shrinkage
-# mechanism (v3/weight_proposal.py) proposes drift toward measured forward IC as data accrues.
-# 2026-07-20: earnings-trajectory (PET/PEF) added at 0.10 — the strongest clean signal on
-# the panel (beta-neutral t 2.17, hit 80%, incremental to value+growth). Funded by trimming
-# value/momentum 0.20->0.18, growth 0.08->0.05, strength 0.07->0.05, quality 0.25->0.24.
-# 2026-07-20 (C): analyst_mom (strength_z) upweighted 0.05->0.08 — β-neutral forward IC
-# t 2.36 on the panel, the 2nd-strongest clean signal after trajectory; kept modest (it is
-# a single noisy metric: raw IC ~0, hit 50%). Funded by growth 0.05->0.03 (theory-weak) +
-# low-vol 0.10->0.09 (risk-diversifier, not alpha). Upside/EXR stay MONITOR (zero β-alpha,
-# t -0.15) — a negative-upside BUY is often a right contrarian bet (see capitulation study).
-# 2026-07-21 (owner review): cluster weights re-derived as the SUM of the locked per-metric
-# weights per cluster (master taxonomy). Quality absorbs net_issuance (t2.95) + is the
-# strongest sleeve; value = P/S+P/B+pe_forward; growth = earn_growth+earn_stability; low-vol
-# → 0 (beta/realized_vol moved to SIZING, not alpha). Within-cluster is still ~equal-mean here
-# (a first-look approximation of the 13/13/9/7-type per-metric weights).
+# ---------------------------------------------------------------------------
+# Owner taxonomy (2026-07-23): per-metric conviction weights are the SINGLE SOURCE OF
+# TRUTH. Every scored metric carries an explicit GLOBAL weight here; the cluster weights
+# below are DERIVED as the sum of their members' weights, and the intra-cluster split (see
+# compute_scores) is these weights renormalized over the members PRESENT for a row. This
+# replaces the old equal-mean-within-cluster approximation, so a declared weight (e.g. ROE
+# at 0.10 = 2x the other quality metrics) is what the engine ACTUALLY applies.
+#
+# Value is the one COMPOSITE cluster: it carries a single cluster weight (_VALUE_WEIGHT) and
+# its internal split is sector-conditional (VALUE_GROUP_RECIPES), so it is not listed per
+# metric here. Low-vol (beta/realized_vol) is SIZING-only -> weight 0 (BAB: the low-vol
+# premium is a beta artifact — size on it, do not score alpha on it).
+#
+# History: quality-led best-bet prior (2026-07-19/21; GP/assets + net_issuance + PEAD +
+# trajectory the survivorship-clean leaders, low-vol -> sizing). 2026-07-23 owner rebalance:
+# quality 0.42->0.25 (ROE 0.10 kept as the quality lead, 2x the FCF/GP/net_issuance 0.05
+# each); SUE + PEF/PET raised to 0.15 (the two most robust expectation signals); analyst_mom
+# 0.10, momentum 0.10, growth 0.10, value 0.15. The adaptive shrinkage mechanism
+# (v3/weight_proposal.py) proposes drift toward measured forward IC as data accrues; these
+# remain a PRIOR, applied only by human decision.
+# ---------------------------------------------------------------------------
+METRIC_WEIGHTS: dict[str, float] = {
+    # quality (0.25): ROE leads at 2x the others
+    "roe": 0.10,
+    "fcf": 0.05,
+    "gp_assets": 0.05,
+    "net_issuance": 0.05,
+    # growth (0.10)
+    "earn_growth": 0.05,
+    "earn_stability": 0.05,
+    # momentum (0.10)
+    "pct_52w_high": 0.10,
+    # PEAD / earnings surprise (0.15)
+    "sue": 0.15,
+    # earnings trajectory PEF/PET (0.15)
+    "earn_trajectory": 0.15,
+    # analyst momentum (0.10)
+    "analyst_mom": 0.10,
+}
+_VALUE_WEIGHT = 0.15  # the composite value cluster (sector-conditional recipe)
+
+# Cluster weights are DERIVED: value = _VALUE_WEIGHT; every other cluster = the sum of its
+# members' METRIC_WEIGHTS (metrics absent from METRIC_WEIGHTS contribute 0 -> low-vol = 0).
 CLUSTER_WEIGHTS = {
-    "value_z": 0.16,
-    "quality_z": 0.42,
-    "momentum_z": 0.14,
-    "growth_z": 0.12,
-    "pead_z": 0.06,
-    "trajectory_z": 0.05,
-    "strength_z": 0.05,
-    "lowvol_z": 0.00,
+    cluster: (
+        _VALUE_WEIGHT
+        if cluster == "value_z"
+        else round(sum(METRIC_WEIGHTS.get(m, 0.0) for m in members), 10)
+    )
+    for cluster, members in CLUSTERS.items()
 }
 
 # The Value+Quality joint weight is capped here regardless of the weighting scheme.
@@ -307,14 +321,13 @@ _ELIG_CLUSTERS = [
 ]
 _MIN_CLUSTERS = 3
 
-# Value-trap gate (2026-07-20, owner rule): a forward P/E materially above trailing means
-# earnings are expected to FALL (a value trap / cyclical peak) — the trailing-cheap look is
-# a mirage. earn_trajectory = PET/PEF, so "forward > 1.10x trailing" is earn_trajectory <
-# 1/1.10. Trap names are made INELIGIBLE: they never surface as a new BUY, and a held trap
-# trips the overlay's weak-name SELL — so a collapsing-earnings name is never recommended
-# as attractive. Names with a missing PET or PEF (NaN trajectory) are never gated.
-_TRAP_MAX_FWD_TTM = 1.10
-_TRAP_MIN_TRAJECTORY = 1.0 / _TRAP_MAX_FWD_TTM
+# Value-trap gate (owner rule): a forward P/E materially above trailing means earnings are
+# expected to FALL (a value trap / cyclical peak) — the trailing-cheap look is a mirage.
+# earn_trajectory = PEF/PET, so "forward > 1.10x trailing" is earn_trajectory > 1.10. Trap
+# names are made INELIGIBLE: they never surface as a new BUY, and a held trap trips the
+# overlay's weak-name SELL — so a collapsing-earnings name is never recommended as attractive.
+# Names with a missing PET or PEF (NaN trajectory) are never gated.
+_TRAP_MAX_FWD_TTM = 1.10  # forward P/E may not exceed 1.10x trailing (= PEF/PET ceiling)
 
 
 def _rank_z(s: pd.Series) -> pd.Series:
@@ -427,10 +440,10 @@ def _eligibility(out: pd.DataFrame) -> pd.Series:
             ok &= pd.to_numeric(out[col], errors="coerce").notna()
     clusters_present = out[_ELIG_CLUSTERS].notna().sum(axis=1)
     ok &= clusters_present >= _MIN_CLUSTERS
-    # Value-trap gate: forward P/E > 1.10x trailing (earn_trajectory below 1/1.10).
+    # Value-trap gate: forward P/E > 1.10x trailing (earn_trajectory = PEF/PET above 1.10).
     if "earn_trajectory" in out.columns:
         traj = pd.to_numeric(out["earn_trajectory"], errors="coerce")
-        ok &= ~(traj < _TRAP_MIN_TRAJECTORY)  # NaN trajectory (missing PET/PEF) never gated
+        ok &= ~(traj > _TRAP_MAX_FWD_TTM)  # NaN trajectory (missing PET/PEF) never gated
     return ok.fillna(False).astype(bool)
 
 
@@ -480,12 +493,24 @@ def compute_scores(
             z = _sector_demean(z, sector)
         out[f"{m}_z"] = z
 
-    # Non-value clusters: cluster z = mean of member metric-z, skipping NaN.
+    # Non-value clusters: cluster z = METRIC_WEIGHTS-weighted mean of member metric-z,
+    # renormalized over the members PRESENT for each row (a missing metric is never a
+    # penalty; equal weights reproduce the plain mean). This is what makes the declared
+    # per-metric weights — e.g. ROE at 2x the other quality metrics — actually apply.
     for cluster, members in CLUSTERS.items():
         if cluster == "value_z":
             continue
         zcols = [f"{m}_z" for m in members if f"{m}_z" in out.columns]
-        out[cluster] = out[zcols].mean(axis=1, skipna=True) if zcols else np.nan
+        if not zcols:
+            out[cluster] = np.nan
+            continue
+        ws = np.array([METRIC_WEIGHTS.get(c[:-2], 1.0) for c in zcols], dtype=float)
+        sub = out[zcols]
+        wmat = pd.DataFrame(np.tile(ws, (len(sub), 1)), index=sub.index, columns=zcols).where(
+            sub.notna()
+        )
+        wsum = wmat.sum(axis=1)
+        out[cluster] = (sub * wmat).sum(axis=1) / wsum.where(wsum > 0)
 
     # Value cluster: sector-conditional recipe (banks->P/B, REITs->cash-flow,
     # tech->sales) instead of one uniform P/E + EV/EBITDA mean.

--- a/trade_modules/v3/features.py
+++ b/trade_modules/v3/features.py
@@ -591,12 +591,12 @@ def enrich_features(
     safe_price = price.where(price > 0)
     disp = (feats["target_high"] - feats["target_low"]) / safe_price
     feats["target_dispersion"] = disp.replace([float("inf"), float("-inf")], float("nan"))
-    # earnings trajectory = trailing/forward P/E (>1 = forward cheaper = earnings expected
-    # to rise; <1 = value-trap). The distinct PET->PEF information lost when raw pe_forward
-    # left scoring; scored via the trajectory_z cluster (2026-07-20).
+    # earnings trajectory = forward/trailing P/E (PEF/PET, owner 2026-07-23): <1 = forward
+    # cheaper = earnings expected to RISE; >1 = value-trap (earnings expected to fall).
+    # Scored via the trajectory_z cluster with DIRECTION -1 (smaller is better).
     pet = pd.to_numeric(feats["pe_trailing"], errors="coerce")
     pef = pd.to_numeric(feats["pe_forward"], errors="coerce")
-    feats["earn_trajectory"] = (pet / pef).where((pet > 0) & (pef > 0))
+    feats["earn_trajectory"] = (pef / pet).where((pet > 0) & (pef > 0))
     # adv_usd = shares * local price * FX -> USD dollar-volume (for the ADV floor).
     feats["adv_usd"] = feats["avg_volume"] * price * feats.index.to_series().map(_usd_rate_for)
 

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -32,7 +32,7 @@ from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
-from trade_modules.v3.combine import _TRAP_MIN_TRAJECTORY
+from trade_modules.v3.combine import _TRAP_MAX_FWD_TTM
 from trade_modules.v3.construct import (
     _norm_name,
     _root_of,
@@ -157,7 +157,7 @@ def _screen_buy_candidates(
     max_de: float | None,
     min_analyst_mom: float | None = None,
     min_analyst_n: int = 4,
-    min_earn_trajectory: float | None = None,
+    max_earn_trajectory: float | None = None,
 ) -> tuple[list[str], list[str]]:
     """FIX-NOW 2026-07-18 (D4/D8): drop squeeze-risky / distressed names from the BUY
     pool. Applied to buys ONLY — never force-sells a holding.
@@ -170,9 +170,9 @@ def _screen_buy_candidates(
         Street is actively downgrading the name with meaningful coverage (owner
         2026-07-22). Asymmetric: we reject active downgrades but never *require*
         positive coverage (that would anti-select momentum winners);
-      * earn_trajectory (= trailing/forward P/E) < ``min_earn_trajectory`` — forward
-        P/E materially above trailing, i.e. earnings expected to FALL (value-trap tilt;
-        owner 2026-07-22). Use ``1/1.05`` to block a > 1.05x forward/trailing rise.
+      * earn_trajectory (= PEF/PET = forward/trailing P/E) > ``max_earn_trajectory`` —
+        forward P/E materially above trailing, i.e. earnings expected to FALL (value-trap
+        tilt; owner 2026-07-22). Use ``1.05`` to block a > 1.05x forward/trailing rise.
     A criterion whose param is ``None`` is off; an absent column or NaN value never
     excludes (missing data is not treated as a red flag). Returns (kept, screened_out).
     """
@@ -217,7 +217,7 @@ def _screen_buy_candidates(
             and na >= min_analyst_n
         )
         value_trap = (
-            min_earn_trajectory is not None and pd.notna(traj) and traj < min_earn_trajectory
+            max_earn_trajectory is not None and pd.notna(traj) and traj > max_earn_trajectory
         )
         excluded = squeeze or illiquid or levered or downgraded or value_trap
         (out if excluded else kept).append(t)
@@ -357,7 +357,7 @@ def build_overlay(
     max_de: float | None = None,
     min_analyst_mom: float | None = -3.0,  # owner 2026-07-22: veto buys the Street is downgrading
     min_analyst_n: int = 4,  # ...only when coverage is meaningful (>=4 analysts)
-    min_earn_trajectory: float | None = 1.0 / 1.05,  # veto buys w/ fwd P/E > 1.05x trailing
+    max_earn_trajectory: float | None = 1.05,  # veto buys w/ fwd P/E > 1.05x trailing (PEF/PET)
     min_conviction: float | None = None,  # absolute conviction floor for a new buy (owner)
     portfolio_aware: bool = False,  # tilt buy selection toward under-weight sectors/markets
     tier_name_caps: bool = False,
@@ -437,8 +437,8 @@ def build_overlay(
     core_set = set(core_list or [])
 
     # Value-trap = a POSITIVE deterioration signal: forward P/E materially above
-    # trailing (earn_trajectory < 1/1.10 => earnings expected to fall). A held trap is
-    # SOLD even though the eligibility gate marks it ineligible; MISSING data (no
+    # trailing (earn_trajectory = PEF/PET > 1.10 => earnings expected to fall). A held trap
+    # is SOLD even though the eligibility gate marks it ineligible; MISSING data (no
     # trajectory) is NOT a trap and must never trigger a sell.
     _traj = (
         pd.to_numeric(scored["earn_trajectory"], errors="coerce")
@@ -450,7 +450,7 @@ def build_overlay(
         if t not in _traj.index:
             return False
         v = _traj.loc[t]
-        return bool(pd.notna(v) and float(v) < _TRAP_MIN_TRAJECTORY)
+        return bool(pd.notna(v) and float(v) > _TRAP_MAX_FWD_TTM)
 
     def _is_unscoreable(t: str) -> bool:
         """Un-scoreable from MISSING DATA: dataless, NaN conviction, or ineligible.
@@ -509,7 +509,7 @@ def build_overlay(
             max_de=max_de,
             min_analyst_mom=min_analyst_mom,
             min_analyst_n=min_analyst_n,
-            min_earn_trajectory=min_earn_trajectory,
+            max_earn_trajectory=max_earn_trajectory,
         )
         # Owner 2026-07-22: tilt selection toward what the book NEEDS — skip at-cap
         # sectors/markets and re-rank by conviction minus a mild crowding penalty.

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -98,7 +98,7 @@ DISPLAY_GROUPS = [
         ],
     ),
     ("PEAD", [("sue", "SUE")]),
-    ("Trajectory", [("earn_trajectory", "PET/PEF")]),
+    ("Trajectory", [("earn_trajectory", "PEF/PET")]),
     ("Low-vol", [("beta", "Beta"), ("realized_vol", "Realized Vol")]),
     ("Strength", [("short_interest", "Short Int"), ("target_dispersion", "Target Disp")]),
     (


### PR DESCRIPTION
## Summary
Owner factor-weight rebalance + a structural fix so the declared per-metric weights are **actually applied** (the engine previously approximated with an equal mean inside each cluster).

### New per-metric weights (Σ=100)
| Metric | Weight | | Metric | Weight |
|---|---|---|---|---|
| ROE | **10** | | SUE | **15** |
| FCF | 5 | | PEF/PET | **15** |
| GP/assets | 5 | | analyst momentum | 10 |
| net issuance | 5 | | value (composite) | 15 |
| earn growth | 5 | | %52w-high | 10 |
| earn stability | 5 | | low-vol | 0 (sizing) |

### Key changes
- **Per-metric weighting**: `METRIC_WEIGHTS` is the SSOT; `CLUSTER_WEIGHTS` is derived from it; non-value clusters aggregate as a **weighted mean** (renormalized over present members). ROE now leads quality at 2× the others.
- **PEF/PET inversion**: `earn_trajectory` renamed + inverted PET/PEF → **PEF/PET** (forward/trailing P/E, `DIRECTION -1`, smaller = better, <1 = forward cheaper = earnings rising). Eligibility gate, buy-veto (`max_earn_trajectory=1.05`) and held-trap SELL flipped to `> 1.10`/`1.05`.
- **No drift**: live `BALANCED_WEIGHTS` (overlay_report + cap_modes + ceiling_sweep) now DERIVE from `CLUSTER_WEIGHTS`.
- **Display/docs**: master-taxonomy per-metric weights + PEF/PET labels updated; taxonomy caveat corrected (per-metric split is now executed, not equal-mean).
- Resolves the `weight_proposal` xfail (quality 0.42→0.25 clears the 0.30 cap).

### Validation
- **719 v3 + riskfirst tests green** (TDD: new `test_v3_metric_weights.py`, updated combine/features/overlay/weight_proposal).
- **Live overlay run**: mega core held (NVDA/GOOG/MSFT/AAPL), PEF/PET oriented correctly (median 0.54; 18 value-traps all ineligible), `corr(roe_z, quality_z)=0.87` (ROE emphasis live), turnover 18.8%, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)