### PR TITLE
feat(ci): publish merged .info snapshot as a workflow artifact (Step 2 delivery)

### DIFF
--- a/.github/workflows/daily-signals.yml
+++ b/.github/workflows/daily-signals.yml
@@ -57,6 +57,12 @@ jobs:
           python trade.py -o e
           mv yahoofinance/output/etoro.csv "etoro_shard_${SHARD_INDEX}.csv"
           echo "Shard ${SHARD_INDEX} complete: $(wc -l < etoro_shard_${SHARD_INDEX}.csv) lines"
+          # Byproduct: the .info snapshot the build emitted for this shard's tickers
+          # (dumped at process exit by yahoofinance/data/info_snapshot.py). Non-fatal.
+          mv yahoofinance/output/etoro_info_snapshot.parquet \
+            "info_snapshot_shard_${SHARD_INDEX}.parquet" 2>/dev/null \
+            && echo "Snapshot shard ${SHARD_INDEX} emitted" \
+            || echo "No .info snapshot for shard ${SHARD_INDEX} (ok — consumer falls back)"
 
       - name: Upload shard output
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -65,6 +71,14 @@ jobs:
           path: etoro_shard_${{ matrix.shard }}.csv
           retention-days: 1
           if-no-files-found: error
+
+      - name: Upload shard .info snapshot (byproduct — non-fatal)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: etoro-info-shard-${{ matrix.shard }}
+          path: info_snapshot_shard_${{ matrix.shard }}.parquet
+          retention-days: 1
+          if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
   # Stage 2 — merge shard slices into etoro.csv, refresh portfolio, derive
@@ -109,6 +123,33 @@ jobs:
           echo "Merging shard slices..."
           python scripts/merge_shards.py --shard-dir shards --output yahoofinance/output/etoro.csv
           echo "Merge complete: $(wc -l < yahoofinance/output/etoro.csv) lines"
+
+      # --- .info snapshot (byproduct): merge the per-shard snapshots into one artifact
+      # the plessas-trading-stack VPS pulls via `gh run download`, so the single .info
+      # sweep here feeds the stack's info store too (no second .info fetch on the VPS).
+      # Entirely non-fatal — a missing/failed snapshot never blocks the signals build.
+      - name: Download shard .info snapshots
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: etoro-info-shard-*
+          path: info-shards
+          merge-multiple: true
+
+      - name: Merge .info snapshots
+        continue-on-error: true
+        run: |
+          python -c "from yahoofinance.data.info_snapshot import merge_snapshots as m; \
+            print('merged snapshot tickers:', m('info-shards', 'yahoofinance/output/etoro_info_snapshot.parquet'))"
+
+      - name: Upload merged .info snapshot (byproduct — non-fatal)
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: etoro-info-snapshot
+          path: yahoofinance/output/etoro_info_snapshot.parquet
+          retention-days: 2
+          if-no-files-found: warn
 
       - name: Download fresh portfolio from eToro
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        args: [--strict, -d, '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}']
+        args: [--strict, -d, '{extends: default, rules: {line-length: {max: 120}, document-start: disable, truthy: {check-keys: false}, comments: {min-spaces-from-content: 1}, comments-indentation: disable}}']
         files: \.github/workflows/.*\.ya?ml$
 
   # Markdown linting

--- a/tests/yahoofinance/data/test_info_snapshot.py
+++ b/tests/yahoofinance/data/test_info_snapshot.py
@@ -1,0 +1,39 @@
+"""Tests for the raw yfinance .info snapshot byproduct (record → dump → merge shards)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from yahoofinance.data import info_snapshot as S
+
+
+def test_record_projects_and_dump_roundtrips(tmp_path):
+    S._ACCUM.clear()
+    S.record("AAA", {"priceToBook": 2.5, "operatingMargins": 0.3, "junkField": 999})
+    S.record("BBB", {"priceToBook": 1.1})
+    S.record("CCC", None)  # ignored
+    out = str(tmp_path / "snap.parquet")
+    n = S.dump(out)
+    assert n == 2
+    df = pd.read_parquet(out)
+    assert "junkField" not in df.columns  # projected to the snapshot keys only
+    aaa = df[df.ticker == "AAA"].iloc[0].dropna().to_dict()
+    assert aaa["priceToBook"] == 2.5 and aaa["operatingMargins"] == 0.3
+
+
+def test_merge_snapshots_dedupes_shards(tmp_path):
+    pd.DataFrame(
+        [{"ticker": "AAA", "priceToBook": 2.5}, {"ticker": "BBB", "priceToBook": 1.0}]
+    ).to_parquet(tmp_path / "info_snapshot_shard_0.parquet", index=False)
+    pd.DataFrame(
+        [{"ticker": "CCC", "priceToBook": 3.0}, {"ticker": "AAA", "priceToBook": 9.9}]
+    ).to_parquet(tmp_path / "info_snapshot_shard_1.parquet", index=False)
+    out = str(tmp_path / "merged.parquet")
+    n = S.merge_snapshots(str(tmp_path), output=out)
+    assert n == 3  # AAA, BBB, CCC
+    df = pd.read_parquet(out).set_index("ticker")
+    assert df.loc["AAA", "priceToBook"] == 9.9  # newest shard wins on dedupe
+
+
+def test_merge_snapshots_no_files_is_noop(tmp_path):
+    assert S.merge_snapshots(str(tmp_path), output=str(tmp_path / "x.parquet")) == 0

--- a/yahoofinance/data/info_snapshot.py
+++ b/yahoofinance/data/info_snapshot.py
@@ -73,6 +73,38 @@ def record(ticker: str, raw_info: dict[str, Any] | None) -> None:
         _DUMP_REGISTERED = True
 
 
+def merge_snapshots(
+    snapshot_dir: str,
+    output: str | None = None,
+    pattern: str = "info_snapshot_shard_*.parquet",
+) -> int:
+    """Merge per-shard snapshot parquets (the CI market scan is sharded) into one file.
+
+    Concatenate every ``info_snapshot_shard_*.parquet`` under ``snapshot_dir`` and dedupe
+    on ticker (newest wins). Returns the merged ticker count; 0 (no file written) when no
+    shard snapshots are found. Never raises.
+    """
+    import glob
+
+    try:
+        paths = sorted(glob.glob(os.path.join(snapshot_dir, pattern)))
+        frames = []
+        for p in paths:
+            try:
+                frames.append(pd.read_parquet(p))
+            except Exception:  # noqa: BLE001 - skip a corrupt shard, keep the rest
+                continue
+        if not frames:
+            return 0
+        df = pd.concat(frames, ignore_index=True).drop_duplicates(subset=["ticker"], keep="last")
+        out = os.path.abspath(output or SNAPSHOT_PATH)
+        os.makedirs(os.path.dirname(out), exist_ok=True)
+        df.to_parquet(out, index=False)
+        return len(df)
+    except Exception:  # noqa: BLE001 - best-effort; a merge failure just means no snapshot
+        return 0
+
+
 def dump(path: str | None = None) -> int:
     """Write the accumulated snapshot to a tidy parquet (one row per ticker). Returns the
     number of tickers written; 0 (and no file) when nothing was recorded. Never raises."""


### PR DESCRIPTION
Step 2 delivery — owner chose the **artifact route** (no git bloat). The sharded market scan already fetches `.info` once per ticker; this ships those fields to the plessas-trading-stack VPS as a workflow artifact.

- Each shard emits its `.info` snapshot (byproduct of the existing sweep) → uploads `etoro-info-shard-*`.
- The merge stage combines them (`info_snapshot.merge_snapshots`, dedupe on ticker) → uploads one **`etoro-info-snapshot`** artifact.
- The VPS `refresh-market.sh` pulls it via `gh run download`; market-ingest reads it → **no second `.info` fetch on the VPS**.
- Every snapshot step is `continue-on-error` / non-fatal — it never blocks the etoro.csv build or commit; the consumer falls back to a live fetch if the artifact is absent.
- `.pre-commit-config.yaml`: GitHub-Actions-friendly yamllint (`truthy` check-keys off for `on:`, 1-space inline comments) so the workflow file lints under `--strict`.

TDD: `tests/yahoofinance/data/test_info_snapshot.py` (record/dump/merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)