### PR TITLE
fix(tickers): complete eToro original-market resolution for held dual-listings

### DIFF
--- a/tests/core/config/test_ticker_mappings.py
+++ b/tests/core/config/test_ticker_mappings.py
@@ -141,11 +141,11 @@ class TestTickerNormalization:
             ("NOVO-B.CO", "NVO"),
             ("novo-b.co", "NVO"),  # Case insensitive
             ("SAN.PA", "SNY"),
-            ("9618.HK", "JD.US"),  # Based on actual reverse mapping
+            ("9618.HK", "JD"),  # JD/JD.US both map to 9618.HK; reverse prefers dot-less JD
             ("9988.HK", "BABA"),
             ("GOOG", "GOOGL"),  # Based on actual reverse mapping
             ("ASML.NV", "ASML"),
-            ("SHEL.L", "RDS.B"),  # Based on actual reverse mapping (last one wins)
+            ("SHEL.L", "SHEL"),  # SHEL/RDS.A/RDS.B all map to SHEL.L; reverse prefers live SHEL
         ]
 
         for input_ticker, expected_us in test_cases:
@@ -411,8 +411,11 @@ class TestIntegration:
             display = get_display_ticker(ticker)
             fetch = get_data_fetch_ticker(ticker)
 
-            # For now, all should return the same normalized ticker
-            assert normalized == display == fetch
+            # Display is the eToro / home-exchange form and must equal the normalized ticker.
+            # The data-fetch symbol MAY differ by design (e.g. ASML -> display ASML.NV but
+            # fetch ASML.AS, since Yahoo 404s on the .NV form).
+            assert normalized == display
+            assert fetch  # resolves to a non-empty Yahoo symbol
 
     def test_equivalence_symmetry(self):
         """Test that ticker equivalence is symmetric."""

--- a/tests/unit/trade_modules/test_dual_listing_resolution.py
+++ b/tests/unit/trade_modules/test_dual_listing_resolution.py
@@ -1,0 +1,74 @@
+"""Dual-listing / eToro original-market ticker resolution.
+
+Regression tests for the bug where held dual-listed holdings resolved to the
+wrong market: Roche (ROP.ZU) / Novartis (NOVN.ZU) / Investor AB (INVEB.ST) came
+back as dead '--' rows because their eToro suffix was never mapped to a Yahoo
+symbol, and cross-listed US tickers leaked the eToro *display* form (ASML.NV)
+into the *data-fetch* path.
+
+Contract:
+  * display ticker  = the eToro original-market symbol, verbatim
+  * data-fetch ticker = a live Yahoo Finance symbol (may differ from display)
+  * the two must stay consistent with scripts/refresh_etoro_universe._SUFFIX_REMAP
+"""
+
+from yahoofinance.utils import ticker_mappings as tm
+
+
+class TestDataFetchForHeldSwissAndNordicListings:
+    """eToro Swiss (.ZU) and Nordic (.ST share-class) holdings must fetch live."""
+
+    def test_roche_zu_fetches_via_swiss_suffix(self):
+        # eToro ROP.ZU = Roche; Yahoo carries it under .SW (same .ZU->.SW rule the
+        # universe build already uses: refresh_etoro_universe NESN.ZU -> NESN.SW).
+        assert tm.get_data_fetch_ticker("ROP.ZU") == "ROP.SW"
+
+    def test_novartis_zu_fetches_via_swiss_suffix(self):
+        assert tm.get_data_fetch_ticker("NOVN.ZU") == "NOVN.SW"
+
+    def test_investor_ab_stockholm_gets_share_class_hyphen(self):
+        # eToro INVEB.ST = Investor AB ser. B; Yahoo symbol is INVE-B.ST.
+        assert tm.get_data_fetch_ticker("INVEB.ST") == "INVE-B.ST"
+
+
+class TestCrossListedFetchDoesNotLeakDisplayForm:
+    """A US/ADR base must never resolve to the eToro .NV display form for fetching."""
+
+    def test_bare_asml_resolves_to_live_yahoo_symbol(self):
+        # Bug: get_data_fetch_ticker('ASML') returned 'ASML.NV' (dead on Yahoo).
+        assert tm.get_data_fetch_ticker("ASML") == "ASML.AS"
+
+    def test_asml_nv_fetches_amsterdam(self):
+        assert tm.get_data_fetch_ticker("ASML.NV") == "ASML.AS"
+
+
+class TestDisplayIsEtoroOriginalMarket:
+    """Display must be the eToro original-market ticker, unchanged."""
+
+    def test_roche_display_stays_zu(self):
+        assert tm.get_display_ticker("ROP.ZU") == "ROP.ZU"
+
+    def test_newmont_display_stays_bare(self):
+        assert tm.get_display_ticker("NEM") == "NEM"
+
+
+class TestReverseMappingIsCollisionFree:
+    """Many US tickers map to one home listing; the reverse must pick the live US ticker."""
+
+    def test_shell_reverse_is_shel_not_dead_rds_class(self):
+        # dual_listed_mappings has SHEL, RDS.A, RDS.B all -> SHEL.L; naive dict
+        # inversion collapsed SHEL.L -> RDS.B (a dead ticker).
+        assert tm.get_us_ticker("SHEL.L") == "SHEL"
+
+    def test_jd_reverse_is_jd_not_jd_us(self):
+        assert tm.get_us_ticker("9618.HK") == "JD"
+
+
+class TestGeographyForEuropeanSuffixes:
+    """Swiss/Nordic suffixes are European, not US, for risk multipliers."""
+
+    def test_swiss_zu_is_europe(self):
+        assert tm.get_ticker_geography("ROP.ZU") == "EU"
+
+    def test_stockholm_st_is_europe(self):
+        assert tm.get_ticker_geography("INVEB.ST") == "EU"

--- a/trade_modules/config_manager.py
+++ b/trade_modules/config_manager.py
@@ -15,7 +15,19 @@ from .yaml_config_loader import YamlConfigLoader
 # eToro/Bloomberg exchange suffix -> Yahoo Finance suffix, applied in get_data_fetch_ticker
 # (Yahoo 404s on the eToro form; verified via live probes). .DH (Gulf) is intentionally
 # absent — Yahoo uses numeric codes there, so it needs per-name data_fetch_substitutions.
-_YAHOO_SUFFIX_MAP = {"NV": "AS", "IM": "MI", "LN": "L", "CH": "SW"}
+# NOTE: keep in sync with scripts/refresh_etoro_universe._SUFFIX_REMAP (the universe-build
+# normalizer). The two diverging is what left held Swiss (.ZU) lines fetching dead: eToro
+# uses .ZU for its CBOE-EU Swiss book (Roche ROP.ZU, Novartis NOVN.ZU), which Yahoo carries
+# under .SW.
+_YAHOO_SUFFIX_MAP = {
+    "NV": "AS",
+    "IM": "MI",
+    "LN": "L",
+    "CH": "SW",
+    "ZU": "SW",
+    "ASX": "AX",
+    "LSB": "LS",
+}
 # Currency / price-unit lines eToro appends (e.g. MSFT.EUR, KSP.L.GBX) -> stripped before fetch.
 _CURRENCY_SUFFIXES = {"EUR", "USD", "GBP", "GBX"}
 # US class-share letters -> Yahoo dash form (BRK.B -> BRK-B).
@@ -214,6 +226,9 @@ class ConfigManager:
             # KAP.IL both return ~507 bars vs 5 for .L).
             "SMSN.L": "SMSN.IL",  # Samsung Electronics GDR (USD) — London IOB has full history
             "KAP.L": "KAP.IL",  # Kazatomprom GDR (USD) — London IOB has full history
+            # Nordic share-class lines: eToro base is un-hyphenated (INVEB), Yahoo hyphenates
+            # the class letter (INVE-B.ST). A pure stem change, so a suffix rule can't express it.
+            "INVEB.ST": "INVE-B.ST",  # Investor AB ser. B
         }
 
         # US Ticker -> Original Exchange Ticker mappings
@@ -253,8 +268,15 @@ class ConfigManager:
             (".AS", ".NV"),  # Euronext Amsterdam: Yahoo Finance uses .AS, eToro uses .NV
         ]
 
-        # Reverse mapping: Original Exchange Ticker -> US Ticker
-        self.reverse_mappings = {v: k for k, v in self.dual_listed_mappings.items()}
+        # Reverse mapping: Original Exchange Ticker -> US Ticker.
+        # Several US tickers can map to one home listing (SHEL, RDS.A, RDS.B -> SHEL.L;
+        # JD, JD.US -> 9618.HK). A naive dict inversion keeps the LAST one (a dead RDS.B /
+        # JD.US), so prefer the dot-less US ticker (SHEL over RDS.A, JD over JD.US).
+        self.reverse_mappings = {}
+        for _us, _home in self.dual_listed_mappings.items():
+            _cur = self.reverse_mappings.get(_home)
+            if _cur is None or ("." in _cur and "." not in _us):
+                self.reverse_mappings[_home] = _us
 
         # Set of all tickers that have dual listings (for quick lookup)
         self.dual_listed_tickers = set(self.dual_listed_mappings.keys()) | set(
@@ -443,12 +465,13 @@ class ConfigManager:
                 if suf in _CLASS_SHARE_LETTERS and "." not in stem:
                     return stem + "-" + suf
 
-        # For data fetching, we might want to use US tickers when available
-        # as they often have better data coverage, but we'll normalize the results
+        # Normalize to the canonical (home-exchange) form. That form may itself carry an
+        # eToro display suffix that Yahoo 404s on (ASML -> ASML.NV), so re-resolve it once
+        # through this same function to reach a live Yahoo symbol (ASML -> ASML.NV -> ASML.AS).
+        # get_normalized_ticker is idempotent on home tickers, so this recurses at most once.
         normalized = self.get_normalized_ticker(ticker)
-
-        # For now, prefer the normalized ticker, but this can be customized
-        # based on data quality preferences per ticker
+        if normalized and normalized != tu:
+            return self.get_data_fetch_ticker(normalized)
         return normalized
 
     def get_ticker_geography(self, ticker: str) -> str:
@@ -475,7 +498,26 @@ class ConfigManager:
             return "HK"
         elif normalized_ticker.endswith(".L"):
             return "UK"
-        elif normalized_ticker.endswith((".PA", ".DE", ".NV", ".MI", ".BR")):
+        elif normalized_ticker.endswith(
+            # Continental Europe + Nordics + Switzerland (eToro .ZU / Yahoo .SW).
+            (
+                ".PA",
+                ".DE",
+                ".NV",
+                ".AS",
+                ".MI",
+                ".BR",
+                ".MC",
+                ".LS",
+                ".VI",
+                ".SW",
+                ".ZU",
+                ".ST",
+                ".OL",
+                ".CO",
+                ".HE",
+            )
+        ):
             return "EU"
         elif normalized_ticker.endswith(".T"):
             return "JP"


### PR DESCRIPTION
## Problem

Held dual-listed / non-US holdings resolved to the wrong market. Two failure modes:

1. **Dead data.** eToro's Swiss book uses the `.ZU` suffix (Roche `ROP.ZU`, Novartis `NOVN.ZU`) and Nordic share classes drop the hyphen (`INVEB.ST`). `config_manager.get_data_fetch_ticker` had no `.ZU` mapping and no `INVEB.ST` substitution, so these fetched dead (`--`) rows on Yahoo. The universe-build normalizer (`scripts/refresh_etoro_universe._SUFFIX_REMAP`) already had `.ZU -> .SW`; the two normalizers diverging was the root cause.
2. **Display form leaking into the fetch path.** `get_data_fetch_ticker("ASML")` returned the eToro display form `ASML.NV` (which Yahoo 404s) instead of a live symbol.
3. **Reverse-mapping collision.** `SHEL`, `RDS.A`, `RDS.B` all map to `SHEL.L`; `JD` and `JD.US` both map to `9618.HK`. Naive dict inversion left `get_us_ticker("SHEL.L") == "RDS.B"` (a dead ticker) and `get_us_ticker("9618.HK") == "JD.US"`.
4. **Geography.** Swiss/Nordic suffixes classified as `US`, applying the wrong geographic risk multiplier.

## Fix

Contract kept clean: **display = eToro original-market symbol; data-fetch = a live Yahoo symbol** (they may differ).

- `_YAHOO_SUFFIX_MAP` now covers `.ZU -> .SW`, `.ASX -> .AX`, `.LSB -> .LS`, aligned with `refresh_etoro_universe._SUFFIX_REMAP` (with a sync note on both).
- `data_fetch_substitutions` adds `INVEB.ST -> INVE-B.ST`.
- `get_data_fetch_ticker` re-resolves the normalized home-exchange form once, so `ASML -> ASML.NV -> ASML.AS`.
- `reverse_mappings` built collision-free (prefer the dot-less US ticker): `SHEL.L -> SHEL`, `9618.HK -> JD`.
- `get_ticker_geography` treats continental-EU + Nordic + Swiss suffixes as `EU`.

## Tests

- New regression suite `tests/unit/trade_modules/test_dual_listing_resolution.py` (11 cases).
- Two existing tests updated: they pinned the *buggy* reverse-mapping (`SHEL.L -> RDS.B`) and the `display == fetch` invariant that this fix intentionally breaks.
- `95 passed` across the ticker / config / dedup suites; ruff clean.

## Verified fetch mapping for held names

`ROP.ZU -> ROP.SW` (Roche), `NOVN.ZU -> NOVN.SW` (Novartis), `INVEB.ST -> INVE-B.ST` (Investor AB), `ASML.NV -> ASML.AS`, `SBMO.NV -> SBMO.AS`; display unchanged (`ROP.ZU`, `NEM`, `ASML.NV`).

## Follow-ups (not in this PR)

- **plessas-trading** display + conviction-join changes (separate PR): keep dead-price holdings in the committee instead of silently dropping them, and join committee conviction onto holdings by a collision-safe key so every holding shows a conviction.
- Consolidate `data_manager.DUPLICATE_TICKERS` / `_EQUIVALENT_SUFFIXES` into this one resolver (two dedup tables still exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
