### PR TITLE
fix(analyst-momentum): correct sign/ordering — yfinance recommendations are newest-first

### DIFF
--- a/tests/unit/yahoofinance/api/providers/test_recommendations_parser_momentum.py
+++ b/tests/unit/yahoofinance/api/providers/test_recommendations_parser_momentum.py
@@ -1,0 +1,88 @@
+"""Regression tests for calculate_analyst_momentum row-ordering (2026-07-30).
+
+Bug: yfinance returns `.recommendations` NEWEST-FIRST (row 0 = current month '0m',
+last row = oldest '-3m'). The old code used `sort_index().iloc[-1]` as "latest",
+which is actually the OLDEST row — so it compared -3m vs -1m: sign-inverted AND the
+wrong window, never reading the true current month. Verified systematic across 10
+tickers (AAPL stored +7.1 vs true -5.0, Toyota -3.1 vs +8.4, etc.).
+
+Fix: select the '0m' and '-3m' rows by their `period` label so row order cannot
+invert the comparison.
+"""
+
+import pandas as pd
+import pytest
+
+from yahoofinance.api.providers.async_modules.recommendations_parser import (
+    calculate_analyst_momentum,
+)
+
+
+class _FakeTicker:
+    def __init__(self, rec, ticker="TEST"):
+        self.recommendations = rec
+        self.ticker = ticker
+
+
+def _rec(rows):
+    """Build a yfinance-style recommendations frame (a RangeIndex + 'period' column)."""
+    return pd.DataFrame(rows)
+
+
+# The real INVE-B.ST shape: buy% 20.0 (0m) vs 33.3 (-3m) -> analysts turned MORE bearish.
+_INVE_ROWS = [
+    {"period": "0m", "strongBuy": 0, "buy": 1, "hold": 3, "sell": 1, "strongSell": 0},  # 20.0%
+    {"period": "-1m", "strongBuy": 0, "buy": 1, "hold": 4, "sell": 1, "strongSell": 0},  # 16.7%
+    {"period": "-2m", "strongBuy": 0, "buy": 2, "hold": 3, "sell": 1, "strongSell": 0},  # 33.3%
+    {"period": "-3m", "strongBuy": 0, "buy": 2, "hold": 3, "sell": 1, "strongSell": 0},  # 33.3%
+]
+
+
+def test_momentum_is_current_minus_three_months_ago():
+    res = calculate_analyst_momentum(_FakeTicker(_rec(_INVE_ROWS)))
+    # 0m 20.0% - (-3m) 33.3% = -13.3 (bearish). The OLD bug returned +16.7 (bullish).
+    assert res["analyst_momentum"] == pytest.approx(-13.3, abs=0.1)
+    assert res["analyst_momentum"] < 0  # sign must reflect the real (bearish) trend
+
+
+def test_momentum_bullish_when_buy_share_rises():
+    rows = [
+        {"period": "0m", "strongBuy": 3, "buy": 3, "hold": 2, "sell": 0, "strongSell": 0},  # 75%
+        {"period": "-1m", "strongBuy": 2, "buy": 2, "hold": 4, "sell": 0, "strongSell": 0},
+        {"period": "-2m", "strongBuy": 1, "buy": 2, "hold": 5, "sell": 0, "strongSell": 0},
+        {"period": "-3m", "strongBuy": 0, "buy": 2, "hold": 6, "sell": 0, "strongSell": 0},  # 25%
+    ]
+    res = calculate_analyst_momentum(_FakeTicker(_rec(rows)))
+    assert res["analyst_momentum"] == pytest.approx(50.0, abs=0.1)  # 75 - 25
+
+
+def test_momentum_is_row_order_invariant():
+    """Selecting by 'period' label must give the same answer no matter the row order."""
+    forward = calculate_analyst_momentum(_FakeTicker(_rec(_INVE_ROWS)))
+    shuffled = _rec(list(reversed(_INVE_ROWS)))  # oldest-first
+    reverse = calculate_analyst_momentum(_FakeTicker(shuffled))
+    assert (
+        forward["analyst_momentum"] == reverse["analyst_momentum"] == pytest.approx(-13.3, abs=0.1)
+    )
+
+
+def test_momentum_falls_back_to_oldest_when_3m_missing():
+    rows = [
+        {"period": "0m", "strongBuy": 0, "buy": 1, "hold": 3, "sell": 0, "strongSell": 0},  # 25%
+        {"period": "-1m", "strongBuy": 0, "buy": 2, "hold": 2, "sell": 0, "strongSell": 0},
+        {
+            "period": "-2m",
+            "strongBuy": 0,
+            "buy": 3,
+            "hold": 1,
+            "sell": 0,
+            "strongSell": 0,
+        },  # 75% (oldest)
+    ]
+    res = calculate_analyst_momentum(_FakeTicker(_rec(rows)))
+    assert res["analyst_momentum"] == pytest.approx(-50.0, abs=0.1)  # 25 - 75 (oldest present)
+
+
+def test_momentum_none_with_insufficient_data():
+    res = calculate_analyst_momentum(_FakeTicker(_rec(_INVE_ROWS[:1])))
+    assert res["analyst_momentum"] is None

--- a/yahoofinance/api/providers/async_modules/recommendations_parser.py
+++ b/yahoofinance/api/providers/async_modules/recommendations_parser.py
@@ -199,14 +199,24 @@ def calculate_analyst_momentum(yticker) -> dict[str, Any]:
         if recommendations_df is None or len(recommendations_df) < 2:
             return result  # Need at least 2 months of data
 
-        # Sort by date and get rows
-        sorted_df = recommendations_df.sort_index()
+        # yfinance returns recommendations NEWEST-FIRST with a 'period' column
+        # ('0m' = current month, then '-1m','-2m','-3m') on a RangeIndex whose row 0 is the
+        # current month. The old code took ``sort_index().iloc[-1]`` as "latest" — but that is
+        # the OLDEST row (-3m), so it compared -3m vs -1m: sign-INVERTED and the wrong window,
+        # never even reading the true current month. Select by the 'period' LABEL (with a
+        # newest-first positional fallback) so row order can't fool the comparison.
+        df = recommendations_df
+        period_col = df["period"].astype(str) if "period" in df.columns else None
 
-        # Get latest and approximately 3 months ago (or earliest available)
-        latest = sorted_df.iloc[-1]
-        # Try to get 3 months ago, otherwise use earliest
-        past_idx = max(0, len(sorted_df) - 3)
-        past = sorted_df.iloc[past_idx]
+        def _row_for(label: str, fallback_pos: int):
+            if period_col is not None:
+                match = df[period_col == label]
+                if len(match):
+                    return match.iloc[0]
+            return df.iloc[fallback_pos]
+
+        latest = _row_for("0m", 0)  # current month (newest-first -> row 0)
+        past = _row_for("-3m", -1)  # ~3 months ago (fallback: oldest row present)
 
         # Calculate buy percentages
         def calc_buy_pct(row):


### PR DESCRIPTION
## Fix analyst-momentum sign/ordering bug

`calculate_analyst_momentum` used `sort_index().iloc[-1]` as "latest", but yfinance returns `.recommendations` **newest-first** (row 0 = current `0m`, last row = oldest `-3m`). So it took the **oldest** row as "current" and compared `-3m` vs `-1m` — **sign-inverted and the wrong window**, never even reading the true current month.

### Verified systematic (10 tickers, all newest-first)
| ticker | stored (buggy) | true | |
|---|---|---|---|
| AAPL | +7.1 | −5.0 | sign flip |
| MSFT | −0.2 | +0.1 | sign flip |
| SAP.DE | +0.5 | −0.5 | sign flip |
| ASML | −2.3 | +4.5 | sign flip |
| 7203.T (Toyota) | −3.1 | +8.4 | sign flip |
| TSM | +0.0 | +5.3 | misses signal |

### Impact on the scored book
Across the eligible ≥8-analyst names where AM is scored: **103 of 122 (84%) flip sign**; 292 names move conviction, ~15 by ±1.5. The analyst-momentum cluster (0.10 weight) has effectively been pointing the wrong way for the entire scored universe.

### Fix
Select the `0m` and `-3m` rows by their `period` **label** (with a newest-first positional fallback) so row order can't invert the comparison. Also fixes the count-trend, which had the same inversion.

5 regression tests: correct sign/window, bullish case, **row-order invariance**, `-3m`-missing fallback, insufficient-data guard. Includes the real INVE-B.ST shape (→ −13.3, not the buggy +16.7).

`yahoofinance/api/providers/async_modules/recommendations_parser.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
