### PR TITLE
chore(v3): clean up cash-target follow-up minors

### DIFF
--- a/scripts/v3_overlay_report.py
+++ b/scripts/v3_overlay_report.py
@@ -307,9 +307,9 @@ def _print_console_summary(diag: dict, actions: list, gross_target: float) -> No
     )
     print(f"turnover: {diag['turnover']:.1%}  freed: {diag['freed_weight']:.1%}")
     print(
-        f"deployment: {gross_target:.0%}  vol: {vol_after:.1%}"
+        f"model deployment: {gross_target:.0%}  vol: {vol_after:.1%}"
         if vol_after is not None
-        else f"deployment: {gross_target:.0%}"
+        else f"model deployment: {gross_target:.0%}"
     )
     print(
         f"thresholds: sell<= {diag['sell_threshold']:.3f}  buy>= {diag['buy_threshold']:.3f}"

--- a/tests/unit/trade_modules/test_v3_report_email.py
+++ b/tests/unit/trade_modules/test_v3_report_email.py
@@ -162,6 +162,8 @@ def _actions() -> list:
 def _view() -> dict:
     return {
         "gross": 0.89,  # model (~0.75) + managed (~0.14) — true total invested
+        "cash": 0.11,  # 1 - gross
+        "managed_weight": 0.14,
         "diagnostics": {
             "gate": {
                 "gross_after": 0.84,
@@ -183,6 +185,7 @@ def test_render_summary_is_compact_and_outlook_safe():
     assert "RISK_ON" in html
     assert "buy" in html and "sell" in html
     assert "89" in html  # deployment portfolio["gross"] 0.89 -> 89.0% (model + managed)
+    assert "cash 11" in html  # explicit cash line: portfolio["cash"] 0.11 -> 11.0%
     # Action rows carry ticker + action.
     assert "AAA" in html and "BUY" in html
     assert "BBB" in html and "SELL" in html

--- a/trade_modules/v3/conditioning.py
+++ b/trade_modules/v3/conditioning.py
@@ -25,7 +25,7 @@ _UNKNOWN_DEPLOYMENT = DEPLOYMENT_BY_REGIME["neutral"]
 def regime_deployment(regime: str) -> float:
     """Return the base deployment fraction for a regime string.
 
-    Unknown / missing regime labels fall back to neutral (0.88).
+    Unknown / missing regime labels fall back to neutral (0.87).
 
     Args:
         regime: One of ``"risk_off"``, ``"neutral"``, ``"risk_on"``.

--- a/trade_modules/v3/overlay.py
+++ b/trade_modules/v3/overlay.py
@@ -342,7 +342,7 @@ def _fund_floor_weakest_first(
 
 
 def _distribute_to_headroom(
-    weights: pd.Series, conviction: pd.Series, caps: pd.Series, gap: float
+    weights: pd.Series, conviction: pd.Series, caps: pd.Series, gap: float | None
 ) -> pd.Series:
     """Distribute ``gap`` across ``weights``' names proportional to positive conviction,
     each bounded by its per-name cap headroom (``caps - weights``). Weight that spills

--- a/trade_modules/v3/report_email.py
+++ b/trade_modules/v3/report_email.py
@@ -780,6 +780,7 @@ def render_summary(
     gen = _esc(meta.get("generated_utc", ""))
     date = _esc(meta.get("date", ""))
     dep = _pct1((portfolio or {}).get("gross"))
+    cash = _pct1((portfolio or {}).get("cash"))
     vol = _pct1(diag.get("vol_after"))
 
     head = (
@@ -793,7 +794,7 @@ def render_summary(
         f'Regime <b style="color:{INK};">{regime}</b> &middot; '
         f'<b style="color:{BULL};">{c.get("BUY", 0)}</b> buy &middot; {keep} keep &middot; '
         f'<b style="color:{BEAR};">{c.get("SELL", 0)}</b> sell &middot; '
-        f'deployment <b style="color:{INK};">{dep}</b> &middot; vol {vol}</div>'
+        f'deployment <b style="color:{INK};">{dep}</b> &middot; cash {cash} &middot; vol {vol}</div>'
         f'<div style="font-family:{FONT};font-size:11px;color:{MUTED};margin-top:3px;">{gen}</div>'
     )
 


### PR DESCRIPTION
Non-blocking follow-ups from the cash-target PR #195 review: email-body cash line (browser parity), docstring 0.88→0.87, gap type hint, self-consistent test fixture, console 'model deployment' label. 84 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)