### PR TITLE
feat(v3): cash as a deliberate regime-conditional sizing target

### DIFF
--- a/docs/superpowers/plans/2026-07-24-cash-target-sizing.md
+++ b/docs/superpowers/plans/2026-07-24-cash-target-sizing.md
@@ -1,0 +1,424 @@
+# Cash-Target Sizing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make total-book cash a deliberate, regime-conditional target the v3 overlay sizes to (~11% RISK_ON), instead of an under-absorption residual, and report true total invested.
+
+**Architecture:** Three isolated changes: (A) lower the regime deployment targets in `conditioning.py`; (B) add a post-gate "redeploy-to-target" step in `overlay.build_overlay` (a pure `_distribute_to_headroom` helper + a vol-safe wiring block) that up-grosses toward `gross_target` within per-name caps and the vol ceiling; (C) make the report headline include the held-out managed sleeves so deployment/cash are honest.
+
+**Tech Stack:** Python 3.12 (local `.venv`) / 3.14 (VPS), pandas, numpy, pytest. Existing helpers: `risk_gate.portfolio_vol`, `overlay._tiered_name_caps`, `combine.compute_scores`.
+
+## Global Constraints
+
+- TDD: write the failing test first, watch it fail, implement, watch it pass, commit. One behavior per test.
+- Run tests with `.venv/bin/python -m pytest <path> -q -p no:cacheprovider`.
+- Pre-commit hooks run ruff + ruff-format + mypy + markdownlint on commit; if ruff-format rewrites a file, `git add -A` and re-commit.
+- Do NOT change: mega-cap core floor/protection, value-trap/forward-loss gates, factor scoring, managed-sleeve carve-out. The 20% vol ceiling is a HARD constraint the redeploy must never breach.
+- Branch: `feat/cash-target-sizing` (already created). Never push to master directly; land via PR.
+- Spec: `docs/superpowers/specs/2026-07-24-cash-target-sizing-design.md`.
+
+---
+
+## File Structure
+
+- `trade_modules/v3/conditioning.py` — regime deployment values (Task 1).
+- `trade_modules/v3/overlay.py` — `_distribute_to_headroom` helper (Task 2) + redeploy wiring in `build_overlay` (Task 3).
+- `scripts/v3_overlay_report.py` + `trade_modules/v3/report.py` + `report_email.py` — reporting of total invested incl. managed (Task 4).
+- Tests: `tests/unit/trade_modules/test_v3_conditioning.py`, `test_v3_overlay.py`.
+
+---
+
+## Task 1: Regime deployment targets
+
+**Files:**
+
+- Modify: `trade_modules/v3/conditioning.py:16-20` (`DEPLOYMENT_BY_REGIME`) and `:78` (band default).
+- Test: `tests/unit/trade_modules/test_v3_conditioning.py`
+
+**Interfaces:**
+
+- Produces: `DEPLOYMENT_BY_REGIME` = `{"risk_off": 0.80, "neutral": 0.87, "risk_on": 0.89}`; `resolve_deployment(regime)` band default `(0.75, 0.92)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/trade_modules/test_v3_conditioning.py
+from trade_modules.v3.conditioning import DEPLOYMENT_BY_REGIME, resolve_deployment
+
+
+def test_regime_deployment_targets_are_the_cash_band():
+    # Total-book invested targets -> cash 20% / 13% / 11%.
+    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.80
+    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.87
+    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.89
+
+
+def test_resolve_deployment_clamps_to_new_band():
+    dep, diag = resolve_deployment("risk_on")
+    assert dep == 0.89
+    assert diag["base_deployment"] == 0.89
+    # A large positive tilt cannot exceed the new upper band.
+    dep_hi, _ = resolve_deployment("risk_on", polymarket_signal=1.0, max_pm_tilt=0.20)
+    assert dep_hi == 0.92
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_conditioning.py -q -p no:cacheprovider`
+Expected: FAIL (values are still 0.78/0.88/0.98, band 0.78-0.98).
+
+- [ ] **Step 3: Implement the minimal change**
+
+In `conditioning.py`, set:
+
+```python
+DEPLOYMENT_BY_REGIME: dict[str, float] = {
+    "risk_off": 0.80,   # 20% cash — the debate's confirmed-risk-off band (15-25%)
+    "neutral": 0.87,    # 13% cash
+    "risk_on": 0.89,    # 11% cash — deliberate buffer for a copied book near highs
+}
+```
+
+And update the comment on the line above from `band 78-98%` to `band 75-92%`, and change the `resolve_deployment` signature default `band: tuple[float, float] = (0.78, 0.98)` to `band: tuple[float, float] = (0.75, 0.92)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_conditioning.py -q -p no:cacheprovider`
+Expected: PASS. Then run the existing suite that imports these:
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_overlay.py tests/unit/scripts/test_v3_overlay_report.py -q -p no:cacheprovider`
+Expected: PASS (fix any test that hard-coded 0.98/0.78).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_modules/v3/conditioning.py tests/unit/trade_modules/test_v3_conditioning.py
+git commit -m "feat(v3): regime deployment targets -> 10-12% cash band"
+```
+
+---
+
+## Task 2: `_distribute_to_headroom` pure helper
+
+**Files:**
+
+- Modify: `trade_modules/v3/overlay.py` (add module-level helper near the other `_` helpers).
+- Test: `tests/unit/trade_modules/test_v3_overlay.py`
+
+**Interfaces:**
+
+- Produces: `_distribute_to_headroom(weights: pd.Series, conviction: pd.Series, caps: pd.Series, gap: float) -> pd.Series` — returns boosted weights (same index); distributes `gap` proportional to positive conviction, each name bounded by `caps - weights` headroom; unplaceable remainder is simply not added (caller treats as residual cash).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_distribute_to_headroom_fills_by_conviction_up_to_caps():
+    from trade_modules.v3.overlay import _distribute_to_headroom
+
+    w = pd.Series({"A": 0.05, "B": 0.05, "C": 0.05})
+    conv = pd.Series({"A": 2.0, "B": 1.0, "C": -1.0})  # C disliked -> gets nothing
+    caps = pd.Series({"A": 0.10, "B": 0.10, "C": 0.10})
+    out = _distribute_to_headroom(w, conv, caps, gap=0.06)
+    # 0.06 split 2:1 by conviction between A and B; C untouched.
+    assert out["A"] == pytest.approx(0.09)
+    assert out["B"] == pytest.approx(0.07)
+    assert out["C"] == pytest.approx(0.05)
+    assert out.sum() == pytest.approx(w.sum() + 0.06)
+
+
+def test_distribute_to_headroom_spills_capped_weight_to_others():
+    from trade_modules.v3.overlay import _distribute_to_headroom
+
+    w = pd.Series({"A": 0.08, "B": 0.02})
+    conv = pd.Series({"A": 3.0, "B": 1.0})  # A favored but near its cap
+    caps = pd.Series({"A": 0.10, "B": 0.10})
+    out = _distribute_to_headroom(w, conv, caps, gap=0.06)
+    # A can only take 0.02 (to its 0.10 cap); the remaining 0.04 spills to B.
+    assert out["A"] == pytest.approx(0.10)
+    assert out["B"] == pytest.approx(0.06)
+
+
+def test_distribute_to_headroom_leaves_unplaceable_gap():
+    from trade_modules.v3.overlay import _distribute_to_headroom
+
+    w = pd.Series({"A": 0.09, "B": 0.09})
+    conv = pd.Series({"A": 1.0, "B": 1.0})
+    caps = pd.Series({"A": 0.10, "B": 0.10})
+    out = _distribute_to_headroom(w, conv, caps, gap=0.50)  # only 0.02 placeable
+    assert out.sum() == pytest.approx(0.20)  # 0.18 + 0.02; rest unplaced
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_overlay.py -k distribute_to_headroom -q -p no:cacheprovider`
+Expected: FAIL with `ImportError: cannot import name '_distribute_to_headroom'`.
+
+- [ ] **Step 3: Implement the helper**
+
+```python
+def _distribute_to_headroom(
+    weights: pd.Series, conviction: pd.Series, caps: pd.Series, gap: float
+) -> pd.Series:
+    """Distribute ``gap`` across ``weights``' names proportional to positive conviction,
+    each bounded by its per-name cap headroom (``caps - weights``). Weight that spills
+    off a name hitting its cap is re-distributed to those with remaining headroom, so
+    the whole gap is placed unless every name is capped. Any unplaceable remainder is
+    left unplaced (the caller treats it as residual cash). Pure; no vol/sector logic."""
+    w = weights.astype(float).copy()
+    if gap is None or gap <= 1e-12:
+        return w
+    names = list(w.index)
+    conv = conviction.reindex(names).astype(float).clip(lower=0.0).fillna(0.0)
+    cap = caps.reindex(names).astype(float)
+    remaining = float(gap)
+    for _ in range(64):  # each pass fills >=1 name to cap or exhausts the gap -> converges
+        head = (cap - w).clip(lower=0.0)
+        active = (head > 1e-12) & (conv > 0.0)
+        wsum = float(conv[active].sum())
+        if remaining <= 1e-12 or not bool(active.any()) or wsum <= 0.0:
+            break
+        alloc = pd.Series(0.0, index=names)
+        alloc[active] = remaining * (conv[active] / wsum)
+        alloc = pd.concat([alloc, head], axis=1).min(axis=1)  # clip each to its headroom
+        placed = float(alloc.sum())
+        if placed <= 1e-12:
+            break
+        w = w + alloc
+        remaining -= placed
+    return w
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_overlay.py -k distribute_to_headroom -q -p no:cacheprovider`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_modules/v3/overlay.py tests/unit/trade_modules/test_v3_overlay.py
+git commit -m "feat(v3): _distribute_to_headroom — conviction-weighted, cap-bounded gap fill"
+```
+
+---
+
+## Task 3: Wire redeploy-to-target into `build_overlay`
+
+**Files:**
+
+- Modify: `trade_modules/v3/overlay.py` — insert a redeploy block after the core-floor block (after the `vol_after` update near line 639) and before the turnover computation (line 644); add `redeploy` to the `diagnostics` dict (near line 663-683).
+- Test: `tests/unit/trade_modules/test_v3_overlay.py`
+
+**Interfaces:**
+
+- Consumes: `_distribute_to_headroom` (Task 2), `portfolio_vol` (already imported), `_tiered_name_caps`, in-scope locals `final`, `gross_target`, `cov`, `pos`, `conv_all`, `elig_mask`, `vol_ceiling`, `name_cap`, `tier_name_caps`, `scored`, `target_names`.
+- Produces: `diagnostics["redeploy"]` = `{"gap": float, "deployed_before": float, "deployed_after": float, "residual_cash": float}`; `final` now sums to ~`gross_target` when capacity + vol allow.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_build_overlay_redeploys_to_target_instead_of_cash():
+    """Under-absorption fix: when small tier-capped buys can't fill the budget, the
+    freed weight is redeployed into held eligible names (up to caps) so the book hits
+    gross_target, rather than pooling as cash."""
+    _tks, _convs, sc = _universe20()
+    sc["cap"] = 5e11  # all large-cap so tiered caps give ample per-name headroom
+    current = pd.Series({"U00": 0.30, "U01": 0.30})  # 60% held, strong names
+    res = build_overlay(
+        sc, current, pd.DataFrame(), max_new=2, gross_target=0.90, tier_name_caps=False,
+        name_cap=0.60, vol_ceiling=None,
+    )
+    d, w = res["diagnostics"], res["weights"]
+    assert float(w.sum()) == pytest.approx(0.90, abs=0.02)  # hit the target
+    assert d["redeploy"]["deployed_after"] >= d["redeploy"]["deployed_before"]
+
+
+def test_build_overlay_redeploy_respects_vol_ceiling():
+    """Redeploy never breaches the vol ceiling — residual stays cash and is reported."""
+    _tks, _convs, sc = _universe20()
+    current = pd.Series({"U00": 0.20})
+    res = build_overlay(
+        sc, current, pd.DataFrame(), max_new=0, gross_target=0.95, vol_ceiling=0.01,
+    )  # a 1% ceiling is unreachable at 95% gross -> cannot fully redeploy
+    w = res["weights"]
+    assert float(w.sum()) <= 0.95 + 1e-6
+    assert res["diagnostics"]["redeploy"]["residual_cash"] >= 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_overlay.py -k "redeploy" -q -p no:cacheprovider`
+Expected: FAIL — `KeyError: 'redeploy'` and/or `w.sum()` well below 0.90.
+
+- [ ] **Step 3: Implement the redeploy block**
+
+Insert after the core-floor block closes (immediately before the `# Turnover` comment at line ~644):
+
+```python
+    # Redeploy-to-target (owner 2026-07-24): make cash DELIBERATE, not an under-absorption
+    # residual. If the gated + floored book sits BELOW gross_target and vol headroom exists,
+    # top up held + bought ELIGIBLE names (conviction-weighted, per-name-cap bounded via
+    # _distribute_to_headroom), then bisection-scale the increment so the 20% vol ceiling is
+    # never breached. Any gap that still can't be placed stays cash and is REPORTED. The
+    # gate's DE-gross (excess -> cash) path is untouched; this only up-grosses within caps.
+    redeploy_diag = {"gap": 0.0, "deployed_before": float(final.sum()) if len(final) else 0.0,
+                     "deployed_after": float(final.sum()) if len(final) else 0.0, "residual_cash": 0.0}
+    if len(final) and gross_target is not None:
+        deployed = float(final.sum())
+        gap = float(gross_target) - deployed
+        if gap > 1e-4:
+            caps_ser = (
+                pd.Series(_tiered_name_caps(scored, target_names), index=target_names)
+                if tier_name_caps and scored is not None
+                else pd.Series(float(name_cap), index=target_names)
+            )
+            elig_names = [
+                t for t in final.index
+                if t in caps_ser.index and bool(elig_mask.get(t, False))
+            ]
+            if elig_names:
+                boosted = _distribute_to_headroom(
+                    final.reindex(elig_names), conv_all.reindex(elig_names),
+                    caps_ser.reindex(elig_names), gap,
+                )
+                trial = final.copy()
+                trial.loc[elig_names] = boosted
+                names_v = [t for t in trial.index if t in pos]
+                ix = [pos[t] for t in names_v]
+                covm = cov[np.ix_(ix, ix)]
+                base = final.reindex(names_v).to_numpy()
+                delta = (trial.reindex(names_v).to_numpy() - base)
+                if vol_ceiling is not None and portfolio_vol(base + delta, covm) > float(vol_ceiling):
+                    lo, hi = 0.0, 1.0
+                    for _ in range(40):  # bisection: largest step with vol <= ceiling
+                        mid = 0.5 * (lo + hi)
+                        if portfolio_vol(base + mid * delta, covm) <= float(vol_ceiling):
+                            lo = mid
+                        else:
+                            hi = mid
+                    delta = lo * delta
+                final = pd.Series(base + delta, index=names_v)
+                final = final[final > 1e-12]
+            deployed_after = float(final.sum())
+            redeploy_diag = {
+                "gap": gap, "deployed_before": deployed, "deployed_after": deployed_after,
+                "residual_cash": max(0.0, float(gross_target) - deployed_after),
+            }
+```
+
+Then add to the `diagnostics` dict (after `"core_floor_applied": core_floor_applied,`):
+
+```python
+        "redeploy": redeploy_diag,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/test_v3_overlay.py -q -p no:cacheprovider`
+Expected: PASS (new redeploy tests + all existing overlay tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_modules/v3/overlay.py tests/unit/trade_modules/test_v3_overlay.py
+git commit -m "feat(v3): redeploy-to-target — deliberate cash, not under-absorption residual"
+```
+
+---
+
+## Task 4: Report true total invested (incl. managed sleeves)
+
+**Files:**
+
+- Modify: `scripts/v3_overlay_report.py:237` — `overlay_portfolio_view(overlay, scored)` gains a `managed_weight` param so `gross` includes the held-out managed sleeves; update its call sites (`main()` passes the real `managed_weight`; `build_overlay_preview_html` at ~line 363 passes the default `0.0`).
+- Modify: `trade_modules/v3/report.py:623` and `report_email.py` render_summary — label the headline as total invested; no formula change since `portfolio["gross"]`/`["cash"]` now carry the totals.
+- Test: `tests/unit/scripts/test_v3_overlay_report.py`
+
+**Interfaces:**
+
+- Consumes: `managed_weight` (float, computed in `main()` as `managed_weight`), the overlay result.
+- Produces: `overlay_portfolio_view(overlay, scored, managed_weight=0.0)` → dict with `gross` = model deployed + managed_weight, `cash` = `1 - gross`, `model_gross` = model deployed, `managed_weight` = managed_weight.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_overlay_portfolio_view_gross_includes_managed_sleeves():
+    import pandas as pd
+    from scripts.v3_overlay_report import overlay_portfolio_view
+
+    overlay = {"weights": pd.Series({"AAA": 0.40, "BBB": 0.35}), "diagnostics": {}}
+    view = overlay_portfolio_view(overlay, None, managed_weight=0.14)
+    assert view["model_gross"] == pytest.approx(0.75)
+    assert view["gross"] == pytest.approx(0.89)      # 0.75 model + 0.14 managed
+    assert view["cash"] == pytest.approx(0.11)
+    assert view["managed_weight"] == pytest.approx(0.14)
+
+
+def test_overlay_portfolio_view_defaults_managed_zero():
+    import pandas as pd
+    from scripts.v3_overlay_report import overlay_portfolio_view
+
+    overlay = {"weights": pd.Series({"AAA": 0.40}), "diagnostics": {}}
+    view = overlay_portfolio_view(overlay, None)  # default managed_weight=0.0
+    assert view["gross"] == pytest.approx(0.40)
+    assert view["managed_weight"] == pytest.approx(0.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/scripts/test_v3_overlay_report.py -k managed -q -p no:cacheprovider`
+Expected: FAIL — `overlay_portfolio_view()` takes 2 positional args / no `managed_weight`; `gross` is model-only 0.75.
+
+- [ ] **Step 3: Implement**
+
+Change the signature at `scripts/v3_overlay_report.py:237` to
+`def overlay_portfolio_view(overlay: dict, scored: pd.DataFrame, managed_weight: float = 0.0) -> dict:`
+and replace the `gross` computation (line 247) with:
+
+```python
+    model_gross = float(weights.sum()) if len(weights) else 0.0
+    gross = model_gross + float(managed_weight)
+```
+
+Then in the returned dict add `"model_gross": model_gross,` and `"managed_weight": float(managed_weight),` alongside the existing `"gross": gross,` / `"cash": max(0.0, 1.0 - gross),` (these now reflect the total). Update the `main()` call site to pass `managed_weight=managed_weight` (it is already a local there); leave `build_overlay_preview_html`'s call on the default.
+
+In `report.py:623` change the label text to `"{gross} deployed (incl. managed) / {cash} cash"` (keep reading `portfolio.get('gross')`/`('cash')`). In `report_email.py` render_summary, confirm `dep` reads `portfolio.get("gross")` (the total); if it reads `meta["gross_target"]`, switch it to `portfolio.get("gross")`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/scripts/test_v3_overlay_report.py tests/unit/trade_modules/test_v3_report.py tests/unit/trade_modules/test_v3_report_email.py -q -p no:cacheprovider`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/v3_overlay_report.py trade_modules/v3/report.py trade_modules/v3/report_email.py tests/unit/scripts/test_v3_overlay_report.py
+git commit -m "feat(v3): report true total invested incl. managed sleeves"
+```
+
+---
+
+## Task 5: Full-suite verify, deploy, regenerate
+
+**Files:** none (integration + ops).
+
+- [ ] **Step 1: Run the full v3 sweep**
+
+Run: `.venv/bin/python -m pytest tests/unit/trade_modules/ tests/unit/scripts/ -q -p no:cacheprovider -k "v3 or riskfirst or combine or overlay or conditioning or report or fundamental"`
+Expected: all PASS (target ~915+ tests, 0 fail).
+
+- [ ] **Step 2: Land via PR + deploy**
+
+```bash
+git push -u origin feat/cash-target-sizing
+gh pr create --base master --title "feat(v3): cash as a deliberate regime-conditional sizing target" --body "See docs/superpowers/specs/2026-07-24-cash-target-sizing-design.md"
+gh pr merge --merge --admin --delete-branch
+```
+
+Then on Mac and VPS: `git checkout master && git pull origin master`.
+
+- [ ] **Step 3: Regenerate the snapshot on the VPS and verify**
+
+Run the account snapshot + overlay report on the VPS with the locked env (as in `scripts/vps/run-v3-report.sh`, no email), then confirm: console prints `deployment: 89%` for RISK_ON, and the report headline shows total invested ~89% / cash ~11% (incl. managed), redeploy diagnostics present.
+Expected: total cash lands ~11%; headline honest.
+
+- [ ] **Step 4: Send the fresh snapshot** (only if the owner asks) via `run-v3-report.sh`.

--- a/docs/superpowers/specs/2026-07-24-cash-target-sizing-design.md
+++ b/docs/superpowers/specs/2026-07-24-cash-target-sizing-design.md
@@ -1,0 +1,80 @@
+# Cash as a first-class sizing factor — design
+
+- **Date:** 2026-07-24
+- **Status:** Approved (design), pending implementation plan
+- **Owner:** Dimitrios Plessas
+- **Scope:** `etorotrade` v3 overlay (portfolio construction)
+
+## Problem
+
+The v3 overlay's total cash level is neither deliberate nor honestly reported.
+
+1. **Cash is a residual, not a target.** The RISK_ON deployment policy targets **98% invested / 2% cash** (`conditioning.DEPLOYMENT_BY_REGIME["risk_on"] = 0.98`). The book only lands near ~10% cash because the risk gate clamps small, tier-capped buys DOWN and drops the excess to cash with **no redistribution** (`risk_gate._clamp_caps`: "excess → cash"). So the ~10% cash is an *under-absorption shortfall*, not a chosen buffer — if absorption improved, the book would deploy toward 98% (2% cash), which is more aggressive than the owner wants for a copied book near highs.
+
+2. **The deployment headline is misleading.** The report headline shows the **model-part only** (e.g. "deployment 76.6%"), which is `gross_target` AFTER the ~14% managed-sleeve carve-out (`LYXGRE.DE + GLD + UVXY`). Total invested including the held managed sleeves is ~90% (cash ~10%), but the headline reads as if cash were ~23%.
+
+The owner wants cash to be an **explicit, deliberate input to sizing** — the portfolio manager should size positions to a target cash band (~10-12%), accounting for the managed sleeves, rather than letting cash fall out as a residual.
+
+## Goals
+
+- A deliberate, regime-conditional **total-book** cash band (~10-12% in RISK_ON).
+- The overlay **sizes to** that target: redeploy un-absorbed budget into eligible names (up to caps + the vol ceiling) instead of dropping it to cash. Cash rises above the operating floor only via a genuine regime / vol / capacity constraint.
+- Honest reporting: the deployment headline reflects **true total invested** (model + managed sleeves) plus a cash line and the regime target.
+
+## Non-goals (explicitly unchanged)
+
+- Mega-cap core floor & protection; value-trap / forward-loss gates; factor scoring; managed-sleeve carve-out (GLD/UVXY/LYXGRE stay held-out).
+- No shorts (separate decision, rejected).
+- The 20% annualized book-vol ceiling remains a HARD constraint and always wins over the deployment target.
+
+## Design
+
+### A. Regime deployment targets (`trade_modules/v3/conditioning.py`)
+
+`DEPLOYMENT_BY_REGIME` is already the **total-book** invested target (the managed carve-out is subtracted afterward: `model gross = resolve_deployment(regime) − managed_weight`). Change the values so total-book cash lands in the intended band:
+
+| regime | current (invested / cash) | new (invested / cash) |
+|--------|---------------------------|-----------------------|
+| `risk_on`  | 0.98 / 2%  | **0.89 / 11%** |
+| `neutral`  | 0.88 / 12% | **0.87 / 13%** |
+| `risk_off` | 0.78 / 22% | **0.80 / 20%** |
+
+- Update the `resolve_deployment` band clamp from `(0.78, 0.98)` to `(0.75, 0.92)` so future tilts (e.g. Polymarket) stay within the intended range.
+- **Resolved judgment call:** `risk_off = 0.80` (20% cash) — within the debate's 15-25% risk-off band.
+
+### B. Redeploy-to-target — make cash deliberate (`trade_modules/v3/overlay.py`)
+
+A new **post-gate redeploy step** in `build_overlay`, after `apply_risk_gate` and the core floor:
+
+```text
+IF sum(final) < gross_target − epsilon AND vol headroom exists:
+    gap = gross_target − sum(final)
+    redeploy `gap` across the held + bought ELIGIBLE names, conviction-weighted,
+      each capped by its tier / sector / USD-bloc name cap,
+      re-checking book vol after each allocation so the 20% ceiling is never breached.
+    iterate until: gap consumed, OR every eligible name is at a cap, OR vol headroom exhausted.
+residual (gap not placed) stays as cash and is REPORTED (never silently hidden).
+```
+
+- **Scope (resolved judgment call):** conviction-weighted across ALL held + bought eligible names (more diversified than concentrating in the top-conviction few). Managed sleeves, ineligible names, and core-beyond-its-cap are excluded.
+- **Ordering:** allocate to the highest-conviction names first, but cap each at its tier limit so the sweep spreads rather than piling onto one name.
+- **Vol ceiling wins:** if redeploying to `gross_target` would push book vol above the ceiling, stop at the ceiling — the extra stays cash. (Today's book vol ~11.2% vs 20% ceiling, so ample headroom.)
+- This is additive and isolated: `apply_risk_gate`'s existing "clamp-down / excess→cash" de-gross semantics are untouched; the new step only *up-grosses* toward the target within the same caps.
+
+### C. Reporting fix (`trade_modules/v3/report.py`, `report_email.py`)
+
+- The deployment headline shows **true total invested = model deployment + managed-sleeve weight**, with a cash line and the regime target. Example: `deployment 89% · cash 11% (target 11%)` instead of `76.6%`.
+- Surface the managed-sleeve weight explicitly so the split (model vs managed vs cash) is legible.
+- Applies to both the browser report and the Outlook-safe email summary.
+
+### D. Tests + rollout
+
+- **TDD** (per changed area):
+  - `conditioning`: new regime values + band clamp.
+  - `overlay` redeploy: (1) hits `gross_target` when capacity + vol allow; (2) leaves an honest, reported residual when capacity is exhausted; (3) never breaches per-name / sector / USD / vol caps; (4) no-op when already at/above target.
+  - reporting: headline reflects total invested incl. managed; cash line correct.
+- **Rollout:** merge to master via PR, deploy Mac + VPS, regenerate the snapshot, verify total cash lands ~11% and the headline is honest.
+
+## Expected impact
+
+Net book change is modest. Relative to the **live** book (~94% invested / ~6% cash), the deliberate RISK_ON target of **~89% invested / ~11% cash** is a ~5pp de-risk — ~$55K raised to cash on a $1.097M book. Relative to where the model *accidentally* lands today (~90% invested / ~10% cash via the under-absorption shortfall), the practical book barely moves. The important change is *mechanism*: cash becomes a controlled, regime-conditional target the PM sizes to — not an accidental residual — and the report tells the truth about it.

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -272,7 +272,7 @@ def overlay_portfolio_view(
                 sector_exp[key] = sector_exp.get(key, 0.0) + w
 
     cvar_dep = gate.get("cvar_after")
-    cvar_rb = float(cvar_dep) / gross if (cvar_dep is not None and gross > 0) else None
+    cvar_rb = float(cvar_dep) / model_gross if (cvar_dep is not None and model_gross > 0) else None
     odiag = overlay["diagnostics"]
     region_exp = odiag.get("region_exposures") or {}
     max_region = odiag.get("max_region")

--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -234,17 +234,25 @@ def _compute_allocations(positions: dict, scores: pd.DataFrame) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def overlay_portfolio_view(overlay: dict, scored: pd.DataFrame) -> dict:
+def overlay_portfolio_view(
+    overlay: dict, scored: pd.DataFrame, managed_weight: float = 0.0
+) -> dict:
     """Adapt a ``build_overlay`` result into the dict shape ``render_report`` reads.
 
     ``build_overlay`` returns ``{weights, diagnostics}``; the report's exec panel
     expects a ``build_portfolio``-style dict (gross / cash / usd_bloc /
     sector_exposures / diagnostics with a ``gate`` block). This fills those from
     the gated book + gate diagnostics so the same template renders the overlay.
+
+    ``managed_weight`` is the NAV fraction held in owner-managed sleeves (GLD /
+    UVXY / LYXGRE) that the model does not touch.  Including it here makes the
+    reported ``gross`` reflect the TRUE total invested (model + managed) so the
+    headline cash figure is not artificially inflated.
     """
     weights = overlay["weights"]
     gate = overlay["diagnostics"].get("gate") or {}
-    gross = float(weights.sum()) if len(weights) else 0.0
+    model_gross = float(weights.sum()) if len(weights) else 0.0
+    gross = model_gross + float(managed_weight)
     # NAV-basis absolute USD weight; the caps tile converts to book-basis (/gross) to
     # rank it alongside name/sector/region (I2 is fixed at the tile, one place).
     usd_bloc = float(sum(float(w) for t, w in weights.items() if currency_of(t) in USD_BLOC))
@@ -271,6 +279,8 @@ def overlay_portfolio_view(overlay: dict, scored: pd.DataFrame) -> dict:
     return {
         "weights": weights,
         "gross": gross,
+        "model_gross": model_gross,
+        "managed_weight": float(managed_weight),
         "cash": max(0.0, 1.0 - gross),
         "usd_bloc": usd_bloc,
         "sector_exposures": sector_exp,
@@ -611,6 +621,7 @@ def main() -> None:
     #     sells nor re-deploys their capital; deployment shrinks by their weight. ---
     managed_upper = {s.upper() for s in _MANAGED_SLEEVES}
     held_managed = [t for t in current_weights.index if str(t).upper() in managed_upper]
+    managed_weight: float = 0.0
     if held_managed:
         managed_weight = float(sum(float(current_weights[t]) for t in held_managed))
         current_weights = current_weights.drop(index=held_managed)
@@ -661,7 +672,7 @@ def main() -> None:
         min_conviction=_MIN_CONVICTION,
         portfolio_aware=_PORTFOLIO_AWARE,
     )
-    view = overlay_portfolio_view(overlay, scores)
+    view = overlay_portfolio_view(overlay, scores, managed_weight=managed_weight)
     actions = build_actions(overlay["weights"], current_weights, scores, nav=nav)
     # Attach live P/L from the eToro account snapshot to held names (P/L $ / % / value).
     _positions = load_account_positions()

--- a/tests/unit/scripts/test_v3_overlay_report.py
+++ b/tests/unit/scripts/test_v3_overlay_report.py
@@ -1,12 +1,18 @@
-"""TDD — overlay holding-key canonicalization.
+"""TDD — overlay holding-key canonicalization + managed-sleeve gross reporting.
 
 eToro carries US listings with a ``.US`` suffix in the account + portfolio.csv (T.US),
 while etoro.csv + the price store use the bare Yahoo ticker (T). The overlay normalizes
 held/candidate keys to the etoro.csv-canonical form so the book, universe, price store
 and display all agree (owner 2026-07-24).
+
+Task 4: overlay_portfolio_view gains a ``managed_weight`` param so the reported
+``gross`` includes held-out managed sleeves (GLD/UVXY/LYXGRE) and ``cash`` reflects
+the true un-invested portion (owner 2026-07-24).
 """
 
 from __future__ import annotations
+
+import pytest
 
 from scripts.v3_overlay_report import _canonicalize_keys
 
@@ -34,3 +40,32 @@ def test_ambiguous_root_left_unresolved():
     # Two CSV keys share the root "T" -> ambiguous -> a held "T.EUR" is not remapped.
     out = _canonicalize_keys(["T.EUR"], ["T", "T.L"])
     assert out == ["T.EUR"]
+
+
+# ---------------------------------------------------------------------------
+# Task 4: overlay_portfolio_view gross includes managed sleeves
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_portfolio_view_gross_includes_managed_sleeves():
+    import pandas as pd
+
+    from scripts.v3_overlay_report import overlay_portfolio_view
+
+    overlay = {"weights": pd.Series({"AAA": 0.40, "BBB": 0.35}), "diagnostics": {}}
+    view = overlay_portfolio_view(overlay, None, managed_weight=0.14)
+    assert view["model_gross"] == pytest.approx(0.75)
+    assert view["gross"] == pytest.approx(0.89)  # 0.75 model + 0.14 managed
+    assert view["cash"] == pytest.approx(0.11)
+    assert view["managed_weight"] == pytest.approx(0.14)
+
+
+def test_overlay_portfolio_view_defaults_managed_zero():
+    import pandas as pd
+
+    from scripts.v3_overlay_report import overlay_portfolio_view
+
+    overlay = {"weights": pd.Series({"AAA": 0.40}), "diagnostics": {}}
+    view = overlay_portfolio_view(overlay, None)  # default managed_weight=0.0
+    assert view["gross"] == pytest.approx(0.40)
+    assert view["managed_weight"] == pytest.approx(0.0)

--- a/tests/unit/trade_modules/test_v3_conditioning.py
+++ b/tests/unit/trade_modules/test_v3_conditioning.py
@@ -17,9 +17,9 @@ from trade_modules.v3.conditioning import (
 
 
 def test_deployment_by_regime_values() -> None:
-    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.78
-    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.88
-    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.98
+    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.80
+    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.87
+    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.89
 
 
 # ---------------------------------------------------------------------------
@@ -29,23 +29,23 @@ def test_deployment_by_regime_values() -> None:
 
 class TestRegimeDeployment:
     def test_risk_off(self) -> None:
-        assert regime_deployment("risk_off") == pytest.approx(0.78)
+        assert regime_deployment("risk_off") == pytest.approx(0.80)
 
     def test_neutral(self) -> None:
-        assert regime_deployment("neutral") == pytest.approx(0.88)
+        assert regime_deployment("neutral") == pytest.approx(0.87)
 
     def test_risk_on(self) -> None:
-        assert regime_deployment("risk_on") == pytest.approx(0.98)
+        assert regime_deployment("risk_on") == pytest.approx(0.89)
 
     def test_unknown_returns_neutral(self) -> None:
-        assert regime_deployment("unknown") == pytest.approx(0.88)
+        assert regime_deployment("unknown") == pytest.approx(0.87)
 
     def test_empty_string_returns_neutral(self) -> None:
-        assert regime_deployment("") == pytest.approx(0.88)
+        assert regime_deployment("") == pytest.approx(0.87)
 
     def test_none_as_string_returns_neutral(self) -> None:
         # None is not in the dict; falls back to neutral.
-        assert regime_deployment("None") == pytest.approx(0.88)
+        assert regime_deployment("None") == pytest.approx(0.87)
 
 
 # ---------------------------------------------------------------------------
@@ -102,27 +102,27 @@ class TestPolymarketAdjustment:
 class TestResolveDeployment:
     def test_known_regime_no_pm(self) -> None:
         dep, diag = resolve_deployment("risk_on")
-        assert dep == pytest.approx(0.98)
-        assert diag["final_deployment"] == pytest.approx(0.98)
+        assert dep == pytest.approx(0.89)
+        assert diag["final_deployment"] == pytest.approx(0.89)
 
     def test_neutral_regime(self) -> None:
         dep, diag = resolve_deployment("neutral")
-        assert dep == pytest.approx(0.88)
+        assert dep == pytest.approx(0.87)
 
     def test_risk_off_regime(self) -> None:
         dep, diag = resolve_deployment("risk_off")
-        assert dep == pytest.approx(0.78)
+        assert dep == pytest.approx(0.80)
 
     def test_unknown_regime_neutral_fallback(self) -> None:
         dep, _ = resolve_deployment("garbage")
-        assert dep == pytest.approx(0.88)
+        assert dep == pytest.approx(0.87)
 
     # Polymarket inert by default
     def test_polymarket_inactive_by_default(self) -> None:
         _, diag = resolve_deployment("neutral", polymarket_signal=0.9)
         assert diag["polymarket_active"] is False
         assert diag["polymarket_tilt"] == pytest.approx(0.0)
-        assert diag["final_deployment"] == pytest.approx(0.88)
+        assert diag["final_deployment"] == pytest.approx(0.87)
 
     def test_polymarket_active_flag(self) -> None:
         _, diag = resolve_deployment("neutral", polymarket_signal=1.0, max_pm_tilt=0.03)
@@ -130,14 +130,14 @@ class TestResolveDeployment:
 
     # Band clamping
     def test_clamped_to_upper_band(self) -> None:
-        # risk_on (0.98) + large positive tilt should not exceed 0.98 (hi of default band)
+        # risk_on (0.89) + large positive tilt should not exceed 0.92 (hi of default band)
         dep, diag = resolve_deployment("risk_on", polymarket_signal=1.0, max_pm_tilt=0.10)
-        assert dep <= 0.98 + 1e-9
+        assert dep <= 0.92 + 1e-9
 
     def test_clamped_to_lower_band(self) -> None:
-        # risk_off (0.78) + large negative tilt should not go below 0.78 (lo of default band)
+        # risk_off (0.80) + large negative tilt should not go below 0.75 (lo of default band)
         dep, diag = resolve_deployment("risk_off", polymarket_signal=-1.0, max_pm_tilt=0.10)
-        assert dep >= 0.78 - 1e-9
+        assert dep >= 0.75 - 1e-9
 
     def test_custom_band(self) -> None:
         dep, _ = resolve_deployment("risk_on", band=(0.70, 0.80))
@@ -169,3 +169,24 @@ class TestResolveDeployment:
         for regime in ("risk_off", "neutral", "risk_on"):
             _, diag = resolve_deployment(regime)
             assert diag["base_deployment"] == pytest.approx(regime_deployment(regime))
+
+
+# ---------------------------------------------------------------------------
+# New cash-band targets (Task 1)
+# ---------------------------------------------------------------------------
+
+
+def test_regime_deployment_targets_are_the_cash_band():
+    # Total-book invested targets -> cash 20% / 13% / 11%.
+    assert DEPLOYMENT_BY_REGIME["risk_off"] == 0.80
+    assert DEPLOYMENT_BY_REGIME["neutral"] == 0.87
+    assert DEPLOYMENT_BY_REGIME["risk_on"] == 0.89
+
+
+def test_resolve_deployment_clamps_to_new_band():
+    dep, diag = resolve_deployment("risk_on")
+    assert dep == 0.89
+    assert diag["base_deployment"] == 0.89
+    # A large positive tilt cannot exceed the new upper band.
+    dep_hi, _ = resolve_deployment("risk_on", polymarket_signal=1.0, max_pm_tilt=0.20)
+    assert dep_hi == 0.92

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -14,7 +14,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from trade_modules.v3.overlay import build_overlay
+from trade_modules.riskfirst.construct import portfolio_vol
+from trade_modules.riskfirst.fx import USD_BLOC, currency_of
+from trade_modules.v3.overlay import _beta_array, _cov_matrix, build_overlay
 
 _SECTORS = ["Tech", "Health", "Financials", "Energy", "Industrials"]
 
@@ -723,9 +725,17 @@ def test_distribute_to_headroom_leaves_unplaceable_gap():
 
 
 def test_build_overlay_redeploys_to_target_instead_of_cash():
-    """Under-absorption fix: when small tier-capped buys can't fill the budget, the
-    freed weight is redeployed into held eligible names (up to caps) so the book hits
-    gross_target, rather than pooling as cash."""
+    """Under-absorption fix: freed/unfunded budget is redeployed into held eligible
+    names (up to caps) so the book hits gross_target, rather than pooling as cash.
+
+    A clean gap is created with ``max_new=0`` and ``gross_target`` above the kept
+    weight (keep_sum 0.60 -> target 0.90), so the 0.30 fill comes purely from
+    redeploy. ``_universe20`` is entirely USD, so ``usd_bloc_cap`` is set to 1.0
+    here: the redeploy now ENFORCES the USD-bloc cap, and the default 0.60 would
+    correctly refuse to refill an already-100%-USD book (that enforcement is covered
+    by ``test_build_overlay_redeploy_respects_usd_bloc_cap``). ``sector_cap=0.99``
+    and ``vol_ceiling=5.0`` keep sector/vol non-binding so redeploy fills to target.
+    """
     _tks, _convs, sc = _universe20()
     sc["cap"] = 5e11  # all large-cap so tiered caps give ample per-name headroom
     current = pd.Series({"U00": 0.30, "U01": 0.30})  # 60% held, strong names
@@ -736,19 +746,26 @@ def test_build_overlay_redeploys_to_target_instead_of_cash():
         sc,
         current,
         pd.DataFrame(),
-        max_new=2,
+        max_new=0,
         gross_target=0.90,
         tier_name_caps=False,
         name_cap=0.60,
+        sector_cap=0.99,
+        usd_bloc_cap=1.0,
         vol_ceiling=5.0,
     )
     d, w = res["diagnostics"], res["weights"]
     assert float(w.sum()) == pytest.approx(0.90, abs=0.02)  # hit the target
-    assert d["redeploy"]["deployed_after"] >= d["redeploy"]["deployed_before"]
+    assert d["redeploy"]["deployed_after"] > d["redeploy"]["deployed_before"]  # redeploy filled
 
 
 def test_build_overlay_redeploy_respects_vol_ceiling():
-    """Redeploy never breaches the vol ceiling — residual stays cash and is reported."""
+    """Redeploy never breaches the vol ceiling — residual stays cash and is reported.
+
+    Caps are set non-binding (single USD name -> sector/USD are 100% of gross, so
+    ``sector_cap`` / ``usd_bloc_cap`` must be 1.0 to impose no limit) so the VOL
+    ceiling is the constraint the redeploy has to respect here.
+    """
     _tks, _convs, sc = _universe20()
     current = pd.Series({"U00": 0.20})
     res = build_overlay(
@@ -757,8 +774,137 @@ def test_build_overlay_redeploy_respects_vol_ceiling():
         pd.DataFrame(),
         max_new=0,
         gross_target=0.95,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
         vol_ceiling=0.01,
     )  # a 1% ceiling is unreachable at 95% gross -> cannot fully redeploy
     w = res["weights"]
     assert float(w.sum()) <= 0.95 + 1e-6
     assert res["diagnostics"]["redeploy"]["residual_cash"] >= 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Redeploy respects sector / USD-bloc caps (owner 2026-07-24) + vol
+# --------------------------------------------------------------------------- #
+
+
+def _mixed_book(sectors, currencies, convs, weights):
+    """Build (scored, current) for a redeploy-cap test. ``currencies`` picks a bare
+    (USD) ticker or a ``.DE`` (EUR) suffix per held name; six low-conviction eligible
+    fillers pin the sell percentile well below the held convictions so nothing sells.
+    """
+    held = [(f"H{i}.DE" if c == "EUR" else f"H{i}") for i, c in enumerate(currencies)]
+    fill = [f"F{i:02d}" for i in range(6)]
+    tickers = held + fill
+    all_convs = list(convs) + [-1.0] * len(fill)
+    all_sectors = list(sectors) + [_SECTORS[i % 5] for i in range(len(fill))]
+    sc = _scored(tickers, all_convs, sectors=all_sectors)
+    current = pd.Series(dict(zip(held, weights, strict=True)))
+    return sc, current, held
+
+
+def _sector_fracs(weights, scored):
+    """Per-sector exposure as a fraction of gross, from output weights."""
+    gross = float(weights.sum())
+    out: dict[str, float] = {}
+    for t, w in weights.items():
+        lab = str(scored.loc[t, "sector"])
+        out[lab] = out.get(lab, 0.0) + float(w) / gross
+    return out
+
+
+def test_build_overlay_redeploy_respects_sector_cap():
+    """Redeploy must NOT push any sector above ``sector_cap``. Two high-conviction
+    Tech names + mid-conviction Health/Energy names: uncapped conviction-weighted
+    fill would drive Tech to ~44% of gross, over the 40% cap. The closed-form cap
+    scale throttles the whole increment so Tech lands exactly at the cap; the rest
+    of the gap stays cash.
+    """
+    sc, current, _held = _mixed_book(
+        sectors=["Tech", "Tech", "Health", "Health", "Energy", "Energy"],
+        currencies=["USD"] * 6,
+        convs=[3.0, 3.0, 1.5, 1.5, 1.5, 1.5],
+        weights=[0.05] * 6,
+    )
+    res = build_overlay(
+        sc,
+        current,
+        pd.DataFrame(),
+        max_new=0,
+        gross_target=0.90,
+        tier_name_caps=False,
+        name_cap=0.60,
+        sector_cap=0.40,
+        usd_bloc_cap=1.0,  # all-USD book: 1.0 keeps the bloc cap from binding here
+        vol_ceiling=5.0,
+    )
+    d, w = res["diagnostics"], res["weights"]
+    fracs = _sector_fracs(w, sc)
+    assert max(fracs.values()) <= 0.40 + 1e-9  # invariant: no sector over its cap
+    assert fracs["Tech"] == pytest.approx(0.40, abs=1e-6)  # the cap actually bound
+    assert d["redeploy"]["deployed_after"] > d["redeploy"]["deployed_before"]  # partial fill
+
+
+def test_build_overlay_redeploy_respects_usd_bloc_cap():
+    """Redeploy must NOT push the USD bloc above ``usd_bloc_cap``. One high-conviction
+    USD name (base 25% of gross) + two EUR names: uncapped fill would drive the USD
+    bloc to ~52% of gross, over the 50% cap. The closed-form scale throttles the
+    increment so the USD bloc lands exactly at the cap.
+    """
+    sc, current, held = _mixed_book(
+        sectors=["Tech", "Health", "Energy"],
+        currencies=["USD", "EUR", "EUR"],
+        convs=[3.0, 1.0, 1.0],
+        weights=[0.05, 0.075, 0.075],
+    )
+    res = build_overlay(
+        sc,
+        current,
+        pd.DataFrame(),
+        max_new=0,
+        gross_target=0.90,
+        tier_name_caps=False,
+        name_cap=0.80,
+        sector_cap=0.99,  # distinct sectors: keep sector from binding
+        usd_bloc_cap=0.50,
+        vol_ceiling=5.0,
+    )
+    d, w = res["diagnostics"], res["weights"]
+    gross = float(w.sum())
+    usd = sum(float(v) for t, v in w.items() if currency_of(t) in USD_BLOC)
+    assert usd / gross <= 0.50 + 1e-9  # invariant: USD bloc within cap
+    assert usd / gross == pytest.approx(0.50, abs=1e-6)  # the cap actually bound
+    assert d["redeploy"]["deployed_after"] > d["redeploy"]["deployed_before"]  # partial fill
+
+
+def test_build_overlay_redeploy_respects_vol_ceiling_partial_fill():
+    """With a MILDLY-binding vol ceiling and non-binding caps, the redeploy output
+    respects the vol ceiling AND still partially fills (deployed_after > before).
+    Covariance is reconstructed via the SAME single-factor path the overlay uses.
+    """
+    sc, current, _held = _mixed_book(
+        sectors=["Tech", "Health", "Energy"],
+        currencies=["USD", "USD", "USD"],
+        convs=[2.0, 1.9, 1.8],
+        weights=[0.10, 0.10, 0.10],
+    )
+    vol_ceiling = 0.15
+    res = build_overlay(
+        sc,
+        current,
+        pd.DataFrame(),
+        max_new=0,
+        gross_target=0.90,
+        tier_name_caps=False,
+        name_cap=0.95,
+        sector_cap=1.0,
+        usd_bloc_cap=1.0,
+        vol_ceiling=vol_ceiling,
+    )
+    d, w = res["diagnostics"], res["weights"]
+    names = list(w.index)
+    betas_arr = _beta_array(names, sc, None)
+    cov = _cov_matrix(pd.DataFrame(), names, betas_arr)
+    assert portfolio_vol(w.to_numpy(), cov) <= vol_ceiling + 1e-6  # vol respected
+    assert d["redeploy"]["deployed_after"] > d["redeploy"]["deployed_before"]  # partial fill
+    assert d["redeploy"]["deployed_after"] < 0.90  # vol prevents a full fill

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -715,3 +715,50 @@ def test_distribute_to_headroom_leaves_unplaceable_gap():
     caps = pd.Series({"A": 0.10, "B": 0.10})
     out = _distribute_to_headroom(w, conv, caps, gap=0.50)  # only 0.02 placeable
     assert out.sum() == pytest.approx(0.20)  # 0.18 + 0.02; rest unplaced
+
+
+# --------------------------------------------------------------------------- #
+# Redeploy-to-target — deliberate cash, not an under-absorption residual
+# --------------------------------------------------------------------------- #
+
+
+def test_build_overlay_redeploys_to_target_instead_of_cash():
+    """Under-absorption fix: when small tier-capped buys can't fill the budget, the
+    freed weight is redeployed into held eligible names (up to caps) so the book hits
+    gross_target, rather than pooling as cash."""
+    _tks, _convs, sc = _universe20()
+    sc["cap"] = 5e11  # all large-cap so tiered caps give ample per-name headroom
+    current = pd.Series({"U00": 0.30, "U01": 0.30})  # 60% held, strong names
+    # vol_ceiling=5.0 (non-binding): the risk gate does arithmetic on vol_ceiling and
+    # rejects None (`None + tol` -> TypeError, pre-existing), so a large finite ceiling
+    # expresses "vol is not the constraint here" the way the other overlay tests do.
+    res = build_overlay(
+        sc,
+        current,
+        pd.DataFrame(),
+        max_new=2,
+        gross_target=0.90,
+        tier_name_caps=False,
+        name_cap=0.60,
+        vol_ceiling=5.0,
+    )
+    d, w = res["diagnostics"], res["weights"]
+    assert float(w.sum()) == pytest.approx(0.90, abs=0.02)  # hit the target
+    assert d["redeploy"]["deployed_after"] >= d["redeploy"]["deployed_before"]
+
+
+def test_build_overlay_redeploy_respects_vol_ceiling():
+    """Redeploy never breaches the vol ceiling — residual stays cash and is reported."""
+    _tks, _convs, sc = _universe20()
+    current = pd.Series({"U00": 0.20})
+    res = build_overlay(
+        sc,
+        current,
+        pd.DataFrame(),
+        max_new=0,
+        gross_target=0.95,
+        vol_ceiling=0.01,
+    )  # a 1% ceiling is unreachable at 95% gross -> cannot fully redeploy
+    w = res["weights"]
+    assert float(w.sum()) <= 0.95 + 1e-6
+    assert res["diagnostics"]["redeploy"]["residual_cash"] >= 0.0

--- a/tests/unit/trade_modules/test_v3_overlay.py
+++ b/tests/unit/trade_modules/test_v3_overlay.py
@@ -679,3 +679,39 @@ def test_fund_floor_weakest_first_treats_nan_conviction_as_weakest():
 
     assert abs(out["NANC"] - 0.02) < 1e-9  # NaN cut first
     assert out["STRONG"] == 0.05  # spared
+
+
+def test_distribute_to_headroom_fills_by_conviction_up_to_caps():
+    from trade_modules.v3.overlay import _distribute_to_headroom
+
+    w = pd.Series({"A": 0.05, "B": 0.05, "C": 0.05})
+    conv = pd.Series({"A": 2.0, "B": 1.0, "C": -1.0})  # C disliked -> gets nothing
+    caps = pd.Series({"A": 0.10, "B": 0.10, "C": 0.10})
+    out = _distribute_to_headroom(w, conv, caps, gap=0.06)
+    # 0.06 split 2:1 by conviction between A and B; C untouched.
+    assert out["A"] == pytest.approx(0.09)
+    assert out["B"] == pytest.approx(0.07)
+    assert out["C"] == pytest.approx(0.05)
+    assert out.sum() == pytest.approx(w.sum() + 0.06)
+
+
+def test_distribute_to_headroom_spills_capped_weight_to_others():
+    from trade_modules.v3.overlay import _distribute_to_headroom
+
+    w = pd.Series({"A": 0.08, "B": 0.02})
+    conv = pd.Series({"A": 3.0, "B": 1.0})  # A favored but near its cap
+    caps = pd.Series({"A": 0.10, "B": 0.10})
+    out = _distribute_to_headroom(w, conv, caps, gap=0.06)
+    # A can only take 0.02 (to its 0.10 cap); the remaining 0.04 spills to B.
+    assert out["A"] == pytest.approx(0.10)
+    assert out["B"] == pytest.approx(0.06)
+
+
+def test_distribute_to_headroom_leaves_unplaceable_gap():
+    from trade_modules.v3.overlay import _distribute_to_headroom
+
+    w = pd.Series({"A": 0.09, "B": 0.09})
+    conv = pd.Series({"A": 1.0, "B": 1.0})
+    caps = pd.Series({"A": 0.10, "B": 0.10})
+    out = _distribute_to_headroom(w, conv, caps, gap=0.50)  # only 0.02 placeable
+    assert out.sum() == pytest.approx(0.20)  # 0.18 + 0.02; rest unplaced

--- a/tests/unit/trade_modules/test_v3_portfolio.py
+++ b/tests/unit/trade_modules/test_v3_portfolio.py
@@ -127,13 +127,13 @@ class TestTrendRegime:
 
 class TestDeploymentByRegime:
     def test_mapping_values(self):
-        assert DEPLOYMENT_BY_REGIME["risk_off"] == pytest.approx(0.78)
-        assert DEPLOYMENT_BY_REGIME["neutral"] == pytest.approx(0.88)
-        assert DEPLOYMENT_BY_REGIME["risk_on"] == pytest.approx(0.98)
+        assert DEPLOYMENT_BY_REGIME["risk_off"] == pytest.approx(0.80)
+        assert DEPLOYMENT_BY_REGIME["neutral"] == pytest.approx(0.87)
+        assert DEPLOYMENT_BY_REGIME["risk_on"] == pytest.approx(0.89)
 
     def test_averages_about_mid_band(self):
         vals = [DEPLOYMENT_BY_REGIME[r] for r in ("risk_off", "neutral", "risk_on")]
-        assert sum(vals) / len(vals) == pytest.approx(0.88)
+        assert sum(vals) / len(vals) == pytest.approx(0.8533, abs=1e-3)  # (0.80+0.87+0.89)/3
 
     def test_ordered_by_risk_appetite(self):
         assert (

--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -161,6 +161,7 @@ def _actions() -> list:
 
 def _view() -> dict:
     return {
+        "gross": 0.89,  # model (~0.75) + managed (~0.14) — true total invested
         "diagnostics": {
             "gate": {
                 "gross_after": 0.84,
@@ -172,7 +173,7 @@ def _view() -> dict:
                 "min_effective_bets": 10,
                 "usd_bloc": 0.68,
             }
-        }
+        },
     }
 
 
@@ -181,7 +182,7 @@ def test_render_summary_is_compact_and_outlook_safe():
     # Header: regime + counts + deployment.
     assert "RISK_ON" in html
     assert "buy" in html and "sell" in html
-    assert "84" in html  # deployment gross_after 0.84 -> 84.0%
+    assert "89" in html  # deployment portfolio["gross"] 0.89 -> 89.0% (model + managed)
     # Action rows carry ticker + action.
     assert "AAA" in html and "BUY" in html
     assert "BBB" in html and "SELL" in html

--- a/trade_modules/v3/conditioning.py
+++ b/trade_modules/v3/conditioning.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 # Regime → base deployment fraction
 # ---------------------------------------------------------------------------
 
-# Fraction of capital deployed by market regime (band 78-98%).
+# Fraction of capital deployed by market regime (band 75-92%).
 # This is the SINGLE SOURCE OF TRUTH — imported back into v3_portfolio.py.
 DEPLOYMENT_BY_REGIME: dict[str, float] = {
-    "risk_off": 0.78,
-    "neutral": 0.88,
-    "risk_on": 0.98,
+    "risk_off": 0.80,  # 20% cash — the debate's confirmed-risk-off band (15-25%)
+    "neutral": 0.87,  # 13% cash
+    "risk_on": 0.89,  # 11% cash — deliberate buffer for a copied book near highs
 }
 
 _UNKNOWN_DEPLOYMENT = DEPLOYMENT_BY_REGIME["neutral"]
@@ -75,7 +75,7 @@ def resolve_deployment(
     polymarket_signal: float | None = None,
     *,
     max_pm_tilt: float = 0.0,
-    band: tuple[float, float] = (0.78, 0.98),
+    band: tuple[float, float] = (0.75, 0.92),
 ) -> tuple[float, dict]:
     """Resolve the final deployment fraction and emit a diagnostic dict.
 

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -341,6 +341,38 @@ def _fund_floor_weakest_first(
     return out
 
 
+def _distribute_to_headroom(
+    weights: pd.Series, conviction: pd.Series, caps: pd.Series, gap: float
+) -> pd.Series:
+    """Distribute ``gap`` across ``weights``' names proportional to positive conviction,
+    each bounded by its per-name cap headroom (``caps - weights``). Weight that spills
+    off a name hitting its cap is re-distributed to those with remaining headroom, so
+    the whole gap is placed unless every name is capped. Any unplaceable remainder is
+    left unplaced (the caller treats it as residual cash). Pure; no vol/sector logic."""
+    w = weights.astype(float).copy()
+    if gap is None or gap <= 1e-12:
+        return w
+    names = list(w.index)
+    conv = conviction.reindex(names).astype(float).clip(lower=0.0).fillna(0.0)
+    cap = caps.reindex(names).astype(float)
+    remaining = float(gap)
+    for _ in range(64):  # each pass fills >=1 name to cap or exhausts the gap -> converges
+        head = (cap - w).clip(lower=0.0)
+        active = (head > 1e-12) & (conv > 0.0)
+        wsum = float(conv[active].sum())
+        if remaining <= 1e-12 or not bool(active.any()) or wsum <= 0.0:
+            break
+        alloc = pd.Series(0.0, index=names)
+        alloc[active] = remaining * (conv[active] / wsum)
+        alloc = pd.concat([alloc, head], axis=1).min(axis=1)  # clip each to its headroom
+        placed = float(alloc.sum())
+        if placed <= 1e-12:
+            break
+        w = w + alloc
+        remaining -= placed
+    return w
+
+
 def build_overlay(
     scored: pd.DataFrame,
     current_weights,

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -673,6 +673,69 @@ def build_overlay(
         final = pd.Series(dtype=float)
         gate_diag = {}
 
+    # Redeploy-to-target (owner 2026-07-24): make cash DELIBERATE, not an under-absorption
+    # residual. If the gated + floored book sits BELOW gross_target and vol headroom exists,
+    # top up held + bought ELIGIBLE names (conviction-weighted, per-name-cap bounded via
+    # _distribute_to_headroom), then bisection-scale the increment so the vol ceiling is never
+    # breached. Any gap that still can't be placed stays cash and is REPORTED. The gate's
+    # DE-gross (excess -> cash) path is untouched; this only up-grosses within per-name caps.
+    redeploy_diag = {
+        "gap": 0.0,
+        "deployed_before": float(final.sum()) if len(final) else 0.0,
+        "deployed_after": float(final.sum()) if len(final) else 0.0,
+        "residual_cash": 0.0,
+    }
+    if len(final) and gross_target is not None:
+        deployed = float(final.sum())
+        gap = float(gross_target) - deployed
+        if gap > 1e-4:
+            # cov is ordered by target_names, so this maps each in-book ticker to its cov
+            # row/col. The core-floor block builds the same `pos`, but only when the floor
+            # fires; recompute here so redeploy never NameErrors on the no-floor path.
+            pos = {t: i for i, t in enumerate(target_names)}
+            caps_ser = (
+                pd.Series(_tiered_name_caps(scored, target_names), index=target_names)
+                if tier_name_caps and scored is not None
+                else pd.Series(float(name_cap), index=target_names)
+            )
+            elig_names = [
+                t for t in final.index if t in caps_ser.index and bool(elig_mask.get(t, False))
+            ]
+            if elig_names:
+                boosted = _distribute_to_headroom(
+                    final.reindex(elig_names),
+                    conv_all.reindex(elig_names),
+                    caps_ser.reindex(elig_names),
+                    gap,
+                )
+                trial = final.copy()
+                trial.loc[elig_names] = boosted
+                names_v = [t for t in trial.index if t in pos]
+                ix = [pos[t] for t in names_v]
+                covm = cov[np.ix_(ix, ix)]
+                base = final.reindex(names_v).to_numpy()
+                delta = trial.reindex(names_v).to_numpy() - base
+                if vol_ceiling is not None and portfolio_vol(base + delta, covm) > float(
+                    vol_ceiling
+                ):
+                    lo, hi = 0.0, 1.0
+                    for _ in range(40):  # bisection: largest step with vol <= ceiling
+                        mid = 0.5 * (lo + hi)
+                        if portfolio_vol(base + mid * delta, covm) <= float(vol_ceiling):
+                            lo = mid
+                        else:
+                            hi = mid
+                    delta = lo * delta
+                final = pd.Series(base + delta, index=names_v)
+                final = final[final > 1e-12]
+            deployed_after = float(final.sum())
+            redeploy_diag = {
+                "gap": gap,
+                "deployed_before": deployed,
+                "deployed_after": deployed_after,
+                "residual_cash": max(0.0, float(gross_target) - deployed_after),
+            }
+
     # Turnover = sum(|Δw|)/2 over the union of tickers (reported, not capped).
     idx = final.index.union(cur.index)
     turnover = 0.5 * float(
@@ -712,6 +775,7 @@ def build_overlay(
         "screened_out": screened_out,
         "gate": gate_diag,
         "core_floor_applied": core_floor_applied,
+        "redeploy": redeploy_diag,
     }
 
     if core_list is not None:

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -30,7 +30,7 @@ import pandas as pd
 
 from trade_modules.riskfirst.construct import portfolio_vol
 from trade_modules.riskfirst.covariance import single_factor_cov
-from trade_modules.riskfirst.fx import currency_of
+from trade_modules.riskfirst.fx import USD_BLOC, currency_of
 from trade_modules.riskfirst.prices import daily_returns, shrunk_cov
 from trade_modules.v3.combine import _TRAP_MAX_FWD_TTM, _fwd_loss_trap, _value_trap_gate
 from trade_modules.v3.construct import (
@@ -693,11 +693,15 @@ def build_overlay(
             # row/col. The core-floor block builds the same `pos`, but only when the floor
             # fires; recompute here so redeploy never NameErrors on the no-floor path.
             pos = {t: i for i, t in enumerate(target_names)}
-            caps_ser = (
+            # Per-name headroom on the ABSOLUTE ``cap * gross_target`` basis, matching the
+            # gate (risk_gate uses ``name_cap * g_target``). Passing the raw FRACTION as an
+            # absolute weight cap under-counted a name's true headroom at the target gross.
+            _name_cap_fracs = (
                 pd.Series(_tiered_name_caps(scored, target_names), index=target_names)
                 if tier_name_caps and scored is not None
                 else pd.Series(float(name_cap), index=target_names)
             )
+            caps_ser = _name_cap_fracs * float(gross_target)
             elig_names = [
                 t for t in final.index if t in caps_ser.index and bool(elig_mask.get(t, False))
             ]
@@ -715,6 +719,43 @@ def build_overlay(
                 covm = cov[np.ix_(ix, ix)]
                 base = final.reindex(names_v).to_numpy()
                 delta = trial.reindex(names_v).to_numpy() - base
+
+                # --- Sector + USD-bloc caps (closed-form scale, applied FIRST) ------- #
+                # These caps are ABSOLUTE fraction-of-gross thresholds (risk_gate: cap *
+                # gross). A bloc's exposure and the total gross are BOTH linear in the
+                # increment scale ``a``, so the max feasible ``a`` solving
+                #   e + a*d <= c*(g + a*gd)   (e,g = base bloc/total; d,gd = delta bloc/total)
+                # is closed-form: coef = d - c*gd; ``a <= (c*g - e)/coef`` when coef > 0,
+                # else the bloc share is non-increasing in ``a`` (no upper limit). Scaling
+                # the whole increment by the MIN such ``a`` over every distinct sector and
+                # the USD bloc keeps all of them within cap. delta stays >= 0 (never reduces
+                # a core-floored name), and scaling delta down only RELAXES the caps, so the
+                # later vol bisection can only keep the point cap-feasible.
+                g = float(base.sum())
+                gd = float(delta.sum())
+
+                def _cap_alpha(mask: np.ndarray, cap: float | None) -> float:
+                    if cap is None or not bool(mask.any()):
+                        return 1.0
+                    e = float(base[mask].sum())
+                    d = float(delta[mask].sum())
+                    coef = d - float(cap) * gd
+                    if coef > 1e-12:
+                        return max(0.0, (float(cap) * g - e) / coef)
+                    return 1.0  # bloc share non-increasing in ``a`` -> no upper limit
+
+                alpha_caps = 1.0
+                _sec_labels_v = _sector_labels(names_v, scored)
+                for _lab in set(_sec_labels_v):
+                    _m = np.array([s == _lab for s in _sec_labels_v], dtype=bool)
+                    alpha_caps = min(alpha_caps, _cap_alpha(_m, sector_cap))
+                _bloc_m = np.array([currency_of(t) in USD_BLOC for t in names_v], dtype=bool)
+                alpha_caps = min(alpha_caps, _cap_alpha(_bloc_m, usd_bloc_cap))
+                delta = min(1.0, max(0.0, alpha_caps)) * delta
+
+                # --- Vol ceiling (bisection on the ALREADY caps-scaled increment) --- #
+                # ``vol_ceiling is None`` is defensive-only: the gate rejects a None ceiling
+                # upstream (`None + tol` -> TypeError), so this branch is never taken live.
                 if vol_ceiling is not None and portfolio_vol(base + delta, covm) > float(
                     vol_ceiling
                 ):

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -620,7 +620,7 @@ def _exec_summary_line(meta: dict, portfolio, actions, conditioning) -> str:
         items.append(f"{_esc(regime.upper())} regime")
     if portfolio is not None:
         items.append(
-            f"{_pct0(portfolio.get('gross'))} deployed / {_pct0(portfolio.get('cash'))} cash"
+            f"{_pct0(portfolio.get('gross'))} deployed (incl. managed) / {_pct0(portfolio.get('cash'))} cash"
         )
     elif cond.get("final_deployment") is not None:
         items.append(f"{_pct0(cond.get('final_deployment'))} deployment")

--- a/trade_modules/v3/report.py
+++ b/trade_modules/v3/report.py
@@ -620,7 +620,9 @@ def _exec_summary_line(meta: dict, portfolio, actions, conditioning) -> str:
         items.append(f"{_esc(regime.upper())} regime")
     if portfolio is not None:
         items.append(
-            f"{_pct0(portfolio.get('gross'))} deployed (incl. managed) / {_pct0(portfolio.get('cash'))} cash"
+            f"{_pct0(portfolio.get('gross'))} deployed"
+            + (" (incl. managed)" if portfolio.get("managed_weight", 0) > 0 else "")
+            + f" / {_pct0(portfolio.get('cash'))} cash"
         )
     elif cond.get("final_deployment") is not None:
         items.append(f"{_pct0(cond.get('final_deployment'))} deployment")

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -779,7 +779,7 @@ def render_summary(
     regime = _esc(str(meta.get("regime", "")).upper())
     gen = _esc(meta.get("generated_utc", ""))
     date = _esc(meta.get("date", ""))
-    dep = _pct1(diag.get("gross_after"))
+    dep = _pct1((portfolio or {}).get("gross"))
     vol = _pct1(diag.get("vol_after"))
 
     head = (


### PR DESCRIPTION
## What
Makes total-book cash a **deliberate, regime-conditional target** the v3 overlay sizes to (~11% RISK_ON), instead of an under-absorption residual, and reports **true total invested**.

Spec: `docs/superpowers/specs/2026-07-24-cash-target-sizing-design.md` · Plan: `docs/superpowers/plans/2026-07-24-cash-target-sizing.md`

## Changes
1. **Regime targets** (`conditioning.py`): `DEPLOYMENT_BY_REGIME` → risk_off 0.80 / neutral 0.87 / risk_on 0.89 (cash 20/13/11%); band clamp (0.75, 0.92). Total-book targets (managed carve-out subtracted downstream).
2. **Redeploy-to-target** (`overlay.py`): new `_distribute_to_headroom` helper + post-gate redeploy that up-grosses toward `gross_target` within **name + sector + USD-bloc + vol** caps (closed-form cap scale + nested vol bisection); unplaceable remainder = honest reported `residual_cash`. The gate's de-gross path is untouched; the mega-cap core floor + value-trap gates are preserved.
3. **Reporting** (`report.py`, `report_email.py`, `v3_overlay_report.py`): browser + email headlines show TRUE total invested (model + managed sleeves) + cash, fixing the misleading model-only "76.6%" that read as ~23% cash when real cash is ~10%.

## Context
Corrects an earlier mis-read that cash was ~23% — the ~14% managed sleeve (GLD/UVXY/LYXGRE) carve-out was hidden from the headline; real cash is ~10%, and RISK_ON policy was an aggressive 98% invested. Net book impact: ~94% → deliberate ~89% invested (~$55K to cash vs live), now controlled not accidental.

## Tests
1207 v3 tests pass. New: regime values, `_distribute_to_headroom` (3), redeploy cap/vol enforcement (numerically verified sectors/USD land at cap, vol ≤ ceiling), reporting total. Reviewed task-by-task + whole-branch (opus): merge-ready, risk controls provably sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)