### PR TITLE
fix(v3): guard forward-earnings sign in PEF/PET + value scoring

### DIFF
--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -140,6 +140,39 @@ def test_value_trap_gate_excludes_forward_pe_far_above_trailing():
     assert pd.isna(scores.loc["TRAP", "rank"])
 
 
+def test_negative_pe_forward_not_scored_as_cheap():
+    """Owner 2026-07-23: a NEGATIVE forward P/E (loss expected) must NOT rank as the
+    'cheapest' value. Non-positive valuation multiples are cleaned to NaN before scoring,
+    so a loss-maker is UNSCORED on the P/E axis, not treated as an infinitely-low multiple
+    that its low-is-good direction would flip into the best score."""
+    idx = ["LOSS", "CHEAP", "RICH"]
+    df = _base(idx)
+    df["sector"] = ["Industrials"] * 3  # Group A value recipe -> pe_forward is scored
+    df["pe_forward"] = [-10.0, 5.0, 50.0]
+    s = compute_scores(df, sector_neutral=False)
+    assert pd.isna(s.loc["LOSS", "value_z"])  # negative fwd P/E -> unscored, NOT best
+    assert s.loc["CHEAP", "value_z"] > s.loc["RICH", "value_z"]
+
+
+def test_forward_loss_is_ineligible_value_trap():
+    """Owner 2026-07-23: profitable trailing but NON-positive forward earnings (PET>0,
+    PEF<=0) is the extreme value-trap the PEF/PET ratio can't express (ratio = NaN) ->
+    INELIGIBLE. A both-positive forward-cheaper name stays eligible."""
+    idx = ["GOOD", "FWDLOSS"]
+    df = _base(idx)
+    df["quote_type"] = ["EQUITY", "EQUITY"]
+    df["price"] = [100.0, 100.0]
+    df["roe"] = [20.0, 20.0]
+    df["pct_52w_high"] = [0.8, 0.8]
+    df["mom_12_1"] = [0.1, 0.1]
+    df["realized_vol"] = [0.2, 0.2]
+    df["pe_trailing"] = [20.0, 20.0]
+    df["pe_forward"] = [15.0, -5.0]  # GOOD: forward cheaper; FWDLOSS: forward loss
+    s = compute_scores(df, sector_neutral=False)
+    assert bool(s.loc["GOOD", "eligible"]) is True
+    assert bool(s.loc["FWDLOSS", "eligible"]) is False
+
+
 def test_eligibility_excludes_non_equity_and_dataless():
     """With quote_type present, ETFs and dataless names drop out of the ranking."""
     idx = ["EQ1", "EQ2", "ETF1", "DATALESS"]

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -619,6 +619,21 @@ def test_trajectory_guard_excludes_rising_forward_pe_buy():
     assert set(d["bought"]) == {"U01", "U02"}
 
 
+def test_forward_loss_held_name_is_sold_as_trap():
+    """Owner 2026-07-23: a HELD name that flips to a forward loss (PET>0, PEF<=0) trips the
+    value-trap SELL — even though earn_trajectory (PEF/PET) is NaN there (ratio needs PEF>0),
+    and even though its conviction is positive (it would otherwise be KEPT)."""
+    _tks, _convs, sc = _universe20()
+    sc["pe_trailing"] = 20.0
+    sc["pe_forward"] = 15.0
+    sc["earn_trajectory"] = 0.75  # forward-cheaper elsewhere
+    sc.loc["U05", "pe_forward"] = -3.0  # forward LOSS
+    sc.loc["U05", "earn_trajectory"] = np.nan  # ratio can't be computed
+    current = pd.Series({"U05": 0.2, "U19": 0.2})
+    d = build_overlay(sc, current, pd.DataFrame(), max_new=0)["diagnostics"]
+    assert "U05" in d["sold"]  # positive-conviction holding sold purely on the forward loss
+
+
 def test_fund_floor_weakest_first_spares_strong_satellites():
     """The core floor is funded by cutting the WEAKEST-conviction non-core names
     first (to zero if needed); a high-conviction satellite is spared."""

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -329,6 +329,25 @@ _MIN_CLUSTERS = 3
 # Names with a missing PET or PEF (NaN trajectory) are never gated.
 _TRAP_MAX_FWD_TTM = 1.10  # forward P/E may not exceed 1.10x trailing (= PEF/PET ceiling)
 
+# Valuation multiples where a NON-positive value is meaningless as "cheap": a negative or
+# zero P/E / P/B / EV-EBITDA is a loss-maker or negative book, NOT a bargain. Cleaned to NaN
+# before scoring so their low-is-good direction can never rank them as the cheapest. Owner
+# 2026-07-23 (the PEF/PET rework surfaced negative forward P/Es scoring as ultra-cheap).
+_POSITIVE_MULTIPLES = frozenset({"pe_trailing", "pe_forward", "ps_sector", "pb", "ev_ebitda"})
+
+
+def _fwd_loss_trap(out: pd.DataFrame) -> pd.Series:
+    """True where trailing earnings are POSITIVE but forward earnings are NON-positive
+    (profitable today, a loss expected). The extreme value-trap the PEF/PET ratio cannot
+    express — ``earn_trajectory`` is NaN when PEF<=0 — so it is read from the raw signs.
+    Owner 2026-07-23: forward earnings turning negative is the opposite of 'price lagging
+    RISING earnings', so such a name is made ineligible (and a held one is sold)."""
+    if "pe_trailing" not in out.columns or "pe_forward" not in out.columns:
+        return pd.Series(False, index=out.index)
+    pet = pd.to_numeric(out["pe_trailing"], errors="coerce")
+    pef = pd.to_numeric(out["pe_forward"], errors="coerce")
+    return (pet > 0) & (pef <= 0)  # NaN on either side -> False (not a trap)
+
 
 def _rank_z(s: pd.Series) -> pd.Series:
     """Rank-normal (van der Waerden) cross-sectional score.
@@ -444,6 +463,9 @@ def _eligibility(out: pd.DataFrame) -> pd.Series:
     if "earn_trajectory" in out.columns:
         traj = pd.to_numeric(out["earn_trajectory"], errors="coerce")
         ok &= ~(traj > _TRAP_MAX_FWD_TTM)  # NaN trajectory (missing PET/PEF) never gated
+    # Forward-loss trap: profitable now but forward earnings expected NON-positive (owner
+    # 2026-07-23) — the ratio is NaN there, so gate on the raw PET>0 & PEF<=0 signs.
+    ok &= ~_fwd_loss_trap(out)
     return ok.fillna(False).astype(bool)
 
 
@@ -488,7 +510,13 @@ def compute_scores(
     for m in metrics_needing_z:
         if m not in out.columns:
             continue
-        z = _rank_z(out[m]) * DIRECTION.get(m, 1)
+        raw = out[m]
+        if m in _POSITIVE_MULTIPLES:
+            # A non-positive valuation multiple = a loss-maker / negative book, NOT cheap.
+            # Exclude it so DIRECTION -1 can't flip it into the best (cheapest) score.
+            raw = pd.to_numeric(raw, errors="coerce")
+            raw = raw.where(raw > 0)
+        z = _rank_z(raw) * DIRECTION.get(m, 1)
         if sector_neutral:
             z = _sector_demean(z, sector)
         out[f"{m}_z"] = z

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -32,7 +32,7 @@ from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
-from trade_modules.v3.combine import _TRAP_MAX_FWD_TTM
+from trade_modules.v3.combine import _TRAP_MAX_FWD_TTM, _fwd_loss_trap
 from trade_modules.v3.construct import (
     _norm_name,
     _root_of,
@@ -445,8 +445,13 @@ def build_overlay(
         if (scored is not None and "earn_trajectory" in scored.columns)
         else pd.Series(dtype=float)
     )
+    # Forward-loss trap (owner 2026-07-23): profitable now but forward earnings expected
+    # non-positive (PET>0, PEF<=0) — a trap the PEF/PET ratio can't express (NaN when PEF<=0).
+    _fwd_loss = _fwd_loss_trap(scored) if scored is not None else pd.Series(dtype=bool)
 
     def _is_value_trap(t: str) -> bool:
+        if t in _fwd_loss.index and bool(_fwd_loss.loc[t]):
+            return True  # profitable -> forward loss: the extreme deterioration case
         if t not in _traj.index:
             return False
         v = _traj.loc[t]


### PR DESCRIPTION
## Problem
The PEF/PET rework surfaced two sign leaks around **non-positive forward earnings** (live: 1,559 names have PEF≤0; **124 are PET>0 & PEF≤0**).

1. **Value scoring** — `pe_forward` entered the value cluster RAW with `DIRECTION -1`, so a **negative** forward P/E (a loss-maker, e.g. NBIS PEF −135) ranked as the **cheapest** → spuriously high `value_z`.
2. **Trap-gate gap** — `earn_trajectory` (PEF/PET) is NaN when PEF≤0, so a name profitable now but expected to post a **loss** (PET>0 & PEF≤0) — the worst trajectory — escaped the value-trap gate.

## Fix
- **Non-positive valuation multiples cleaned to NaN before scoring** (`_POSITIVE_MULTIPLES` = pe_forward/pe_trailing/ps_sector/pb/ev_ebitda): a negative multiple is unscored on that axis (recipe falls back to P/S), never "infinitely cheap".
- **`_fwd_loss_trap()`** detects PET>0 & PEF≤0 from raw signs → **ineligible** (`combine._eligibility`) and **sold** if held (`overlay._is_value_trap`).

Semantics: we want price lagging **rising** earnings (PET>0, PEF>0, PEF<PET); forward earnings turning negative is the opposite → excluded. `earn_trajectory` scoring itself was already correct (guarded both-positive).

## Tests
722 v3+riskfirst green (3 new: negative-pe_forward not-cheap · forward-loss ineligible · held forward-loss sold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)