### PR TITLE
fix(v3): strip eToro .US suffix for yfinance (T.US -> T)

### DIFF
--- a/tests/core/config/test_ticker_mappings.py
+++ b/tests/core/config/test_ticker_mappings.py
@@ -326,6 +326,9 @@ class TestDisplayAndDataFetch:
             ("KSP.L.GBX", "KSP.L"),  # pence line stripped, exchange suffix kept
             ("BRK.B", "BRK-B"),  # US class share -> dash form
             ("RDS.A", "RDS-A"),  # US class share -> dash form
+            ("T.US", "T"),  # eToro .US US-listing suffix stripped (Yahoo uses the bare ticker)
+            ("AAPL.US", "AAPL"),  # eToro .US stripped
+            ("BRK.B.US", "BRK-B"),  # .US stripped, then US class share -> dash form
             ("7012.T", "7012.T"),  # Tokyo already valid -> unchanged
             ("UCG.MI", "UCG.MI"),  # already-valid Yahoo suffix -> unchanged
             ("AAPL", "AAPL"),  # plain US -> unchanged
@@ -340,6 +343,7 @@ class TestDisplayAndDataFetch:
         """VIX + per-name data_fetch_substitutions survive the new suffix logic."""
         assert get_data_fetch_ticker("VIX") == "^VIX"
         assert get_data_fetch_ticker("LYXGRE.DE") == "GRE.PA"
+        assert get_data_fetch_ticker("JD.US") == "9618.HK"  # ADR override wins over the .US strip
 
 
 class TestDualListedDetection:

--- a/trade_modules/config_manager.py
+++ b/trade_modules/config_manager.py
@@ -423,6 +423,13 @@ class ConfigManager:
                 #    (MSFT.EUR → MSFT ; KSP.L.GBX → KSP.L).
                 if suf in _CURRENCY_SUFFIXES:
                     return self.get_data_fetch_ticker(stem)
+                # 1b. eToro .US US-listing marker: Yahoo uses the BARE US ticker (T.US → T,
+                #     AAPL.US → AAPL). Re-resolve the stem so a US class share still gets its
+                #     dash form (BRK.B.US → BRK.B → BRK-B). ADR overrides that map a .US line
+                #     to a foreign primary (e.g. JD.US → 9618.HK) win above via
+                #     data_fetch_substitutions, so they never reach this strip.
+                if suf == "US":
+                    return self.get_data_fetch_ticker(stem)
                 # 2. exchange-suffix remap (.NV→.AS, .IM→.MI, .LN→.L, .CH→.SW).
                 if suf in _YAHOO_SUFFIX_MAP:
                     return stem + "." + _YAHOO_SUFFIX_MAP[suf]


### PR DESCRIPTION
## Problem
eToro lists US equities with a **`.US`** suffix (`T.US`, `AAPL.US`, `BRK.B.US`). Yahoo Finance uses the **bare** US ticker, but `get_data_fetch_ticker` returned `T.US → T.US` unchanged → yfinance 404 / no price+info data for held US names carried in the account with the `.US` form. (Fundamentals reconciled fine — `_underlying_root` already strips `.US` to match etoro.csv's bare `T` — but the live fetch broke.)

## Fix
`get_data_fetch_ticker` strips a `.US` listing marker and **re-resolves the stem**, so a US class share still gets its dash form:
- `T.US → T`, `AAPL.US → AAPL`, `BRK.B.US → BRK-B`
- ADR overrides that map a `.US` line to a foreign primary (`JD.US → 9618.HK`) are checked first via `data_fetch_substitutions` → unaffected.

One fix covers both entry points (`yahoofinance.utils.ticker_mappings` delegates here).

## Verified
`robust_fetch_prices(['T.US'])` now returns real AT&T data (21 bars, ~$22.94) — was **empty** before. 751 v3+riskfirst+ticker tests green (3 new `.US` cases + a JD.US-preserved assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)