### PR TITLE
fix(v3): momentum-guard the value-trap gate + explain dashed scores

### DIFF
--- a/tests/core/config/test_ticker_mappings.py
+++ b/tests/core/config/test_ticker_mappings.py
@@ -345,6 +345,12 @@ class TestDisplayAndDataFetch:
         assert get_data_fetch_ticker("LYXGRE.DE") == "GRE.PA"
         assert get_data_fetch_ticker("JD.US") == "9618.HK"  # ADR override wins over the .US strip
 
+    def test_get_data_fetch_ticker_lse_gdr_iob_substitution(self):
+        """LSE GDR (USD) depositary lines: the ``.L`` symbol carries ~5 bars on Yahoo, so the
+        full-history International Order Book ``.IL`` line is substituted (owner 2026-07-24)."""
+        assert get_data_fetch_ticker("SMSN.L") == "SMSN.IL"  # Samsung GDR
+        assert get_data_fetch_ticker("KAP.L") == "KAP.IL"  # Kazatomprom GDR
+
 
 class TestDualListedDetection:
     """Test cases for dual-listed stock detection."""

--- a/tests/unit/trade_modules/test_v3_combine.py
+++ b/tests/unit/trade_modules/test_v3_combine.py
@@ -118,14 +118,16 @@ def test_no_quote_type_column_means_all_eligible():
 def test_value_trap_gate_excludes_forward_pe_far_above_trailing():
     """Owner rule: forward P/E > 1.10x trailing (earn_trajectory = PEF/PET > 1.10) = value
     trap -> INELIGIBLE, so a trap never surfaces as a BUY and a held trap trips the overlay's
-    weak-name SELL. Names at/below the threshold stay eligible."""
+    weak-name SELL. Names at/below the threshold stay eligible. The trap requires the price to
+    NOT be rising (non-positive 12-1 momentum), so TRAP here has negative momentum — a genuine
+    cheap-and-falling name (see test_value_trap_gate_cleared_by_positive_momentum)."""
     idx = ["GOOD", "FLAT", "TRAP"]
     df = _base(idx)
     df["quote_type"] = ["EQUITY", "EQUITY", "EQUITY"]
     df["price"] = [100.0, 50.0, 80.0]
     df["pe_trailing"] = [10.0, 15.0, 3.2]
     df["roe"] = [30.0, 20.0, 25.0]
-    df["mom_12_1"] = [0.20, 0.15, 0.10]
+    df["mom_12_1"] = [0.20, 0.15, -0.10]  # TRAP is falling -> the trap flag fires
     df["realized_vol"] = [0.20, 0.22, 0.25]
     # earn_trajectory = PEF/PET: GOOD 0.90 (forward cheaper), FLAT 1.0 (=trailing, not a
     # trap), TRAP 46/3.2 = 14.4 (forward 14x trailing = earnings collapsing).
@@ -138,6 +140,70 @@ def test_value_trap_gate_excludes_forward_pe_far_above_trailing():
     assert bool(scores.loc["TRAP", "eligible"]) is False
     assert pd.isna(scores.loc["TRAP", "conviction"])
     assert pd.isna(scores.loc["TRAP", "rank"])
+
+
+def test_value_trap_gate_cleared_by_positive_momentum():
+    """Owner 2026-07-24: a genuine value trap is cheap-looking AND falling. A name whose
+    forward P/E is far above trailing (earn_trajectory > 1.10) but whose 12-1 momentum is
+    POSITIVE is a rising winner whose low trailing P/E is a one-off-gain artifact (e.g. GOOG:
+    trailing EPS inflated by GAAP investment gains -> trailing P/E distorted low -> spurious
+    PEF/PET 1.35). Positive momentum CLEARS the trap; negative or absent momentum keeps it."""
+    idx = ["RISING", "FALLING", "UNKNOWN_MOM"]
+    df = _base(idx)
+    df["quote_type"] = ["EQUITY"] * 3
+    df["price"] = [100.0, 80.0, 90.0]
+    df["roe"] = [30.0, 25.0, 20.0]
+    df["realized_vol"] = [0.30, 0.25, 0.28]
+    df["pe_trailing"] = [16.0, 7.6, 10.0]
+    df["earn_trajectory"] = [1.35, 1.17, 1.30]  # all forward P/E > 1.10x trailing
+    df["mom_12_1"] = [0.86, -0.12, np.nan]  # rising winner / falling / unknown
+
+    s = compute_scores(df, sector_neutral=False)
+
+    assert bool(s.loc["RISING", "eligible"]) is True  # +momentum clears the false-positive
+    assert bool(s.loc["FALLING", "eligible"]) is False  # -momentum keeps the trap
+    assert bool(s.loc["UNKNOWN_MOM", "eligible"]) is False  # NaN momentum never clears
+
+
+def test_value_trap_gate_helper_momentum_corroboration():
+    """Unit test the momentum-corroborated trap mask directly."""
+    from trade_modules.v3.combine import _value_trap_gate
+
+    df = pd.DataFrame(
+        {
+            "earn_trajectory": [1.35, 1.35, 1.05, np.nan, 1.35],
+            "mom_12_1": [-0.10, 0.86, -0.50, -0.20, np.nan],
+        },
+        index=["FALLING_TRAP", "RISING_CLEARED", "BELOW_THRESH", "NAN_TRAJ", "NAN_MOM"],
+    )
+    trap = _value_trap_gate(df, 1.10)
+    assert bool(trap.loc["FALLING_TRAP"]) is True  # >1.10 and falling -> trap
+    assert bool(trap.loc["RISING_CLEARED"]) is False  # >1.10 but rising -> cleared
+    assert bool(trap.loc["BELOW_THRESH"]) is False  # <=1.10 -> never a trap
+    assert bool(trap.loc["NAN_TRAJ"]) is False  # missing trajectory -> not gated
+    assert bool(trap.loc["NAN_MOM"]) is True  # >1.10, momentum unknown -> stays flagged
+
+
+def test_inelig_reason_labels_each_exclusion():
+    """compute_scores tags WHY each ineligible name is excluded (``inelig_reason``) so the
+    report can show TRAP / NO-HIST / ETF instead of a bare dash. Eligible names carry ''."""
+    idx = ["EQOK", "ETF1", "NOHIST", "TRAP1"]
+    df = _base(idx)
+    df["quote_type"] = ["EQUITY", "ETF", "EQUITY", "EQUITY"]
+    df["price"] = [100.0, 200.0, 50.0, 80.0]
+    df["roe"] = [30.0, 25.0, 20.0, 25.0]
+    df["pe_forward"] = [10.0, 15.0, 12.0, 11.0]
+    df["realized_vol"] = [0.20, 0.22, np.nan, 0.25]  # NOHIST is missing realized_vol
+    df["mom_12_1"] = [0.20, 0.15, np.nan, -0.10]  # NOHIST missing mom; TRAP1 is falling
+    df["pe_trailing"] = [10.0, 15.0, 12.0, 3.2]
+    df["earn_trajectory"] = [0.90, 1.0, np.nan, 46.0 / 3.2]  # TRAP1 = 14.4 > 1.10
+
+    s = compute_scores(df, sector_neutral=False)
+
+    assert s.loc["EQOK", "inelig_reason"] == ""  # eligible -> no reason
+    assert s.loc["ETF1", "inelig_reason"] == "ETF"  # non-equity
+    assert s.loc["NOHIST", "inelig_reason"] == "NO-HIST"  # missing price history
+    assert s.loc["TRAP1", "inelig_reason"] == "TRAP"  # value-trap (falling)
 
 
 def test_negative_pe_forward_not_scored_as_cheap():

--- a/tests/unit/trade_modules/test_v3_fundamentals.py
+++ b/tests/unit/trade_modules/test_v3_fundamentals.py
@@ -191,3 +191,22 @@ def test_live_fundamentals_factors(tmp_path):
     assert not math.isnan(out.loc["AAA", "sue"])  # >=6 quarters -> SUE computable
     assert math.isnan(out.loc["ZZZ", "gp_assets"])  # not in store -> NaN (graceful)
     assert math.isnan(out.loc["ZZZ", "sue"])
+
+
+def test_live_fundamentals_class_share_alias(tmp_path):
+    """Sharadar SF1 keys Alphabet only under GOOGL, but the eToro universe carries GOOG.
+    live_fundamentals_factors must resolve the class-share alias (GOOG -> GOOGL) so GOOG
+    inherits GOOGL's filings, and return them under the ORIGINAL ticker key (GOOG)."""
+    from trade_modules.v3.fundamentals_store import append_records
+
+    store = str(tmp_path / "f.parquet")
+    rows = [
+        {"ticker": "GOOGL", "datekey": dk, "reportperiod": dk, "assets": 400.0, "gp": 60.0}
+        for dk in ("2025-03-15", "2025-06-15", "2025-09-15", "2025-12-15")
+    ]
+    append_records(pd.DataFrame(rows), store_path=store)
+
+    out = live_fundamentals_factors(["GOOG"], store_path=store)
+    # GOOG resolves to GOOGL's filings, returned under the GOOG key.
+    assert list(out.index) == ["GOOG"]
+    assert out.loc["GOOG", "gp_assets"] == pytest.approx(0.15)  # 60 / 400

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -68,6 +68,26 @@ def test_missing_data_holds_but_value_trap_sells():
     assert set(d.get("held_unscored", [])) >= {"INELIG", "MISS"}  # surfaced for manual review
 
 
+def test_value_trap_sell_cleared_by_positive_momentum():
+    """Owner 2026-07-24: the held-trap SELL is momentum-corroborated. A held name with forward
+    P/E far above trailing (earn_trajectory > 1.10) but POSITIVE 12-1 momentum is a rising winner
+    (its low trailing P/E is a one-off-gain artifact, not collapsing earnings) -> HELD, not sold.
+    A falling trap (negative momentum) is still sold."""
+    _tks, _convs, sc = _universe20()
+    extra = _scored(["RISING", "FALLING"], [np.nan, np.nan], eligible=[False, False])
+    extra["earn_trajectory"] = [1.35, 1.35]  # both: forward P/E 35% above trailing
+    extra["mom_12_1"] = [0.86, -0.12]  # RISING winner vs FALLING
+    sc = pd.concat([sc, extra])
+    current = pd.Series({"U00": 0.2, "RISING": 0.2, "FALLING": 0.2})
+
+    res = build_overlay(sc, current, pd.DataFrame(), max_new=0)
+    d, w = res["diagnostics"], res["weights"]
+
+    assert "FALLING" in d["sold"]  # falling trap -> sold
+    assert "RISING" not in d["sold"]  # rising winner cleared the trap -> not sold
+    assert "RISING" in d["kept"] and float(w.get("RISING", 0.0)) > 0.0  # held-with-flag
+
+
 def test_buy_screen_suppresses_current_ratio_and_de_for_financials():
     """Banks/REITs run low current ratios and high leverage BY NATURE (deposits are the
     business), so the current-ratio + D/E distress screens must be suppressed for them

--- a/tests/unit/trade_modules/test_v3_report.py
+++ b/tests/unit/trade_modules/test_v3_report.py
@@ -175,6 +175,18 @@ def test_overview_blank_cell_for_nan_cluster():
     assert "hm-cell nan" in html
 
 
+def test_overview_shows_inelig_reason_token():
+    """An ineligible name shows its reason token (TRAP / NO-HIST / ETF) in the heatmap Conv
+    column instead of a bare dot, so the reader can see WHY it has no score (owner 2026-07-24)."""
+    scores = _scores()
+    scores["conviction"] = scores["conviction"].astype(float)
+    scores.loc["ZZZ", "conviction"] = np.nan
+    scores["inelig_reason"] = ""
+    scores.loc["ZZZ", "inelig_reason"] = "NO-HIST"
+    html = render_report(scores, _meta())
+    assert "NO-HIST" in html  # reason token replaces the bare dot in ZZZ's Conv cell
+
+
 def test_render_curates_candidate_cards_and_notes_count():
     scores = _many_scores(n=34, n_port=4)
     html = render_report(scores, {"regime": "NEUTRAL"}, max_long_cards=5, max_avoid_cards=3)

--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -289,3 +289,16 @@ def test_heatmap_handles_na_rank_and_conviction():
     s.loc["CCC", "conviction"] = NAN
     html = rem.render_email_report(s, _meta(), portfolio=_view(), actions=_actions())
     assert isinstance(html, str) and "Conviction heatmap" in html
+
+
+def test_heatmap_shows_inelig_reason_token():
+    """An ineligible held name shows its reason token (TRAP / NO-HIST / ETF) in the Conv
+    column instead of a bare dot, so the reader can tell WHY it has no score (owner
+    2026-07-24)."""
+    s = _scores().copy()
+    s["rank"] = s["rank"].astype("Int64")
+    s.loc["CCC", "rank"] = pd.NA
+    s.loc["CCC", "conviction"] = NAN
+    s["inelig_reason"] = ["", "", "TRAP"]  # CCC is a held, ineligible value-trap
+    html = rem.render_email_report(s, _meta(), portfolio=_view(), actions=_actions())
+    assert ">TRAP<" in html  # reason token rendered in the Conv cell, not a bare dot

--- a/trade_modules/config_manager.py
+++ b/trade_modules/config_manager.py
@@ -208,6 +208,12 @@ class ConfigManager:
         # via `yf.Ticker(sub).fast_info.last_price`).
         self.data_fetch_substitutions = {
             "LYXGRE.DE": "GRE.PA",  # Amundi MSCI Greece UCITS ETF — Xetra fails on yfinance, Paris listing works
+            # LSE GDR (USD) depositary lines: Yahoo's ``.L`` symbol carries only ~5 recent bars,
+            # but the International Order Book ``.IL`` line (same USD instrument) has full history
+            # (~2y), so mom_12_1 / realized_vol can be computed. Verified 2026-07-24 (SMSN.IL /
+            # KAP.IL both return ~507 bars vs 5 for .L).
+            "SMSN.L": "SMSN.IL",  # Samsung Electronics GDR (USD) — London IOB has full history
+            "KAP.L": "KAP.IL",  # Kazatomprom GDR (USD) — London IOB has full history
         }
 
         # US Ticker -> Original Exchange Ticker mappings

--- a/trade_modules/v3/combine.py
+++ b/trade_modules/v3/combine.py
@@ -349,6 +349,31 @@ def _fwd_loss_trap(out: pd.DataFrame) -> pd.Series:
     return (pet > 0) & (pef <= 0)  # NaN on either side -> False (not a trap)
 
 
+def _value_trap_gate(out: pd.DataFrame, max_fwd_ttm: float = _TRAP_MAX_FWD_TTM) -> pd.Series:
+    """Momentum-corroborated PEF/PET value-trap mask (owner 2026-07-24).
+
+    ``earn_trajectory`` = PEF/PET > ``max_fwd_ttm`` means the forward P/E is materially above
+    trailing — the textbook "earnings expected to fall" value trap. But a GENUINE value trap is
+    cheap-looking AND falling: when 12-1 price momentum is POSITIVE the name is a rising winner,
+    and a low trailing P/E on a rising winner is far more likely a one-off trailing-EPS boost
+    (e.g. a GAAP investment gain) than collapsing earnings. Flagging such a name is a false
+    positive (GOOG: trailing EPS inflated by investment gains -> trailing P/E ~16 vs a real ~26
+    -> spurious PEF/PET 1.35 despite +86% 12-1 momentum). So the trap fires only when momentum
+    does NOT corroborate — positive ``mom_12_1`` clears the flag. NaN trajectory (missing
+    PET/PEF) is never gated; NaN momentum never CLEARS the flag (safe default: only a KNOWN
+    rising price rescues a name). This mask is the single source of truth for the PEF/PET trap
+    across the eligibility gate, the held-trap SELL and the new-buy veto.
+    """
+    if "earn_trajectory" not in out.columns:
+        return pd.Series(False, index=out.index)
+    traj = pd.to_numeric(out["earn_trajectory"], errors="coerce")
+    trap = traj > max_fwd_ttm
+    if "mom_12_1" in out.columns:
+        mom = pd.to_numeric(out["mom_12_1"], errors="coerce")
+        trap &= ~(mom > 0)  # a KNOWN rising price clears the trap; NaN momentum does not
+    return trap.fillna(False).astype(bool)
+
+
 def _rank_z(s: pd.Series) -> pd.Series:
     """Rank-normal (van der Waerden) cross-sectional score.
 
@@ -459,14 +484,49 @@ def _eligibility(out: pd.DataFrame) -> pd.Series:
             ok &= pd.to_numeric(out[col], errors="coerce").notna()
     clusters_present = out[_ELIG_CLUSTERS].notna().sum(axis=1)
     ok &= clusters_present >= _MIN_CLUSTERS
-    # Value-trap gate: forward P/E > 1.10x trailing (earn_trajectory = PEF/PET above 1.10).
-    if "earn_trajectory" in out.columns:
-        traj = pd.to_numeric(out["earn_trajectory"], errors="coerce")
-        ok &= ~(traj > _TRAP_MAX_FWD_TTM)  # NaN trajectory (missing PET/PEF) never gated
+    # Value-trap gate: forward P/E > 1.10x trailing (earn_trajectory = PEF/PET above 1.10),
+    # momentum-corroborated — a rising winner (positive 12-1 momentum) is NOT gated, since its
+    # low trailing P/E is a one-off-gain artifact, not collapsing earnings (see _value_trap_gate).
+    ok &= ~_value_trap_gate(out, _TRAP_MAX_FWD_TTM)
     # Forward-loss trap: profitable now but forward earnings expected NON-positive (owner
-    # 2026-07-23) — the ratio is NaN there, so gate on the raw PET>0 & PEF<=0 signs.
+    # 2026-07-23) — the ratio is NaN there, so gate on the raw PET>0 & PEF<=0 signs. NOT
+    # momentum-guarded: a company heading into a loss is a real risk regardless of price action.
     ok &= ~_fwd_loss_trap(out)
     return ok.fillna(False).astype(bool)
+
+
+def _inelig_reason(out: pd.DataFrame, eligible: pd.Series) -> pd.Series:
+    """Short reason WHY each ineligible name is excluded, so the report can show a token
+    (TRAP / NO-HIST / ETF / NO DATA) in place of a bare dash. Eligible names -> "".
+
+    Mirrors :func:`_eligibility`'s checks and reports the FIRST that fails in gate order:
+    non-equity -> ``ETF``; missing price or 12-1 momentum / realized-vol history ->
+    ``NO-HIST``; fewer than the minimum populated factor clusters -> ``NO DATA``; a
+    (momentum-corroborated) PEF/PET value trap or a forward-loss trap -> ``TRAP``.
+    """
+    idx = out.index
+    reason = pd.Series("", index=idx, dtype="object")
+    if "quote_type" not in out.columns:
+        return reason  # abstract combiner frames: all eligible, no reason
+    inelig = ~eligible.reindex(idx, fill_value=False).astype(bool)
+
+    def _set(mask: pd.Series, label: str) -> None:
+        # Only label ineligible names still unlabeled -> first failing check (gate order) wins.
+        target = mask.reindex(idx, fill_value=False).astype(bool) & inelig & (reason == "")
+        reason.loc[target] = label
+
+    qt = out["quote_type"].astype("string").str.upper()
+    _set(~qt.eq("EQUITY").fillna(False), "ETF")
+    if "price" in out.columns:
+        price = pd.to_numeric(out["price"], errors="coerce")
+        _set(~(price.notna() & (price > 0)), "NO-HIST")
+    for col in ("mom_12_1", "realized_vol"):
+        if col in out.columns:
+            _set(pd.to_numeric(out[col], errors="coerce").isna(), "NO-HIST")
+    _set(out[_ELIG_CLUSTERS].notna().sum(axis=1) < _MIN_CLUSTERS, "NO DATA")
+    _set(_value_trap_gate(out, _TRAP_MAX_FWD_TTM), "TRAP")
+    _set(_fwd_loss_trap(out), "TRAP")
+    return reason
 
 
 def compute_scores(
@@ -571,6 +631,9 @@ def compute_scores(
     # is the eligible equity universe only.
     eligible = _eligibility(out)
     out["eligible"] = eligible
+    # Display: WHY each ineligible name is excluded (TRAP / NO-HIST / ETF / NO DATA), so the
+    # report shows a reason token instead of a bare dash. Eligible names carry "".
+    out["inelig_reason"] = _inelig_reason(out, eligible)
     out["conviction"] = _z_plain(conv_raw.where(eligible))
     out["rank"] = out["conviction"].rank(ascending=False, method="min").astype("Int64")
     return out

--- a/trade_modules/v3/fundamentals.py
+++ b/trade_modules/v3/fundamentals.py
@@ -152,13 +152,21 @@ def factor_panel(fasof: pd.DataFrame, fprior: pd.DataFrame, price: pd.Series) ->
     )
 
 
+# Dual-class alias: Sharadar SF1 keys some US names under ONE share class while the eToro
+# universe carries the OTHER. Map the eToro ticker -> the SF1 store key so a name still inherits
+# its (share-class-identical) fundamentals. Alphabet: SF1 files only GOOGL; eToro carries GOOG.
+# Extend as more dual-class cases surface (results are always returned under the eToro key).
+_SF1_TICKER_ALIAS = {"GOOG": "GOOGL"}
+
+
 def live_fundamentals_factors(tickers, *, store_path: str | None = None) -> pd.DataFrame:
     """Latest-filing GP/assets + SUE per ticker from the PIT SF1 store, for LIVE scoring.
 
     'Live' = the most recent available filing per ticker. Tickers absent from the store
     (non-US / no filing) get NaN so the quality / PEAD clusters degrade gracefully.
     NaN-safe if the store is missing/empty. Returns a frame indexed by ticker with
-    columns ``gp_assets`` and ``sue``.
+    columns ``gp_assets`` and ``sue``. Dual-class names are resolved via ``_SF1_TICKER_ALIAS``
+    (e.g. GOOG reads GOOGL's filings) but the result stays keyed by the original ticker.
     """
     from trade_modules.v3.fundamentals_store import STORE_PATH, read_asof, read_history
 
@@ -168,18 +176,27 @@ def live_fundamentals_factors(tickers, *, store_path: str | None = None) -> pd.D
     for c in ("gp_assets", "sue", "net_issuance", "earn_stability"):
         out[c] = pd.Series(index=idx, dtype=float)
 
-    fasof = read_asof(list(idx), "2099-12-31", store_path=sp)  # latest filing per ticker
+    # Read the store under the (possibly aliased) SF1 key, then map values back onto the
+    # ORIGINAL eToro tickers via ``_back`` (positional reindex over the per-name store keys).
+    store_keys = [_SF1_TICKER_ALIAS.get(t, t) for t in idx]
+    want = list(dict.fromkeys(store_keys))
+
+    def _back(s: pd.Series) -> pd.Series:
+        """Series indexed by SF1 store ticker -> values realigned onto the original ``idx``."""
+        return pd.Series(s.reindex(store_keys).to_numpy(), index=idx)
+
+    fasof = read_asof(want, "2099-12-31", store_path=sp)  # latest filing per ticker
     if not fasof.empty:
         gp = pd.to_numeric(fasof.get("gp"), errors="coerce")
         assets = pd.to_numeric(fasof.get("assets"), errors="coerce")
-        out["gp_assets"] = (gp / assets).where(assets != 0).reindex(idx)
+        out["gp_assets"] = _back((gp / assets).where(assets != 0))
 
-    hist = read_history(list(idx), "2099-12-31", store_path=sp)
+    hist = read_history(want, "2099-12-31", store_path=sp)
     if not hist.empty:
         h = hist.sort_values("datekey")
-        out["sue"] = pd.to_numeric(
-            h.groupby("ticker")["eps"].apply(srw_sue), errors="coerce"
-        ).reindex(idx)
+        out["sue"] = _back(
+            pd.to_numeric(h.groupby("ticker")["eps"].apply(srw_sue), errors="coerce")
+        )
 
         def _net_iss(s) -> float:  # YoY change in shares outstanding (dilution + / buyback -)
             v = pd.to_numeric(pd.Series(s), errors="coerce").dropna()
@@ -194,10 +211,10 @@ def live_fundamentals_factors(tickers, *, store_path: str | None = None) -> pd.D
             m = abs(float(v.mean()))
             return float(-(v.std() / (m + 1e-6)))
 
-        out["net_issuance"] = pd.to_numeric(
-            h.groupby("ticker")["sharesbas"].apply(_net_iss), errors="coerce"
-        ).reindex(idx)
-        out["earn_stability"] = pd.to_numeric(
-            h.groupby("ticker")["eps"].apply(_estab), errors="coerce"
-        ).reindex(idx)
+        out["net_issuance"] = _back(
+            pd.to_numeric(h.groupby("ticker")["sharesbas"].apply(_net_iss), errors="coerce")
+        )
+        out["earn_stability"] = _back(
+            pd.to_numeric(h.groupby("ticker")["eps"].apply(_estab), errors="coerce")
+        )
     return out

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -32,7 +32,7 @@ from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
 from trade_modules.riskfirst.fx import currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
-from trade_modules.v3.combine import _TRAP_MAX_FWD_TTM, _fwd_loss_trap
+from trade_modules.v3.combine import _TRAP_MAX_FWD_TTM, _fwd_loss_trap, _value_trap_gate
 from trade_modules.v3.construct import (
     _norm_name,
     _root_of,
@@ -170,9 +170,12 @@ def _screen_buy_candidates(
         Street is actively downgrading the name with meaningful coverage (owner
         2026-07-22). Asymmetric: we reject active downgrades but never *require*
         positive coverage (that would anti-select momentum winners);
-      * earn_trajectory (= PEF/PET = forward/trailing P/E) > ``max_earn_trajectory`` —
-        forward P/E materially above trailing, i.e. earnings expected to FALL (value-trap
-        tilt; owner 2026-07-22). Use ``1.05`` to block a > 1.05x forward/trailing rise.
+      * earn_trajectory (= PEF/PET = forward/trailing P/E) > ``max_earn_trajectory`` AND the
+        name is NOT a rising winner (12-1 momentum not positive) — forward P/E materially above
+        trailing means earnings expected to FALL (value-trap tilt; owner 2026-07-22), but a
+        positive-momentum name's low trailing P/E is a one-off-gain artifact, not collapsing
+        earnings, so it is not vetoed (momentum corroboration, owner 2026-07-24). Use ``1.05``
+        to block a > 1.05x forward/trailing rise.
     A criterion whose param is ``None`` is off; an absent column or NaN value never
     excludes (missing data is not treated as a red flag). Returns (kept, screened_out).
     """
@@ -216,8 +219,15 @@ def _screen_buy_candidates(
             and pd.notna(na)
             and na >= min_analyst_n
         )
+        mom = _val(t, "mom_12_1")
         value_trap = (
-            max_earn_trajectory is not None and pd.notna(traj) and traj > max_earn_trajectory
+            max_earn_trajectory is not None
+            and pd.notna(traj)
+            and traj > max_earn_trajectory
+            # Momentum-corroborated (owner 2026-07-24): a rising winner (positive 12-1 momentum)
+            # is not a value trap — its low trailing P/E is a one-off-gain artifact, not a
+            # collapsing-earnings signal. Only veto when the price is NOT rising.
+            and not (pd.notna(mom) and mom > 0)
         )
         excluded = squeeze or illiquid or levered or downgraded or value_trap
         (out if excluded else kept).append(t)
@@ -436,26 +446,24 @@ def build_overlay(
 
     core_set = set(core_list or [])
 
-    # Value-trap = a POSITIVE deterioration signal: forward P/E materially above
-    # trailing (earn_trajectory = PEF/PET > 1.10 => earnings expected to fall). A held trap
-    # is SOLD even though the eligibility gate marks it ineligible; MISSING data (no
+    # Value-trap = a POSITIVE deterioration signal: forward P/E materially above trailing
+    # (earn_trajectory = PEF/PET > 1.10 => earnings expected to fall) AND the price is not
+    # rising (momentum-corroborated, owner 2026-07-24 — a rising winner's low trailing P/E is a
+    # one-off-gain artifact, not collapsing earnings; see combine._value_trap_gate). A held
+    # trap is SOLD even though the eligibility gate marks it ineligible; MISSING data (no
     # trajectory) is NOT a trap and must never trigger a sell.
-    _traj = (
-        pd.to_numeric(scored["earn_trajectory"], errors="coerce")
-        if (scored is not None and "earn_trajectory" in scored.columns)
-        else pd.Series(dtype=float)
+    _traj_trap = (
+        _value_trap_gate(scored, _TRAP_MAX_FWD_TTM) if scored is not None else pd.Series(dtype=bool)
     )
     # Forward-loss trap (owner 2026-07-23): profitable now but forward earnings expected
     # non-positive (PET>0, PEF<=0) — a trap the PEF/PET ratio can't express (NaN when PEF<=0).
+    # NOT momentum-guarded: a company heading into a loss is a real risk regardless of price.
     _fwd_loss = _fwd_loss_trap(scored) if scored is not None else pd.Series(dtype=bool)
 
     def _is_value_trap(t: str) -> bool:
         if t in _fwd_loss.index and bool(_fwd_loss.loc[t]):
             return True  # profitable -> forward loss: the extreme deterioration case
-        if t not in _traj.index:
-            return False
-        v = _traj.loc[t]
-        return bool(pd.notna(v) and float(v) > _TRAP_MAX_FWD_TTM)
+        return bool(t in _traj_trap.index and bool(_traj_trap.loc[t]))
 
     def _is_unscoreable(t: str) -> bool:
         """Un-scoreable from MISSING DATA: dataless, NaN conviction, or ineligible.

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -191,6 +191,16 @@ def _znum(z) -> str:
     return "·" if _isnan(z) else f"{z:+.2f}"
 
 
+def _conv_or_reason(conv, reason) -> tuple[str, str]:
+    """(text, color) for a conviction/score cell: the numeric conviction when scored, else the
+    ineligibility reason token (TRAP / NO-HIST / ETF / NO DATA) in muted ink so an excluded name
+    reads as *why* it has no score rather than a bare, ambiguous dash (owner 2026-07-24)."""
+    if not _isnan(conv):
+        return f"{conv:+.2f}", _z_color(conv)
+    token = "" if _isnan(reason) else str(reason).strip()
+    return (_esc(token) if token else "·"), MUTED
+
+
 def _heat_bg(z) -> str:
     """RGBA tint for a heatmap cell: bull-green (pos) / bear-red (neg), the
     opacity ramping with |z| (clamped at ``_Z_HEAT``). Same two hues as the
@@ -395,7 +405,7 @@ def _overview(scores: pd.DataFrame, conv_scale: float) -> str:
         rank_s = "–" if _isnan(rank) else str(int(rank))
         sector_s = _esc(r.get("sector", "")) or "–"
         name_s = _esc(r.get("name", ""))
-        conv_s = "·" if _isnan(conv) else f"{conv:+.2f}"
+        conv_s, conv_color = _conv_or_reason(conv, r.get("inelig_reason"))
         cells = "".join(_heat_cell(lbl, r.get(k, np.nan)) for k, lbl in CLUSTER_CELLS)
         rows.append(
             '<div class="hm-row">'
@@ -404,7 +414,7 @@ def _overview(scores: pd.DataFrame, conv_scale: float) -> str:
             f'<span class="hm-tkr">{_esc(tkr)}</span>'
             f'<span class="hm-sector">{sector_s}</span>'
             f'<span class="hm-name">{name_s}</span>'
-            f'<span class="hm-conv" style="color:{_z_color(conv)};">{conv_s}</span>'
+            f'<span class="hm-conv" style="color:{conv_color};">{conv_s}</span>'
             f'<span class="hm-barcell">{_bar(conv, conv_scale, "meter")}</span>'
             f'<div class="hm-cells">{cells}</div>'
             "</div>"
@@ -550,7 +560,7 @@ def _card(tkr: str, row: pd.Series, cols, conv_scale: float, delay: float) -> st
     )
     desc_html = f'<div class="desc">{_esc(desc_text)}</div>' if desc_text else ""
     price = _fmt("price", row.get("price", np.nan))
-    conv_txt = "·" if _isnan(conv) else f"{conv:+.2f}"
+    conv_txt, conv_color = _conv_or_reason(conv, row.get("inelig_reason"))
     rank_txt = "n/a" if _isnan(rank) else f"#{int(rank)}"
     tilt_label, tilt_cls = _tilt(conv, is_port)
     pf_tag = '<span class="pf-tag" title="Portfolio holding">PF</span>' if is_port else ""
@@ -570,7 +580,7 @@ def _card(tkr: str, row: pd.Series, cols, conv_scale: float, delay: float) -> st
         f'<div class="price-block"><div class="vk">Price</div>'
         f'<div class="price">{price}</div></div>'
         f'<div class="conv-block">'
-        f'<div class="conv" style="color:{_z_color(conv)};">{conv_txt}</div>'
+        f'<div class="conv" style="color:{conv_color};">{conv_txt}</div>'
         f'<div class="conv-l">Conviction · {rank_txt}</div>'
         f'<div class="tilt {tilt_cls}">{tilt_label}</div>'
         f"</div>"

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -110,6 +110,16 @@ def _tone(v) -> str:
     return BULL if v > 0 else (BEAR if v < 0 else INK2)
 
 
+def _conv_or_reason(conv, reason) -> tuple[str, str]:
+    """(text, color) for a conviction/score cell: the numeric conviction when scored, else the
+    ineligibility reason token (TRAP / NO-HIST / ETF / NO DATA) in muted ink so an excluded name
+    reads as *why* it has no score rather than a bare, ambiguous dash (owner 2026-07-24)."""
+    if not _nan(conv):
+        return f"{conv:+.2f}", _tone(conv)
+    token = "" if reason is None or _nan(reason) else str(reason).strip()
+    return (_esc(token) if token else "·"), MUTED
+
+
 def _get(row, key):
     try:
         val = row[key]
@@ -493,9 +503,11 @@ def _heatmap_section(scores, max_rows: int = 120) -> str:
         + _th("Rank", "right")
         + "</tr>"
     )
+    has_reason = "inelig_reason" in shown.columns
     body = []
     for tkr, r in shown.iterrows():
         conv, rank = r.get("conviction"), r.get("rank")
+        conv_txt, conv_color = _conv_or_reason(conv, r.get("inelig_reason") if has_reason else None)
         pf = (
             f' <span style="color:{ACCENT};font-size:8px;font-weight:700;">PF</span>'
             if bool(r.get("is_portfolio"))
@@ -510,7 +522,7 @@ def _heatmap_section(scores, max_rows: int = 120) -> str:
             f'<tr><td style="font-family:{MONO};font-size:10.5px;font-weight:700;color:{INK};'
             f'padding:4px 8px 4px 0;white-space:nowrap;">{_esc(str(tkr))}{pf}</td>{cells}'
             f'<td align="right" style="font-family:{MONO};font-size:10px;font-weight:700;'
-            f'color:{_tone(conv)};padding:4px 0 4px 8px;">{"·" if _nan(conv) else f"{conv:+.2f}"}</td>'
+            f'color:{conv_color};padding:4px 0 4px 8px;">{conv_txt}</td>'
             f'<td align="right" style="font-family:{MONO};font-size:9.5px;color:{MUTED};'
             f'padding:4px 0 4px 6px;">{"" if _nan(rank) else "#" + str(int(rank))}</td></tr>'
         )


### PR DESCRIPTION
## Problem
The factor snapshot showed a bare `-`/`·` score for ~11 names (GOOG, T, 6702.T, SBMO.AS, SMSN.L, KAP.L, GLD, UVXY, …). Root cause: three distinct conditions collapsing into one ambiguous sentinel (NaN conviction → dash).

## Fixes
1. **Value-trap gate false-positives (momentum guard).** `earn_trajectory = PEF/PET > 1.10` marked names ineligible. It misfired on **GOOG** (trajectory 1.35 — etoro.csv PET=16 vs a real ~26 per TipRanks; a one-off GAAP gain inflated trailing EPS) despite +86% 12-1 momentum. A genuine value trap is cheap-looking AND falling, so the gate is now momentum-corroborated (positive `mom_12_1` clears it). New `_value_trap_gate()` = single source of truth across eligibility, held-trap SELL, and new-buy veto. Forward-loss trap stays unguarded.
2. **GOOG→GOOGL SF1 key.** GOOG fundamentals were keyed under GOOGL → GOOG silently lost `gp_assets`/`sue`. `live_fundamentals_factors` now resolves the class-share alias.
3. **SMSN.L / KAP.L history.** LSE GDR (USD) lines Yahoo covers with ~5 bars; the `.IL` International Order Book line (same instrument) has full history → `SMSN.L→SMSN.IL`, `KAP.L→KAP.IL`.
4. **Display.** Ineligible names now show WHY (`TRAP` / `NO-HIST` / `ETF` / `NO DATA`) via a new `inelig_reason` column, in both browser + email editions.

## Verification (real VPS data)
GOOG/6702.T/7269.T/9201.T/SMSN.L/SBMO.AS → **now scored**; T/KAP.L → **TRAP** (data-accurate); GLD/UVXY → **ETF**. GOOG regained gp_assets/sue. 908 tests pass in the v3 sweep (new momentum-guard, alias, substitution, reason-token tests; existing value-trap test updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)