### PR TITLE
feat(data): emit raw yfinance .info snapshot as a build byproduct

### DIFF
--- a/yahoofinance/api/providers/async_yahoo_finance.py
+++ b/yahoofinance/api/providers/async_yahoo_finance.py
@@ -236,6 +236,17 @@ class AsyncYahooFinanceProvider(AsyncFinanceDataProvider):
                 )
                 ticker_info = {}
 
+            # Byproduct (non-fatal): record the raw .info fields the plessas-trading-stack
+            # info store needs, so this single .info sweep feeds BOTH etoro.csv and the
+            # stack's info snapshot — no second .info fetch downstream. Fully guarded: this
+            # must never affect the etoro.csv build.
+            try:
+                from ...data.info_snapshot import record as _record_info_snapshot
+
+                _record_info_snapshot(ticker, ticker_info)
+            except Exception:  # noqa: BLE001
+                pass
+
             info: dict[str, Any] = {"symbol": ticker, "ticker": ticker}
 
             # Extract key fields

--- a/yahoofinance/data/info_snapshot.py
+++ b/yahoofinance/data/info_snapshot.py
@@ -1,0 +1,89 @@
+"""Raw yfinance ``.info`` snapshot — a byproduct of the nightly market build.
+
+The etoro.csv build already fetches ``yticker.info`` once per ticker for the whole
+universe. A downstream consumer (the plessas-trading-stack overlay) needs a handful of
+those raw fields (P/B, trailing P/S, operating margin, ROA, targets, sector, …) that the
+etoro.csv columns don't carry. Rather than re-fetch ``.info`` a second time there, this
+module records those fields as each ticker is fetched and dumps them to a parquet at
+process exit — so the SAME single ``.info`` sweep feeds both etoro.csv and the stack's
+info store.
+
+Design guarantees (this must NEVER affect the etoro.csv build):
+  * ``record`` is a pure in-memory dict write wrapped by the caller in try/except.
+  * the dump is registered via ``atexit`` (runs after etoro.csv is written) and is itself
+    fully guarded — any failure is swallowed.
+  * the consumer treats the snapshot as best-effort: a missing/stale snapshot just means
+    it re-fetches, so nothing breaks if this module no-ops.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+from typing import Any
+
+import pandas as pd
+
+# The yfinance ``.info`` keys the stack's info store consumes (kept in sync with
+# pts_signals.v3.features._INFO_NUM / _INFO_STR). Projecting to these keeps the snapshot
+# small (a raw .info is 100+ fields) and is the contract between the two repos.
+INFO_SNAPSHOT_KEYS: tuple[str, ...] = (
+    "priceToBook",
+    "enterpriseToEbitda",
+    "returnOnAssets",
+    "grossMargins",
+    "operatingMargins",
+    "currentRatio",
+    "targetHighPrice",
+    "targetLowPrice",
+    "averageVolume",
+    "revenueGrowth",
+    "priceToSalesTrailing12Months",
+    "sector",
+    "industry",
+    "country",
+    "quoteType",
+    "longBusinessSummary",
+)
+
+# Default output path: alongside etoro.csv so the stack reads it like it reads etoro.csv.
+SNAPSHOT_PATH: str = os.environ.get(
+    "ETORO_INFO_SNAPSHOT",
+    os.path.join(os.path.dirname(__file__), "..", "output", "etoro_info_snapshot.parquet"),
+)
+
+_ACCUM: dict[str, dict[str, Any]] = {}
+_DUMP_REGISTERED = False
+
+
+def record(ticker: str, raw_info: dict[str, Any] | None) -> None:
+    """Accumulate the snapshot fields for one ticker from its raw ``.info`` dict.
+
+    Non-fatal by contract — the caller wraps this in try/except, and the first call
+    registers the atexit dump. A None/empty ``raw_info`` is ignored.
+    """
+    global _DUMP_REGISTERED
+    if not raw_info:
+        return
+    proj = {k: raw_info.get(k) for k in INFO_SNAPSHOT_KEYS if raw_info.get(k) is not None}
+    if proj:
+        _ACCUM[str(ticker)] = proj
+    if not _DUMP_REGISTERED:
+        atexit.register(dump)
+        _DUMP_REGISTERED = True
+
+
+def dump(path: str | None = None) -> int:
+    """Write the accumulated snapshot to a tidy parquet (one row per ticker). Returns the
+    number of tickers written; 0 (and no file) when nothing was recorded. Never raises."""
+    if not _ACCUM:
+        return 0
+    try:
+        rows = [{"ticker": t, **fields} for t, fields in _ACCUM.items()]
+        df = pd.DataFrame(rows)
+        out = os.path.abspath(path or SNAPSHOT_PATH)
+        os.makedirs(os.path.dirname(out), exist_ok=True)
+        df.to_parquet(out, index=False)
+        return len(df)
+    except Exception:  # noqa: BLE001 - best-effort byproduct; must never break the build
+        return 0


### PR DESCRIPTION
The nightly build already fetches `yticker.info` once per ticker for the whole universe. This records the handful of raw `.info` fields a downstream consumer (plessas-trading-stack overlay) needs — P/B, trailing P/S, operating margin, ROA, targets, sector, … — as each ticker is fetched, and dumps them to `yahoofinance/output/etoro_info_snapshot.parquet` at process exit. So the **same single `.info` sweep feeds both etoro.csv and the snapshot** (no second `.info` fetch downstream).

**Safe by construction — cannot affect the etoro.csv build:**
- the `record()` hook after `ticker_info = yticker.info` is wrapped in try/except;
- the dump runs via `atexit` (after etoro.csv is written) and swallows any error;
- the consumer treats the snapshot as best-effort — a missing/stale file just means it re-fetches.

New isolated module `yahoofinance/data/info_snapshot.py` + one guarded hook in `async_yahoo_finance.py`. 193 provider/normalizer tests pass; round-trip verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)