### PR TITLE
ci(dependabot): stop pip auto-merge corrupting the poetry lockfile

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,17 +12,23 @@ jobs:
     steps:
       - name: Get Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for safe updates
-        # Auto-merge: patch + minor for ALL ecosystems, including grouped updates.
-        # Major version bumps still require manual review.
+        # Auto-merge github-actions patch/minor/grouped ONLY. pip is EXCLUDED on purpose:
+        # this repo's dependency source of truth is poetry.lock, but pip-Dependabot edits
+        # the DERIVED requirements-*-lock.txt WITHOUT updating poetry.lock, so auto-merging
+        # a pip PR corrupts lockfile-sync (poetry.lock vs requirements drift). Python deps
+        # are updated the correct way via poetry (deps-refresh.yml monthly + manual
+        # `poetry update` + relock); pip-Dependabot PRs stay open for SECURITY VISIBILITY
+        # and require poetry-correct handling. Major bumps also still need manual review.
         if: |
+          !startsWith(github.event.pull_request.head.ref, 'dependabot/pip/') && (
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor' ||
           steps.meta.outputs.update-type == 'version-update:semver-patchminor' ||
-          steps.meta.outputs.dependency-group != ''
+          steps.meta.outputs.dependency-group != '')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Problem
`poetry.lock` is the dependency source of truth; `requirements-*-lock.txt` are DERIVED (`poetry export`). **pip-Dependabot edits the derived files without updating `poetry.lock`**, so auto-merging a pip PR lands an inconsistent lockfile and breaks CI `lockfile sync` — it corrupted master via #187 (pillow requirements 12.3 vs poetry.lock 12.2).

## Why not "true poetry-aware Dependabot" (the originally-picked option C)
Not reliably achievable for this repo:
- pyproject uses **PEP 621 `[project]` + setuptools backend** → Dependabot doesn't detect Poetry, so it never touches `poetry.lock`.
- Even converting to poetry-core, Dependabot's PEP 621 + Poetry support has **open upstream bugs**: [dependabot-core #13494](https://github.com/dependabot/dependabot-core/issues/13494) (poetry.lock not updated) and [#13917](https://github.com/dependabot/dependabot-core/issues/13917) (only transitive updated).

## Fix (working realization of the intent)
Exclude `dependabot/pip/*` from auto-merge (github-actions still auto-merges patch/minor/grouped). pip-Dependabot PRs **stay open for security visibility** but never auto-merge; Python deps are updated the correct way via **poetry** (`deps-refresh.yml` monthly + manual `poetry update` + relock — as done today). Also fixes the file's one yamllint warning.

Security: `head.ref` is used only in an `if:` expression (string compare), never in a shell `run:` — no workflow-injection risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)