### PR TITLE
feat(analyst): analyst_momentum = net buy-side analyst count change

### DIFF
--- a/tests/unit/yahoofinance/api/providers/test_recommendations_parser_momentum.py
+++ b/tests/unit/yahoofinance/api/providers/test_recommendations_parser_momentum.py
@@ -11,7 +11,6 @@ invert the comparison.
 """
 
 import pandas as pd
-import pytest
 
 from yahoofinance.api.providers.async_modules.recommendations_parser import (
     calculate_analyst_momentum,
@@ -38,22 +37,25 @@ _INVE_ROWS = [
 ]
 
 
-def test_momentum_is_current_minus_three_months_ago():
+def test_momentum_is_net_buy_side_analyst_count_change():
+    # analyst_momentum is now a signed COUNT: net change in buy-side analysts
+    # (strongBuy+buy) over 3 months. INVE-B.ST 0m buy=1 vs -3m buy=2 -> -1 (one net
+    # analyst dropped their buy). Bounded by coverage; no longer a percentage-point value.
     res = calculate_analyst_momentum(_FakeTicker(_rec(_INVE_ROWS)))
-    # 0m 20.0% - (-3m) 33.3% = -13.3 (bearish). The OLD bug returned +16.7 (bullish).
-    assert res["analyst_momentum"] == pytest.approx(-13.3, abs=0.1)
-    assert res["analyst_momentum"] < 0  # sign must reflect the real (bearish) trend
+    assert res["analyst_momentum"] == -1
+    assert isinstance(res["analyst_momentum"], int)
+    assert res["analyst_momentum"] < 0  # sign reflects the real (bearish) trend
 
 
-def test_momentum_bullish_when_buy_share_rises():
+def test_momentum_bullish_when_buy_side_count_rises():
     rows = [
-        {"period": "0m", "strongBuy": 3, "buy": 3, "hold": 2, "sell": 0, "strongSell": 0},  # 75%
+        {"period": "0m", "strongBuy": 3, "buy": 3, "hold": 2, "sell": 0, "strongSell": 0},  # buy=6
         {"period": "-1m", "strongBuy": 2, "buy": 2, "hold": 4, "sell": 0, "strongSell": 0},
         {"period": "-2m", "strongBuy": 1, "buy": 2, "hold": 5, "sell": 0, "strongSell": 0},
-        {"period": "-3m", "strongBuy": 0, "buy": 2, "hold": 6, "sell": 0, "strongSell": 0},  # 25%
+        {"period": "-3m", "strongBuy": 0, "buy": 2, "hold": 6, "sell": 0, "strongSell": 0},  # buy=2
     ]
     res = calculate_analyst_momentum(_FakeTicker(_rec(rows)))
-    assert res["analyst_momentum"] == pytest.approx(50.0, abs=0.1)  # 75 - 25
+    assert res["analyst_momentum"] == 4  # 6 - 2 net analysts turned buy-side
 
 
 def test_momentum_is_row_order_invariant():
@@ -61,14 +63,12 @@ def test_momentum_is_row_order_invariant():
     forward = calculate_analyst_momentum(_FakeTicker(_rec(_INVE_ROWS)))
     shuffled = _rec(list(reversed(_INVE_ROWS)))  # oldest-first
     reverse = calculate_analyst_momentum(_FakeTicker(shuffled))
-    assert (
-        forward["analyst_momentum"] == reverse["analyst_momentum"] == pytest.approx(-13.3, abs=0.1)
-    )
+    assert forward["analyst_momentum"] == reverse["analyst_momentum"] == -1
 
 
 def test_momentum_falls_back_to_oldest_when_3m_missing():
     rows = [
-        {"period": "0m", "strongBuy": 0, "buy": 1, "hold": 3, "sell": 0, "strongSell": 0},  # 25%
+        {"period": "0m", "strongBuy": 0, "buy": 1, "hold": 3, "sell": 0, "strongSell": 0},  # buy=1
         {"period": "-1m", "strongBuy": 0, "buy": 2, "hold": 2, "sell": 0, "strongSell": 0},
         {
             "period": "-2m",
@@ -77,10 +77,10 @@ def test_momentum_falls_back_to_oldest_when_3m_missing():
             "hold": 1,
             "sell": 0,
             "strongSell": 0,
-        },  # 75% (oldest)
+        },  # buy=3 (oldest)
     ]
     res = calculate_analyst_momentum(_FakeTicker(_rec(rows)))
-    assert res["analyst_momentum"] == pytest.approx(-50.0, abs=0.1)  # 25 - 75 (oldest present)
+    assert res["analyst_momentum"] == -2  # 1 - 3 (oldest present)
 
 
 def test_momentum_none_with_insufficient_data():

--- a/yahoofinance/api/providers/async_modules/recommendations_parser.py
+++ b/yahoofinance/api/providers/async_modules/recommendations_parser.py
@@ -198,7 +198,8 @@ def calculate_analyst_momentum(yticker) -> dict[str, Any]:
 
     Returns:
         Dictionary with:
-        - analyst_momentum: Change in buy% over 3 months (positive = upgrading)
+        - analyst_momentum: NET change in the buy-side analyst count (strongBuy+buy)
+          over ~3 months, as a signed integer (positive = analysts turning buy-side).
         - analyst_count_trend: "increasing", "stable", or "decreasing"
     """
     result: dict[str, Any] = {"analyst_momentum": None, "analyst_count_trend": None}
@@ -227,24 +228,22 @@ def calculate_analyst_momentum(yticker) -> dict[str, Any]:
         latest = _row_for("0m", 0)  # current month (newest-first -> row 0)
         past = _row_for("-3m", -1)  # ~3 months ago (fallback: oldest row present)
 
-        # Calculate buy percentages
-        def calc_buy_pct(row):
-            total = (
-                row.get("strongBuy", 0)
-                + row.get("buy", 0)
-                + row.get("hold", 0)
-                + row.get("sell", 0)
-                + row.get("strongSell", 0)
+        # analyst_momentum = NET change in the number of buy-side analysts (strongBuy+buy)
+        # over ~3 months, as a signed integer (owner 2026-07-30). A COUNT of analysts who
+        # moved to/from a buy rating — bounded by coverage and directly interpretable —
+        # replaces the old buy-% percentage-point change, which was coarse/lumpy on thin
+        # coverage (~20pp per analyst over 5-6 analysts) and read nonsensically next to the
+        # analyst count (a "-13" beside 5 analysts). Requires coverage in BOTH periods.
+        def _tot(row):
+            return sum(
+                (row.get(k, 0) or 0) for k in ("strongBuy", "buy", "hold", "sell", "strongSell")
             )
-            if total == 0:
-                return None
-            return ((row.get("strongBuy", 0) + row.get("buy", 0)) / total) * 100
 
-        current_pct = calc_buy_pct(latest)
-        past_pct = calc_buy_pct(past)
+        def _buy(row):
+            return (row.get("strongBuy", 0) or 0) + (row.get("buy", 0) or 0)
 
-        if current_pct is not None and past_pct is not None:
-            result["analyst_momentum"] = round(current_pct - past_pct, 1)
+        if _tot(latest) > 0 and _tot(past) > 0:
+            result["analyst_momentum"] = int(_buy(latest) - _buy(past))
 
         # Calculate count trend
         current_count = sum(


### PR DESCRIPTION
Redefine analyst_momentum from 3-month buy-% change (pp) to the NET change in buy-side analyst count — interpretable, bounded by coverage (fixes '-13 vs 5 analysts'). Feeds analyst_mom_z; earn-in (analyst history corrupted by just-fixed parse bugs). 7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)