### PR TITLE
ci(relock): reconcile poetry.lock when Dependabot edits the exports

### DIFF
--- a/.github/workflows/dependabot-relock.yml
+++ b/.github/workflows/dependabot-relock.yml
@@ -1,16 +1,23 @@
 name: Dependabot Auto-Relock
 
-# Dependabot bumps pyproject.toml + poetry.lock but never runs
-# scripts/dev/relock.sh, so the committed requirements-*-lock.txt exports go
-# stale and the CI `lockfile sync` job fails on every Python-dependency PR.
-# This job regenerates the exports and pushes them back to the PR branch,
-# clearing the failure with no human intervention.
+# Dependabot never runs scripts/dev/relock.sh, so the committed
+# requirements-*-lock.txt exports and poetry.lock drift apart on every
+# Python-dependency PR and the CI `lockfile sync` job fails. This job
+# reconciles them and pushes the result back to the PR branch, clearing the
+# failure with no human intervention. Two shapes of PR reach it:
+#   - Dependabot bumped pyproject.toml/poetry.lock: re-export is enough.
+#   - Dependabot rewrote the requirements-*-lock.txt exports in place (it parses
+#     them as pip manifests, which is what it does for every transitive bump):
+#     adopt_export_pins.py first pulls those pins into poetry.lock, otherwise a
+#     plain re-export would silently revert the bump.
 #
 # SECURITY (why this is not a "fork code execution" risk):
-#   - It checks out the TRUSTED base repo (no PR head ref), so the relock script
-#     that runs is always the base version — never PR-controlled code.
-#   - Only the PR's *data* manifests (pyproject.toml, poetry.lock) are pulled in,
-#     and only `poetry export` reads them (metadata only; no package code runs).
+#   - It checks out the TRUSTED base repo (no PR head ref), so the scripts that
+#     run are always the base version — never PR-controlled code.
+#   - Only the PR's *data* files (pyproject.toml, poetry.lock and the committed
+#     requirements exports) are pulled in. Poetry reads them as metadata and
+#     adopt_export_pins.py only matches package names against poetry.lock
+#     in-process; nothing from the PR reaches a shell.
 #   - Gated to Dependabot-authored PRs.
 #   - The PR branch name reaches shell only via a quoted env var (no injection).
 # pull_request_target + PUSH_PAT are required so the push re-triggers CI
@@ -22,6 +29,9 @@ name: Dependabot Auto-Relock
     paths:
       - 'pyproject.toml'
       - 'poetry.lock'
+      - 'requirements-lock.txt'
+      - 'requirements-dev-lock.txt'
+      - 'requirements-smoketest-lock.txt'
 
 permissions:
   contents: write
@@ -58,30 +68,37 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          # Pull ONLY the PR's dependency manifests (data, not code) onto the
-          # trusted base checkout, then run the trusted base relock script.
+          # Pull ONLY the PR's dependency files (data, not code) onto the
+          # trusted base checkout, then run the trusted base scripts.
           git fetch --no-tags origin "$HEAD_REF"
-          git checkout FETCH_HEAD -- pyproject.toml poetry.lock
+          git checkout FETCH_HEAD -- pyproject.toml poetry.lock \
+            requirements-lock.txt requirements-dev-lock.txt requirements-smoketest-lock.txt
+          # No-op when Dependabot moved poetry.lock itself.
+          python3 scripts/dev/adopt_export_pins.py
           bash scripts/dev/relock.sh --export-only
           mkdir -p "$RUNNER_TEMP/relock"
-          cp requirements-lock.txt requirements-dev-lock.txt requirements-smoketest-lock.txt "$RUNNER_TEMP/relock/"
+          cp poetry.lock requirements-lock.txt requirements-dev-lock.txt \
+            requirements-smoketest-lock.txt "$RUNNER_TEMP/relock/"
 
-      - name: Commit + push regenerated exports to the PR branch (if drifted)
+      - name: Commit + push the reconciled lockfiles to the PR branch (if drifted)
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
+          LOCKFILES="poetry.lock requirements-lock.txt requirements-dev-lock.txt requirements-smoketest-lock.txt"
           git fetch --no-tags origin "$HEAD_REF"
           git checkout -f -B relock_head FETCH_HEAD
-          cp "$RUNNER_TEMP/relock/requirements-lock.txt" requirements-lock.txt
-          cp "$RUNNER_TEMP/relock/requirements-dev-lock.txt" requirements-dev-lock.txt
-          cp "$RUNNER_TEMP/relock/requirements-smoketest-lock.txt" requirements-smoketest-lock.txt
-          if git diff --quiet -- requirements-lock.txt requirements-dev-lock.txt requirements-smoketest-lock.txt; then
-            echo "Committed requirements exports already match poetry.lock — nothing to do."
+          for f in $LOCKFILES; do
+            cp "$RUNNER_TEMP/relock/$f" "$f"
+          done
+          # shellcheck disable=SC2086
+          if git diff --quiet -- $LOCKFILES; then
+            echo "poetry.lock and the committed exports already agree — nothing to do."
             exit 0
           fi
           git config user.name "dependabot-relock[bot]"
           git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
-          git add requirements-lock.txt requirements-dev-lock.txt requirements-smoketest-lock.txt
-          git commit -m "build: relock requirements exports for Dependabot bump"
+          # shellcheck disable=SC2086
+          git add $LOCKFILES
+          git commit -m "build: reconcile poetry.lock and requirements exports for Dependabot bump"
           git push origin "HEAD:$HEAD_REF"

--- a/scripts/dev/adopt_export_pins.py
+++ b/scripts/dev/adopt_export_pins.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Pull version pins that only exist in the committed exports back into poetry.lock.
+
+Dependabot treats requirements-lock.txt / requirements-dev-lock.txt /
+requirements-smoketest-lock.txt as pip manifests, so it rewrites the pins in
+those files directly and never touches poetry.lock. Re-exporting from an
+untouched poetry.lock would simply undo the bump, and the CI `lockfile sync`
+job fails either way.
+
+This script closes that gap. For every package whose export pin disagrees with
+poetry.lock, it drops that package's `[[package]]` block from poetry.lock and
+re-runs `poetry lock`, which re-resolves exactly those packages to the newest
+version the rest of the constraint set allows. Packages held back by an
+upstream pin (e.g. safety pinning safety-schemas==0.0.16) resolve back to where
+they were, which is the correct answer, not a failure.
+
+Run from the repository root, then run `scripts/dev/relock.sh --export-only`.
+Exits 0 and does nothing when poetry.lock already agrees with the exports.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+LOCK_PATH = Path("poetry.lock")
+EXPORT_PATHS = (
+    Path("requirements-lock.txt"),
+    Path("requirements-dev-lock.txt"),
+    Path("requirements-smoketest-lock.txt"),
+)
+
+# `packaging==26.3 ; python_version >= "3.10" ...` at the start of a line.
+PIN_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s;\\]+)")
+BLOCK_SPLIT_RE = re.compile(r"(?m)^(?=\[\[package\]\])")
+BLOCK_NAME_RE = re.compile(r'\[\[package\]\]\nname = "([^"]+)"')
+BLOCK_VERSION_RE = re.compile(r'(?m)^version = "([^"]+)"')
+
+
+def normalize(name: str) -> str:
+    """PEP 503 name normalisation, so `types_setuptools` == `types-setuptools`."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def locked_versions(lock_text: str) -> dict[str, str]:
+    versions = {}
+    for block in BLOCK_SPLIT_RE.split(lock_text):
+        name_match = BLOCK_NAME_RE.match(block)
+        version_match = BLOCK_VERSION_RE.search(block)
+        if name_match and version_match:
+            versions[normalize(name_match.group(1))] = version_match.group(1)
+    return versions
+
+
+def exported_pins() -> dict[str, str]:
+    pins = {}
+    for path in EXPORT_PATHS:
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            match = PIN_RE.match(line)
+            if match:
+                pins[normalize(match.group(1))] = match.group(2)
+    return pins
+
+
+def drop_blocks(lock_text: str, names: set[str]) -> str:
+    kept = []
+    for block in BLOCK_SPLIT_RE.split(lock_text):
+        name_match = BLOCK_NAME_RE.match(block)
+        if name_match and normalize(name_match.group(1)) in names:
+            continue
+        kept.append(block)
+    return "".join(kept)
+
+
+def main() -> int:
+    if not LOCK_PATH.exists():
+        print("ERROR: poetry.lock not found; run from the repository root.", file=sys.stderr)
+        return 2
+
+    lock_text = LOCK_PATH.read_text()
+    locked = locked_versions(lock_text)
+    stale = {
+        name: (locked[name], pin)
+        for name, pin in exported_pins().items()
+        if name in locked and locked[name] != pin
+    }
+
+    if not stale:
+        print("poetry.lock already agrees with the committed exports; nothing to adopt.")
+        return 0
+
+    for name, (lock_version, export_version) in sorted(stale.items()):
+        print(f"adopting {name}: poetry.lock {lock_version} -> export asks {export_version}")
+
+    LOCK_PATH.write_text(drop_blocks(lock_text, set(stale)))
+    subprocess.run(["poetry", "lock", "--no-interaction"], check=True)
+
+    resolved = locked_versions(LOCK_PATH.read_text())
+    for name, (_, export_version) in sorted(stale.items()):
+        got = resolved.get(name, "MISSING")
+        note = "" if got == export_version else f"  (not {export_version}; other constraints won)"
+        print(f"resolved {name}: {got}{note}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The recurring failure

Dependabot parses the committed `requirements-*-lock.txt` files as pip manifests and rewrites the pins in them directly. For a transitive bump that is the **only** thing it changes: `pyproject.toml` and `poetry.lock` stay untouched. Every pip PR this month hit the same wall:

- The `relock` workflow never fired. It only triggered on `paths: [pyproject.toml, poetry.lock]`, so it reported `skipping` on #216, #217, #218.
- The CI `lockfile sync` job re-exported from the stale `poetry.lock`, found the committed exports ahead of it, and failed.

I unblocked #218, #220 and #221 by hand. This makes it stop happening.

## Why the obvious fix is wrong

Just widening the `paths:` filter makes things worse, not better: `relock.sh --export-only` re-exports from the untouched `poetry.lock`, which **silently reverts** Dependabot's bump and leaves a green PR that upgrades nothing.

## What this does

`scripts/dev/adopt_export_pins.py` runs first. It finds every package whose export pin disagrees with `poetry.lock`, drops those `[[package]]` blocks, and re-runs `poetry lock`, so exactly those packages re-resolve to the newest version the rest of the constraint set allows. Everything else stays pinned.

A package another dependency holds down resolves back to where it was, which is the correct answer, not a failure:

- `safety==3.8.1` declares `safety-schemas==0.0.16` and `typer<0.26.0`
- `pydantic==2.13.4` (newest stable) declares `pydantic-core==2.46.4`

Either way `poetry.lock` and the three exports end up agreeing, which is all `lockfile sync` asks. The pushed commit now carries `poetry.lock` too, not just the exports.

## Verification

Replayed Dependabot's own commit `ba7c0418` (the raw head of #221, before any of my edits) in a clean worktree:

```
adopting packaging: poetry.lock 26.2 -> export asks 26.3
adopting platformdirs: poetry.lock 4.11.0 -> export asks 4.11.1
adopting pydantic-core: poetry.lock 2.46.4 -> export asks 2.48.0
adopting pydantic-settings: poetry.lock 2.14.2 -> export asks 2.15.0
adopting soupsieve: poetry.lock 2.9.1 -> export asks 2.9.2
resolved packaging: 26.3
resolved platformdirs: 4.11.2  (not 4.11.1; other constraints won)
resolved pydantic-core: 2.46.4  (not 2.48.0; other constraints won)
resolved pydantic-settings: 2.15.0
resolved soupsieve: 2.9.2
```

then `relock.sh --export-only` + `poetry check --lock` clean and all three exports in sync. Running it on an already-consistent tree prints `nothing to adopt` and exits 0 without touching anything.

## Security

Unchanged posture. The job still checks out the trusted base (never the PR head), so the scripts that run are always the base version. The PR contributes only data files; `adopt_export_pins.py` matches package names against `poetry.lock` in-process and never passes them to a shell. Still gated to `dependabot[bot]`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>