### PR TITLE
fix(tickers): .CH is a China ADR, not Zurich — plus a guard so the next one is not silent

### DIFF
--- a/scripts/refresh_etoro_universe.py
+++ b/scripts/refresh_etoro_universe.py
@@ -11,6 +11,7 @@ import csv
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -28,15 +29,40 @@ ETF_TYPE_ID = 6
 MIN_INSTRUMENTS_THRESHOLD = 1000
 
 EXCHANGE_NAMES: dict[int, str] = {
-    2: "NYSE", 4: "Nasdaq", 5: "NYSE", 6: "FRA", 7: "LSE", 8: "NYSE",
-    9: "Euronext Paris", 10: "Bolsa De Madrid", 11: "Borsa Italiana",
-    12: "SIX", 14: "Oslo Stock Exchange", 15: "Stockholm Stock Exchange",
-    16: "Copenhagen Stock Exchange", 17: "Helsinki Stock Exchange",
-    19: "OTC Markets", 20: "CBOE", 21: "HKEX", 22: "Euronext Lisbon",
-    23: "Euronext Brussels", 24: "Tadawul", 30: "Euronext Amsterdam",
-    31: "ASX", 32: "Vienna", 33: "Xetra", 34: "Dublin", 35: "Prague SE",
-    36: "Warsaw", 37: "Budapest", 38: "Xetra ETFs", 39: "DFM",
-    41: "Abu Dhabi", 42: "LSE AIM", 43: "LSE AIM", 44: "LSE",
+    2: "NYSE",
+    4: "Nasdaq",
+    5: "NYSE",
+    6: "FRA",
+    7: "LSE",
+    8: "NYSE",
+    9: "Euronext Paris",
+    10: "Bolsa De Madrid",
+    11: "Borsa Italiana",
+    12: "SIX",
+    14: "Oslo Stock Exchange",
+    15: "Stockholm Stock Exchange",
+    16: "Copenhagen Stock Exchange",
+    17: "Helsinki Stock Exchange",
+    19: "OTC Markets",
+    20: "CBOE",
+    21: "HKEX",
+    22: "Euronext Lisbon",
+    23: "Euronext Brussels",
+    24: "Tadawul",
+    30: "Euronext Amsterdam",
+    31: "ASX",
+    32: "Vienna",
+    33: "Xetra",
+    34: "Dublin",
+    35: "Prague SE",
+    36: "Warsaw",
+    37: "Budapest",
+    38: "Xetra ETFs",
+    39: "DFM",
+    41: "Abu Dhabi",
+    42: "LSE AIM",
+    43: "LSE AIM",
+    44: "LSE",
     56: "Tokyo Stock Exchange",
 }
 
@@ -62,12 +88,40 @@ def is_etorian_alias(item: dict) -> bool:
 
 _HK_PAD_WIDTH = 4
 
+# eToro's spelling of a VENUE -> Yahoo's spelling of the same venue.
+# .IM and .LN are Bloomberg-style codes that trade_modules/config_manager.py has always
+# remapped at FETCH time while this generator did not, so the universe carried the eToro
+# spelling and only the resolver knew better. Measured 2026-08-11 (1-month bars):
+#   28IA.IM 0 / 28IA.MI 22 · ITBL.IM 0 / ITBL.MI 2 · SHLD.LN 0 / SHLD.L 22 · CSX5.LN 0 / CSX5.L 22
 _SUFFIX_REMAP = {
     ".ASX": ".AX",
     ".ZU": ".SW",
     ".NV": ".AS",
     ".LSB": ".LS",
+    ".IM": ".MI",
+    ".LN": ".L",
 }
+
+# Markers for a WRAPPER over a US listing rather than a venue: the bare ticker IS the listing.
+# .CH is eToro's Chinese-ADR marker on NYSE/Nasdaq (TCOM Trip.com, ATHM Autohome, QIHU, JMEI,
+# CYOU, QUNR, GSOL) — NOT Switzerland, which eToro spells .ZU and Yahoo spells .SW, both handled
+# above. Without a rule here these seven reached etoro.csv still suffixed, and ConfigManager's
+# table then turned them into Swiss symbols that do not exist.
+_STRIP_SUFFIXES = (".US", ".CH")
+
+# Currency / quote-unit lines eToro appends. Not a venue and not a separate security. Mirrors
+# _CURRENCY_SUFFIXES in trade_modules/config_manager.py, which strips the same four at fetch time.
+#
+# WHETHER TO STRIP OR DROP DEPENDS ON THE SHAPE, and the live file shows both, cleanly split:
+#   KSP.L.GBX  -> the stem KSP.L is still venue-qualified and NO bare KSP.L row exists, so
+#                 stripping RECOVERS a London listing. All 3 .GBX rows are this shape.
+#   AAPL.EUR   -> the stem AAPL carries no venue, the row's exchange is FRA, and a Nasdaq AAPL
+#                 row already exists. All 10 .EUR rows are this shape: stripping would collide
+#                 with the real row and dedupe could keep the one labelled FRA.
+# Hence: strip when the stem is still venue-qualified, drop when it is not. That rule is derived
+# from the shape rather than from today's suffix census, so a future .USD/.GBP row is handled
+# correctly without another audit.
+_CURRENCY_SUFFIXES = (".EUR", ".USD", ".GBP", ".GBX")
 
 _DROP_SUFFIXES = frozenset(
     {
@@ -87,28 +141,265 @@ _DROP_SUFFIXES = frozenset(
         ".RIGHT",
         ".WS",
         ".PFD",
+        # eToro duplicate-listing artifacts for Xetra/Euronext funds: CEBP.DE11, IQQ6.D11,
+        # ICGB.DE22. No Yahoo counterpart exists under either the digit form or the plain
+        # venue form, and all 15 rows have never returned a single price bar.
+        ".DE11",
+        ".D11",
+        ".DE22",
+        # corporate-action lifecycle markers
+        ".ACQUIRED",
+        ".DELETE",
+        # pre-IPO product (SpaceX.IPO) — an eToro instrument, not a listed security
+        ".IPO",
     }
 )
 
+#: Venue strings that mean "a US listing", so a bare symbol on one of them is correct under the
+#: owner's rule. Matched case-insensitively as substrings because two producers spell them
+#: differently: this script's EXCHANGE_NAMES yields "CBOE" while eToro's own catalogue says
+#: "Chicago Board Options Exchange".
+_US_VENUE_TOKENS = ("NYSE", "NASDAQ", "OTC", "CBOE", "CHICAGO BOARD OPTIONS")
+
+# Suffixes that are ALREADY valid and must pass through untouched. Membership here means
+# "a human has ruled on this suffix" — that is the whole point of the list. Anything absent
+# from every ruling set raises a warning instead of sailing through, which is precisely how
+# `.CH` sat mis-mapped for months: nothing in the pipeline could tell "known-good" from
+# "never looked at".
+#
+# Two entries are deliberate exceptions to "valid Yahoo symbol", recorded so nobody reopens them:
+#   .DH  Abu Dhabi. Yahoo indexes the Gulf under numeric codes, so all 33 rows are unfetchable
+#        under this spelling. Kept ON PURPOSE — the fix is per-name substitutions, not a suffix
+#        rule, and dropping the venue would lose the identities as well as the prices.
+#   .A/.B/.C  US class shares. eToro and SHARADAR both key on the DOT form (BF.A, BRK.B) while
+#        Yahoo wants the dash form; the fetch resolvers already convert, so the universe keeps
+#        the upstream identity and must not be "corrected" here.
+_ALLOWED_PASSTHROUGH = frozenset(
+    {
+        ".L",
+        ".DE",
+        ".PA",
+        ".AX",
+        ".ST",
+        ".OL",
+        ".HK",
+        ".T",
+        ".MI",
+        ".HE",
+        ".AS",
+        ".CO",
+        ".BR",
+        ".SW",
+        ".MC",
+        ".VI",
+        ".LS",
+        ".WA",
+        ".BD",
+        ".IR",
+        ".PR",
+        ".AE",
+        ".DH",
+        ".A",
+        ".B",
+        ".C",
+    }
+)
+
+# Stems that mark a placeholder no matter what follows them.
+_JUNK_STEMS = ("CVR", "WRTS", "DORMANT", "DRM")
+
 
 def _is_junk_suffix(suffix: str) -> bool:
-    """True if the suffix is a known junk/placeholder (CVR, DUP, or long numeric ID)."""
-    if suffix in _DROP_SUFFIXES:
+    """True if the SUFFIX alone marks a junk/placeholder instrument."""
+    s = suffix.lstrip(".").upper()
+    if f".{s}" in _DROP_SUFFIXES:
         return True
-    s = suffix.lstrip(".")
     if s.startswith(("CVR", "DUP", "ETF", "STOCK")):
         return True
-    if s.isdigit() and len(s) > 3:
+    # ANY purely numeric suffix. No exchange on earth spells itself with digits, so the old
+    # `len(s) > 3` guard bought nothing and let WRTS.APRN.15 / .18 / .20 through.
+    if s.isdigit():
         return True
     return False
 
 
-def normalize_symbol(symbol: str) -> str | None:
+def is_junk_symbol(symbol: str, company: str = "") -> bool:
+    """True if the WHOLE symbol is a placeholder, independent of its suffix.
+
+    ``_is_junk_suffix`` reads only the text after the LAST dot, which is why it caught
+    ``US.CVR1`` and missed ``CVR.THS`` — same marker, other side of the dot. It also misses
+    every space-delimited placeholder (``LSE CVR``, ``MTN DUMMY CVR``, ``CEPU ESCROW ASSET``)
+    because those contain no dot at all.
+    """
+    s = (symbol or "").upper().strip()
+    if not s:
+        return True
+    stem = s.split(".")[0]
+    if stem in _JUNK_STEMS or stem.startswith(("DORMANT", "DRM")):
+        return True
+    # CVR / escrow / merger / option placeholders. eToro writes these with spaces, and a space
+    # can never appear in a real ticker, but see bloomberg_shape() before widening this to
+    # "any space" — four rows with a space are real securities in Bloomberg notation.
+    if " " in s and re.search(r"\b(CVR\d*|ESCROW|DUMMY|LOCKED)\b", s):
+        return True
+    if " " in s and re.search(r"\b[CP]\d+$", s):  # option line, e.g. "ETOR 4 C40"
+        return True
+    # Lifecycle markers, in the four spellings eToro actually uses: SNDK_OLD, BMPS-OLD,
+    # MRK.DE_OLD and "STJ.L OLD" (a space). \bOLD$ cannot match GOLD — no word boundary there.
+    if re.search(r"(_OLD|\bOLD)$", s):
+        return True
+    # eToro corporate-action / pre-listing placeholders, where the row's only NAME is its own
+    # internal code: CA141.L named "CA141", IPO56.L named "IPO56", CA.OPS31.L named "CA.Ops31".
+    #
+    # THE company==code CONJUNCTION IS LOAD-BEARING, twice over. A bare ^CA\d+ symbol rule also
+    # deletes CA21 (Royal Dutch Shell), CA8 (Meredith Holdings), CA12908 (Everfuel A/S),
+    # CA13026 (Believe SA) and four more real companies — measured, 63 junk rows with the
+    # conjunction against 71 without. And a bare ^IPO\d* rule would delete IPO.L, which is
+    # IP Group PLC. Only the row whose name IS its code is a placeholder.
+    code = company.strip().upper().replace(" ", "")
+    if code and re.match(r"^(CA\d+|CA\.OPS\d+|IPO\d+)$", code):
+        # the symbol must be that same code, optionally venue-qualified (IPO56 / IPO56.L)
+        without_venue = s.rsplit(".", 1)[0] if "." in s else s
+        if code in (s, without_venue):
+            return True
+    return False
+
+
+#: An unknown suffix on this many symbols FAILS the refresh instead of warning. A genuine new
+#: venue arrives in bulk — .ASX was 244 rows, .DE11 13, .LSB 8, .CH 7 — while stray one-off junk
+#: is 1-2 rows. Three is the smallest number that separates them, and failing is deliberate:
+#: main() returns 1 before writing, the workflow's commit step is skipped, and the universe
+#: holds at its last good state until a human rules on the suffix.
+_UNKNOWN_SUFFIX_FAIL_THRESHOLD = 3
+
+
+def audit_symbols(rows: list[dict]) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Find eToro symbols that NO rule has ruled on. The guard this module was missing.
+
+    Every suffix is meant to be in exactly one of four sets — ``_SUFFIX_REMAP`` (venue spelling),
+    ``_STRIP_SUFFIXES`` / ``_CURRENCY_SUFFIXES`` (a wrapper over a listing), ``_DROP_SUFFIXES``
+    plus the junk predicates (not a security), or ``_ALLOWED_PASSTHROUGH`` (already valid).
+    A suffix in none of them used to be returned unchanged and written to the universe in
+    silence. That is how ``.CH`` — eToro's China-ADR marker — spent months being rewritten into
+    Swiss symbols that do not exist: nothing in the pipeline could distinguish "we decided this
+    is fine" from "we have never looked at this".
+
+    Returns ``(unknown, review)``:
+      * ``unknown`` maps an unruled suffix to example symbols. Escalates to a hard failure at
+        ``_UNKNOWN_SUFFIX_FAIL_THRESHOLD``.
+      * ``review`` maps a KNOWN-but-unresolved shape to example symbols. Always warns, never
+        fails — these are pre-existing backlog, and a guard that is red on day one is a guard
+        nobody reads.
+    """
+    unknown: dict[str, list[str]] = {}
+    review: dict[str, list[str]] = {}
+
+    def _add(bucket: dict[str, list[str]], key: str, sym: str) -> None:
+        bucket.setdefault(key, []).append(sym)
+
+    for row in rows:
+        sym = (row.get("symbol") or "").upper().strip()
+        company = row.get("company") or ""
+        exchange = (row.get("exchange") or "").strip()
+        if not sym or is_junk_symbol(sym, company):
+            continue
+        if bloomberg_shape(sym):
+            _add(review, "bloomberg TICKER-CC form (needs a per-venue remap)", sym)
+            continue
+        if " " in sym:
+            _add(review, "space in symbol (never fetchable as spelled)", sym)
+            continue
+        if "." not in sym:
+            # A bare symbol is a US listing under the owner's rule. When eToro says otherwise,
+            # the row carries a non-US venue with no suffix to key on, and passthrough quietly
+            # aims a US ticker at a foreign company. Reported, not guessed at: the fix is a
+            # per-row remap keyed on the exchange COLUMN and it must be hand-reviewed.
+            if exchange and not any(v in exchange.upper() for v in _US_VENUE_TOKENS):
+                _add(review, f"bare symbol on a non-US venue ({exchange})", sym)
+            continue
+        suffix = f".{sym.rsplit('.', 1)[1]}"
+        if (
+            suffix in _SUFFIX_REMAP
+            or suffix in _STRIP_SUFFIXES
+            or suffix in _CURRENCY_SUFFIXES
+            or suffix in _ALLOWED_PASSTHROUGH
+            or _is_junk_suffix(suffix)
+        ):
+            continue
+        _add(unknown, suffix, sym)
+
+    return unknown, review
+
+
+def report_audit(unknown: dict[str, list[str]], review: dict[str, list[str]]) -> bool:
+    """Log the audit. Returns True when the refresh must ABORT rather than write."""
+    for shape, syms in sorted(review.items(), key=lambda kv: -len(kv[1])):
+        logger.warning(
+            "REVIEW — %d symbol(s) %s: %s%s",
+            len(syms),
+            shape,
+            ", ".join(sorted(syms)[:5]),
+            " ..." if len(syms) > 5 else "",
+        )
+    if not unknown:
+        logger.info("Suffix audit clean: every suffix is ruled on.")
+        return False
+    worst = 0
+    for suffix, syms in sorted(unknown.items(), key=lambda kv: -len(kv[1])):
+        worst = max(worst, len(syms))
+        logger.error(
+            "UNRULED SUFFIX %s on %d symbol(s): %s%s",
+            suffix,
+            len(syms),
+            ", ".join(sorted(syms)[:5]),
+            " ..." if len(syms) > 5 else "",
+        )
+    if worst < _UNKNOWN_SUFFIX_FAIL_THRESHOLD:
+        logger.warning(
+            "Unruled suffixes are below the failure threshold (%d < %d); continuing.",
+            worst,
+            _UNKNOWN_SUFFIX_FAIL_THRESHOLD,
+        )
+        return False
+    logger.error(
+        "ABORTING: an unruled suffix appears on >= %d symbols, which is what a NEW EXCHANGE "
+        "looks like. Rule on it in scripts/refresh_etoro_universe.py — add it to _SUFFIX_REMAP "
+        "(eToro's spelling of a venue Yahoo spells differently), _STRIP_SUFFIXES (a wrapper "
+        "over a listing), _DROP_SUFFIXES (not a security), or _ALLOWED_PASSTHROUGH (already a "
+        "valid symbol) — then re-run. The universe is left at its last good state.",
+        _UNKNOWN_SUFFIX_FAIL_THRESHOLD,
+    )
+    return True
+
+
+def bloomberg_shape(symbol: str) -> bool:
+    """True for ``SRT3 GY`` / ``HAWK US`` — a real security in Bloomberg's ``TICKER CC`` form.
+
+    Deliberately NOT junk and deliberately NOT resolved: the correct answer is a per-venue
+    remap (`` GY`` -> ``.DE``), which is a reviewed per-row decision, not a suffix rule. They
+    are reported by :func:`audit_symbols` so they stay visible instead of being silently
+    dropped alongside the CVR placeholders they superficially resemble.
+    """
+    parts = (symbol or "").upper().strip().split()
+    return len(parts) == 2 and len(parts[1]) == 2 and parts[1].isalpha()
+
+
+def normalize_symbol(symbol: str, company: str = "") -> str | None:
     """Normalize eToro symbol to Yahoo Finance format.
 
     Returns None for symbols that should be skipped (RTH variants, junk instruments).
     """
     upper = symbol.upper().strip()
+
+    if is_junk_symbol(upper, company):
+        return None
+
+    # A doubled dot is eToro writing an LSE TIDM that ends in a period: YU..L is Yu Group,
+    # RE..L is R.E.A. Holdings — both live, both 22 bars under the collapsed spelling, and
+    # neither collides with an existing row. Collapse it; NEVER strip it to the bare stem,
+    # because FA..L -> FA and IX..L -> IX would merge into unrelated US tickers.
+    while ".." in upper:
+        upper = upper.replace("..", ".")
 
     if "." in upper:
         base, dot_suffix = upper.rsplit(".", 1)
@@ -118,16 +409,42 @@ def normalize_symbol(symbol: str) -> str | None:
         if full_suffix in _SUFFIX_REMAP:
             upper = base + _SUFFIX_REMAP[full_suffix]
 
-    if upper.endswith(".US"):
-        upper = upper[:-3]
+    # A currency line on a BARE stem is a duplicate of a row that already exists (AAPL.EUR on
+    # FRA against the Nasdaq AAPL). Drop it rather than strip it into a collision.
+    for cur_suffix in _CURRENCY_SUFFIXES:
+        if upper.endswith(cur_suffix) and "." not in upper[: -len(cur_suffix)]:
+            return None
+
+    # Strip wrapper and currency markers, repeatedly: KSP.L.GBX -> KSP.L, BRK.B.US -> BRK.B.
+    # Bounded so a pathological symbol cannot spin.
+    for _ in range(4):
+        for strip_suffix in _STRIP_SUFFIXES + _CURRENCY_SUFFIXES:
+            if upper.endswith(strip_suffix) and len(upper) > len(strip_suffix):
+                upper = upper[: -len(strip_suffix)]
+                break
+        else:
+            break
+
     if upper.endswith(".HK"):
         base = upper[:-3]
-        if base.isdigit() and len(base) > _HK_PAD_WIDTH:
+        # Pad BOTH ways. The old guard was `len(base) > _HK_PAD_WIDTH`, so it only ever
+        # shortened 5-digit codes and left 1-3 digit ones alone — 5.HK and 66.HK stayed
+        # unpadded and 404. zfill never truncates, so genuine long codes are untouched.
+        if base.isdigit():
             upper = base.lstrip("0").zfill(_HK_PAD_WIDTH) + ".HK"
     return upper
 
 
-_SCANDI_SUFFIXES = frozenset({".ST", ".CO", ".HE", ".OL"})
+# Venues where Yahoo HYPHENATES a share-class letter. Stockholm and Copenhagen do; Helsinki and
+# Oslo DO NOT, and having them here was a live bug — measured against Yahoo on 2026-08-11,
+# 1-month bar counts:
+#     KESKOA.HE 21 / KESKO-A.HE 0        METSA.HE 21 / METS-A.HE 0
+#     ODFB.OL   21 / ODF-B.OL   0        ASSA-B.ST 21 / ASSAB.ST  0   <- control, hyphen correct
+# The generator was writing KESKO-A.HE, KESKO-B.HE, METS-A.HE and METS-B.HE into etoro.csv, so
+# Kesko A/B and Metsa Board A/B were in the universe as ACTIVE and could never return a price.
+# Oslo never fired in practice (no symmetric XA/XB pair present) but was armed: VENDB.OL is
+# already in the file, and the day eToro adds VENDA.OL both would be hyphenated into nothing.
+_SCANDI_SUFFIXES = frozenset({".ST", ".CO"})
 _SHARE_CLASS_KEYWORDS = ("ser.", "series", "class", "klass", "aktie")
 
 
@@ -257,12 +574,14 @@ def fetch_all_instruments(
                 ]
                 items = []
                 for i in filtered:
-                    items.append({
-                        "instrumentId": i.get("instrumentID"),
-                        "symbol": i.get("symbolFull", ""),
-                        "displayName": i.get("instrumentDisplayName", ""),
-                        "exchangeName": EXCHANGE_NAMES.get(i.get("exchangeID", 0), ""),
-                    })
+                    items.append(
+                        {
+                            "instrumentId": i.get("instrumentID"),
+                            "symbol": i.get("symbolFull", ""),
+                            "displayName": i.get("instrumentDisplayName", ""),
+                            "exchangeName": EXCHANGE_NAMES.get(i.get("exchangeID", 0), ""),
+                        }
+                    )
                 logger.info(
                     "  Fetched %d total, %d Stocks+ETFs after type filter",
                     len(raw),
@@ -362,6 +681,25 @@ def main(
         )
         return 1
 
+    # AUDIT BEFORE NORMALISING. Runs on the RAW eToro symbols, because the question is "did
+    # eToro send us something no rule has ruled on" — after normalisation an unruled suffix is
+    # indistinguishable from a deliberate passthrough, which is exactly the blindness that let
+    # .CH survive. Aborts before anything is written, so a new venue leaves the universe at its
+    # last good state rather than half-ruled.
+    unknown, review = audit_symbols(
+        [
+            {
+                "symbol": (i.get("symbol") or "").strip(),
+                "company": i.get("displayName", ""),
+                "exchange": i.get("exchangeName", ""),
+            }
+            for i in items
+            if not is_etorian_alias(i)
+        ]
+    )
+    if report_audit(unknown, review):
+        return 1
+
     # Filter ETORIAN aliases + empty symbols + normalize (.US, .RTH, HK 5→4 digit)
     rows: list[dict] = []
     skipped_no_symbol = 0
@@ -375,7 +713,7 @@ def main(
         if not raw_symbol:
             skipped_no_symbol += 1
             continue
-        normalized = normalize_symbol(raw_symbol)
+        normalized = normalize_symbol(raw_symbol, item.get("displayName", ""))
         if normalized is None:
             skipped_rth += 1
             continue

--- a/tests/core/config/test_ticker_mappings.py
+++ b/tests/core/config/test_ticker_mappings.py
@@ -321,7 +321,10 @@ class TestDisplayAndDataFetch:
             ("SBMO.NV", "SBMO.AS"),  # Euronext Amsterdam (eToro .NV -> Yahoo .AS)
             ("28IA.IM", "28IA.MI"),  # Milan (Bloomberg .IM -> Yahoo .MI)
             ("SHLD.LN", "SHLD.L"),  # London (Bloomberg .LN -> Yahoo .L)
-            ("QUNR.CH", "QUNR.SW"),  # Switzerland (Bloomberg .CH -> Yahoo .SW)
+            ("NOVN.ZU", "NOVN.SW"),  # Switzerland (eToro .ZU -> Yahoo .SW) — see note below
+            ("ROP.ZU", "ROP.SW"),  # Roche; .ZU was missing entirely and 404'd
+            ("RRL.ASX", "RRL.AX"),  # Sydney (eToro .ASX -> Yahoo .AX)
+            ("BCP.LSB", "BCP.LS"),  # Euronext Lisbon (eToro .LSB -> Yahoo .LS)
             ("MSFT.EUR", "MSFT"),  # currency line stripped
             ("KSP.L.GBX", "KSP.L"),  # pence line stripped, exchange suffix kept
             ("BRK.B", "BRK-B"),  # US class share -> dash form
@@ -337,6 +340,44 @@ class TestDisplayAndDataFetch:
         for inp, exp in cases:
             assert get_data_fetch_ticker(inp) == exp, (
                 f"{inp} -> {get_data_fetch_ticker(inp)} (want {exp})"
+            )
+
+    def test_dot_ch_is_a_china_adr_not_switzerland(self):
+        """``.CH`` was mapped to Zurich/``.SW`` and this test asserted it, labelled
+        "Switzerland", using QUNR — which is Qunar Cayman Islands on Nasdaq.
+
+        Every ``.CH`` row in ``yahoofinance/input/etoro.csv`` is a Chinese company on NYSE or
+        Nasdaq: QIHU (Qihoo 360, NYSE), JMEI (Jumei, NYSE), CYOU (ChangYou, Nasdaq), QUNR
+        (Nasdaq), TCOM (Trip.com ADR, Nasdaq), ATHM (Autohome ADR, NYSE), GSOL (Global Sources,
+        Nasdaq). Switzerland in that same file is ``.SW`` on exchange SIX (NESN.SW, ROP.SW,
+        ABBN.SW), and eToro spells it ``.ZU``. So the old rule could only ever fire on Chinese
+        ADRs, and it sent every one of them to a Swiss symbol that does not exist — which is
+        why it survived: the names it would have been right about never reached it.
+        """
+        assert get_data_fetch_ticker("TCOM.CH") == "TCOM"  # Trip.com ADR, Nasdaq
+        assert get_data_fetch_ticker("ATHM.CH") == "ATHM"  # Autohome ADR, NYSE
+        assert get_data_fetch_ticker("QUNR.CH") == "QUNR"  # was QUNR.SW
+
+    def test_get_data_fetch_ticker_strips_wrapper_suffixes(self):
+        """eToro sells session products over a listing. They are not listings and Yahoo does
+        not index them, so they resolve to the security underneath."""
+        assert get_data_fetch_ticker("RSG.RTH") == "RSG"  # "Regular Trading Hours"
+        assert get_data_fetch_ticker("AAPL.24-7") == "AAPL"  # 24/7 session
+        assert get_data_fetch_ticker("AMC.EXT") == "AMC"  # extended hours
+        assert get_data_fetch_ticker("JD.CH") == "9618.HK"  # wrapper off, ADR map still applies
+
+    def test_a_different_security_is_never_folded_into_its_underlying(self):
+        """The wrapper rule above is deliberately NOT extended to these. A contingent value
+        right, a warrant, a right and a preferred line each have their own payoff; collapsing
+        them onto the common stock would overstate a position in the underlying."""
+        for sym, base in [
+            ("ACLX.CVR", "ACLX"),
+            ("BBBY.WS", "BBBY"),
+            ("ABMD.RIGHT", "ABMD"),
+            ("JAGX.PFD", "JAGX"),
+        ]:
+            assert get_data_fetch_ticker(sym) != get_data_fetch_ticker(base), (
+                f"{sym} must not resolve to {base}: different security, same underlying"
             )
 
     def test_get_data_fetch_ticker_specials_still_honored(self):

--- a/tests/unit/scripts/test_refresh_etoro_universe.py
+++ b/tests/unit/scripts/test_refresh_etoro_universe.py
@@ -28,6 +28,11 @@ get_credentials = refresh_etoro_universe.get_credentials
 main = refresh_etoro_universe.main
 MIN_INSTRUMENTS_THRESHOLD = refresh_etoro_universe.MIN_INSTRUMENTS_THRESHOLD
 INSTRUMENTS_URL = refresh_etoro_universe.INSTRUMENTS_URL
+is_junk_symbol = refresh_etoro_universe.is_junk_symbol
+bloomberg_shape = refresh_etoro_universe.bloomberg_shape
+audit_symbols = refresh_etoro_universe.audit_symbols
+report_audit = refresh_etoro_universe.report_audit
+_UNKNOWN_SUFFIX_FAIL_THRESHOLD = refresh_etoro_universe._UNKNOWN_SUFFIX_FAIL_THRESHOLD
 
 FIXTURE_PATH = Path(__file__).parents[2] / "fixtures" / "etoro_bulk_sample.json"
 
@@ -105,6 +110,22 @@ class TestNormalizeSymbol:
 
     def test_lsb_remapped_to_ls(self):
         assert normalize_symbol("CA366.LSB") == "CA366.LS"
+
+    def test_ch_is_a_china_adr_and_is_stripped_not_remapped(self):
+        """``.CH`` is eToro's marker for a Chinese ADR on NYSE/Nasdaq, so the bare US ticker
+        IS the listing. It is NOT Switzerland — eToro spells Zurich ``.ZU`` (see the test
+        above) and Yahoo spells it ``.SW``.
+
+        Until 2026-08-11 this generator had no ``.CH`` rule at all, so the seven affected
+        names reached ``yahoofinance/input/etoro.csv`` still suffixed (QIHU.CH, JMEI.CH,
+        CYOU.CH, QUNR.CH, TCOM.CH, ATHM.CH, GSOL.CH), where ConfigManager's own table then
+        mapped them to ``.SW`` — a Swiss symbol that does not exist for any of them.
+        """
+        assert normalize_symbol("TCOM.CH") == "TCOM"  # Trip.com Group ADR, Nasdaq
+        assert normalize_symbol("ATHM.CH") == "ATHM"  # Autohome ADR, NYSE
+        assert normalize_symbol("qunr.ch") == "QUNR"  # case-insensitive, like .US above
+        # ...and the real Swiss path is untouched
+        assert normalize_symbol("NESN.ZU") == "NESN.SW"
 
     def test_drops_delisted(self):
         assert normalize_symbol("BLMZ.DELISTED") is None
@@ -230,9 +251,27 @@ class TestFetchAllInstruments:
     def test_success_filters_stocks_and_etfs(self):
         api_response = {
             "instrumentDisplayDatas": [
-                {"instrumentID": 1, "symbolFull": "EURUSD", "instrumentDisplayName": "EUR/USD", "instrumentTypeID": 1, "exchangeID": 1},
-                {"instrumentID": 1001, "symbolFull": "AAPL", "instrumentDisplayName": "Apple", "instrumentTypeID": 5, "exchangeID": 4},
-                {"instrumentID": 2001, "symbolFull": "SPY", "instrumentDisplayName": "SPDR S&P 500", "instrumentTypeID": 6, "exchangeID": 4},
+                {
+                    "instrumentID": 1,
+                    "symbolFull": "EURUSD",
+                    "instrumentDisplayName": "EUR/USD",
+                    "instrumentTypeID": 1,
+                    "exchangeID": 1,
+                },
+                {
+                    "instrumentID": 1001,
+                    "symbolFull": "AAPL",
+                    "instrumentDisplayName": "Apple",
+                    "instrumentTypeID": 5,
+                    "exchangeID": 4,
+                },
+                {
+                    "instrumentID": 2001,
+                    "symbolFull": "SPY",
+                    "instrumentDisplayName": "SPDR S&P 500",
+                    "instrumentTypeID": 6,
+                    "exchangeID": 4,
+                },
             ]
         }
         with patch.object(refresh_etoro_universe.requests, "get") as mock_get:
@@ -260,9 +299,20 @@ class TestFetchAllInstruments:
     def test_retries_on_500(self):
         responses = [
             MagicMock(status_code=500, text="boom"),
-            MagicMock(status_code=200, json=lambda: {"instrumentDisplayDatas": [
-                {"instrumentID": 1, "symbolFull": "X", "instrumentDisplayName": "X", "instrumentTypeID": 5, "exchangeID": 4},
-            ]}),
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "instrumentDisplayDatas": [
+                        {
+                            "instrumentID": 1,
+                            "symbolFull": "X",
+                            "instrumentDisplayName": "X",
+                            "instrumentTypeID": 5,
+                            "exchangeID": 4,
+                        },
+                    ]
+                },
+            ),
         ]
         with (
             patch.object(refresh_etoro_universe.requests, "get") as mock_get,
@@ -365,9 +415,7 @@ class TestMain:
         def fake_fetch(api_key, user_key, **kw):
             return padded_items
 
-        with patch.object(
-            refresh_etoro_universe, "fetch_all_instruments", side_effect=fake_fetch
-        ):
+        with patch.object(refresh_etoro_universe, "fetch_all_instruments", side_effect=fake_fetch):
             exit_code = main(output_csv_path=str(output_csv), delta_log_path=str(log_path))
 
         assert exit_code == 0
@@ -395,9 +443,7 @@ class TestMain:
         monkeypatch.setenv("ETORO_USER_KEY", "test-user")
 
         def fake_fetch(*args, **kwargs):
-            return [
-                {"symbol": "X", "displayName": "X", "exchangeName": "N"}
-            ] * 10
+            return [{"symbol": "X", "displayName": "X", "exchangeName": "N"}] * 10
 
         with patch.object(refresh_etoro_universe, "fetch_all_instruments", side_effect=fake_fetch):
             exit_code = main(
@@ -420,3 +466,272 @@ class TestMain:
 
     def test_min_threshold_is_1000(self):
         assert MIN_INSTRUMENTS_THRESHOLD == 1000
+
+
+# ---------------------------------------------------------------------------
+# 2026-08-11 suffix audit. Every case below was measured against the live eToro
+# catalogue or probed against Yahoo before being written down; the bar counts in
+# the docstrings are 1-month `yf.download` results from that date.
+# ---------------------------------------------------------------------------
+
+
+class TestVenueSuffixRemaps:
+    """eToro's spelling of an exchange -> Yahoo's spelling of the same exchange."""
+
+    def test_bloomberg_milan_and_london_codes(self):
+        """.IM/.LN were remapped at FETCH time but not here, so the universe carried the
+        eToro spelling. Probed: 28IA.IM 0 bars / 28IA.MI 22; SHLD.LN 0 / SHLD.L 22."""
+        assert normalize_symbol("28IA.IM") == "28IA.MI"
+        assert normalize_symbol("SHLD.LN") == "SHLD.L"
+
+    def test_existing_venue_remaps_still_hold(self):
+        assert normalize_symbol("XYZ.ASX") == "XYZ.AX"
+        assert normalize_symbol("NESN.ZU") == "NESN.SW"
+        assert normalize_symbol("HAVAS.NV") == "HAVAS.AS"
+        assert normalize_symbol("CA366.LSB") == "CA366.LS"
+
+
+class TestHongKongPadsBothWays:
+    """The pad was one-sided (`len(base) > 4`), so only 5-digit codes were touched and every
+    short code stayed unfetchable. Probed: 3.HK 0 bars / 0003.HK 21; 288.HK 0 / 0288.HK 21."""
+
+    def test_short_codes_are_padded(self):
+        assert normalize_symbol("3.HK") == "0003.HK"  # Hong Kong & China Gas
+        assert normalize_symbol("12.HK") == "0012.HK"  # Henderson Land
+        assert normalize_symbol("288.HK") == "0288.HK"  # WH Group
+
+    def test_long_codes_still_trimmed_and_4_digit_untouched(self):
+        assert normalize_symbol("00175.HK") == "0175.HK"
+        assert normalize_symbol("0700.HK") == "0700.HK"
+        assert normalize_symbol("9988.HK") == "9988.HK"
+
+    def test_non_numeric_hk_stem_is_left_alone(self):
+        """zfill must not be applied to a non-numeric stem."""
+        assert normalize_symbol("ANT.HK") == "ANT.HK"
+
+
+class TestDoubledDotIsCollapsedNotStripped:
+    """YU..L is eToro writing an LSE TIDM that ends in a period. Probed: YU.L and RE.L both
+    return 22 bars and neither collides with an existing row."""
+
+    def test_collapse(self):
+        assert normalize_symbol("YU..L") == "YU.L"
+        assert normalize_symbol("RE..L") == "RE.L"
+
+    def test_never_stripped_to_the_bare_stem(self):
+        """FA..L -> FA and IX..L -> IX would merge into unrelated US tickers."""
+        assert normalize_symbol("FA..L") == "FA.L"
+        assert normalize_symbol("IX..L") == "IX.L"
+
+
+class TestJunkSymbolCatchesWhatSuffixRulesCannot:
+    def test_cvr_marker_on_the_stem_side_of_the_dot(self):
+        """_is_junk_suffix reads only after the last dot, so it caught US.CVR1 and missed
+        CVR.THS — the same marker on the other side."""
+        assert normalize_symbol("CVR.THS") is None
+        assert normalize_symbol("CVR.AVDL") is None
+        assert normalize_symbol("US.CVR1") is None
+
+    def test_short_numeric_suffix(self):
+        """The old rule required len > 3, so WRTS.APRN.15 slipped through.
+
+        Asserted on ``_is_junk_suffix`` DIRECTLY and on a stem that is not itself junk. Going
+        through normalize_symbol("WRTS.APRN.15") passes either way, because WRTS is in
+        _JUNK_STEMS and short-circuits first — a mutation reinstating `len(s) > 3` survived
+        that version of this test, which is the definition of a test passing for the wrong
+        reason.
+        """
+        assert refresh_etoro_universe._is_junk_suffix(".15")
+        assert refresh_etoro_universe._is_junk_suffix(".20")
+        assert refresh_etoro_universe._is_junk_suffix(".999")
+        assert refresh_etoro_universe._is_junk_suffix(".15255")
+        assert normalize_symbol("AAPL.15") is None  # stem is NOT junk; only the rule saves it
+        assert normalize_symbol("WRTS.APRN.15") is None
+
+    def test_space_delimited_placeholders(self):
+        for sym in ("LSE CVR", "MTN DUMMY CVR", "CEPU ESCROW ASSET", "OSLO CVR1", "ETOR 4 C40"):
+            assert is_junk_symbol(sym), sym
+
+    def test_lifecycle_markers_in_all_four_spellings(self):
+        for sym in ("SNDK_OLD", "BMPS-OLD", "MRK.DE_OLD", "STJ.L OLD"):
+            assert is_junk_symbol(sym), sym
+
+    def test_old_marker_never_matches_a_real_ticker(self):
+        """\\bOLD$ cannot fire inside a word — GOLD is not a lifecycle marker."""
+        assert not is_junk_symbol("GOLD")
+        assert not is_junk_symbol("GOLD.L")
+
+    def test_dormant_and_drm_placeholders(self):
+        assert is_junk_symbol("DORMANT11232")
+        assert is_junk_symbol("DRM.14731")
+
+    def test_xetra_duplicate_artifacts(self):
+        assert normalize_symbol("CEBP.DE11") is None
+        assert normalize_symbol("IQQ6.D11") is None
+        assert normalize_symbol("ICGB.DE22") is None
+
+
+class TestCorporateActionPlaceholderPredicate:
+    """The company==stem conjunction is LOAD-BEARING. Measured on the live universe file: the
+    conjunction selects 63 junk rows, a bare ^CA\\d+ prefix rule selects 71 — the eight extra
+    are real companies."""
+
+    def test_placeholder_is_dropped(self):
+        assert is_junk_symbol("CA141.L", "CA141")
+        assert is_junk_symbol("CA307.OL", "CA307")
+
+    def test_real_companies_sharing_the_prefix_survive(self):
+        assert not is_junk_symbol("CA21", "Royal Dutch  Shell")
+        assert not is_junk_symbol("CA8", "Meredith Holdings Corp.")
+        assert not is_junk_symbol("CA12908", "Everfuel A/S")
+        assert not is_junk_symbol("CA1.DE", "Circus SE")
+
+
+class TestScandinavianHyphenIsVenueSpecific:
+    """Stockholm and Copenhagen hyphenate a share-class letter; Helsinki and Oslo do NOT.
+    Probed 2026-08-11: KESKOA.HE 21 bars / KESKO-A.HE 0 · ODFB.OL 21 / ODF-B.OL 0 ·
+    ASSA-B.ST 21 / ASSAB.ST 0 (the control that keeps .ST in the set)."""
+
+    def _syms(self, rows):
+        return {r["symbol"] for r in fix_share_classes(rows)}
+
+    def test_helsinki_is_not_hyphenated(self):
+        rows = [
+            {"symbol": "KESKOA.HE", "company": "Kesko Oyj", "exchange": "Helsinki"},
+            {"symbol": "KESKOB.HE", "company": "Kesko Oyj B", "exchange": "Helsinki"},
+        ]
+        assert self._syms(rows) == {"KESKOA.HE", "KESKOB.HE"}
+
+    def test_oslo_is_not_hyphenated(self):
+        rows = [
+            {"symbol": "VENDA.OL", "company": "Vend Marketplaces ASA", "exchange": "Oslo"},
+            {"symbol": "VENDB.OL", "company": "Vend Marketplaces ASA", "exchange": "Oslo"},
+        ]
+        assert self._syms(rows) == {"VENDA.OL", "VENDB.OL"}
+
+    def test_stockholm_and_copenhagen_still_are(self):
+        rows = [
+            {"symbol": "ASSAA.ST", "company": "ASSA ABLOY ser. A", "exchange": "Stockholm"},
+            {"symbol": "ASSAB.ST", "company": "ASSA ABLOY ser. B", "exchange": "Stockholm"},
+            {"symbol": "NOVOA.CO", "company": "Novo Nordisk A", "exchange": "Copenhagen"},
+            {"symbol": "NOVOB.CO", "company": "Novo Nordisk B", "exchange": "Copenhagen"},
+        ]
+        assert self._syms(rows) == {"ASSA-A.ST", "ASSA-B.ST", "NOVO-A.CO", "NOVO-B.CO"}
+
+
+class TestSuffixAudit:
+    """The guard the module was missing. A suffix in none of the ruling sets used to be written
+    to the universe in silence — that is how .CH stayed mis-mapped for months."""
+
+    def _row(self, sym, company="X Corp", exchange="Nasdaq"):
+        return {"symbol": sym, "company": company, "exchange": exchange}
+
+    def test_ruled_suffixes_are_silent(self):
+        rows = [
+            self._row(s)
+            for s in (
+                "AAPL",
+                "VOD.L",
+                "SAP.DE",
+                "RRL.ASX",
+                "NOVN.ZU",
+                "TCOM.CH",
+                "AAPL.EUR",
+                "STX.US",
+                "CVR.THS",
+                "BRK.B",
+            )
+        ]
+        unknown, _ = audit_symbols(rows)
+        assert unknown == {}
+
+    def test_an_unruled_suffix_is_reported(self):
+        rows = [self._row("ABC.XYZ")]
+        unknown, _ = audit_symbols(rows)
+        assert list(unknown) == [".XYZ"]
+        assert unknown[".XYZ"] == ["ABC.XYZ"]
+
+    def test_below_threshold_warns_but_does_not_abort(self):
+        rows = [self._row(f"A{i}.XYZ") for i in range(_UNKNOWN_SUFFIX_FAIL_THRESHOLD - 1)]
+        unknown, review = audit_symbols(rows)
+        assert report_audit(unknown, review) is False
+
+    def test_at_threshold_aborts(self):
+        """A new exchange arrives in bulk. That must stop the refresh, not scroll past."""
+        rows = [self._row(f"A{i}.XYZ") for i in range(_UNKNOWN_SUFFIX_FAIL_THRESHOLD)]
+        unknown, review = audit_symbols(rows)
+        assert report_audit(unknown, review) is True
+
+    def test_the_dot_ch_regression_would_now_be_caught(self):
+        """The whole point. Strip .CH out of the ruling sets and the audit must shout."""
+        original = refresh_etoro_universe._STRIP_SUFFIXES
+        refresh_etoro_universe._STRIP_SUFFIXES = (".US",)
+        try:
+            rows = [self._row(s) for s in ("TCOM.CH", "ATHM.CH", "QUNR.CH")]
+            unknown, review = audit_symbols(rows)
+            assert ".CH" in unknown
+            assert report_audit(unknown, review) is True
+        finally:
+            refresh_etoro_universe._STRIP_SUFFIXES = original
+
+    def test_junk_never_reaches_the_audit(self):
+        unknown, review = audit_symbols([self._row("DORMANT11232"), self._row("LSE CVR")])
+        assert unknown == {}
+        assert review == {}
+
+    def test_bloomberg_form_is_reviewed_not_dropped_and_not_unknown(self):
+        """SRT3 GY is Sartorius Vorzug — a real security in Bloomberg notation. It needs a
+        per-venue remap, which is a reviewed decision, so it warns rather than vanishing."""
+        assert bloomberg_shape("SRT3 GY")
+        assert bloomberg_shape("HAWK US")
+        assert not bloomberg_shape("MTN DUMMY CVR")
+        unknown, review = audit_symbols([self._row("SRT3 GY", "SARTORIUS AG-VORZUG", "FRA")])
+        assert unknown == {}
+        assert any("bloomberg" in k for k in review)
+
+    def test_bare_symbol_on_a_non_us_venue_is_reviewed(self):
+        """A bare symbol means a US listing. When eToro says the venue is London, passthrough
+        would aim a US ticker at a foreign company — report it, never guess."""
+        _, review = audit_symbols([self._row("SJNK", "SPDR Bloomberg Short Term", "LSE")])
+        assert any("non-US venue" in k for k in review)
+
+    def test_bare_us_symbols_are_not_reviewed(self):
+        for venue in ("Nasdaq", "NYSE", "CBOE", "Chicago Board Options Exchange", "OTC Markets"):
+            _, review = audit_symbols([self._row("AAPL", "Apple Inc", venue)])
+            assert review == {}, venue
+
+
+class TestCurrencyLineShapeDecidesStripVsDrop:
+    """Both shapes exist in the live file and they need opposite handling."""
+
+    def test_venue_qualified_stem_is_stripped_and_recovered(self):
+        """GLB.L.GBX / KSP.L.GBX have NO bare GLB.L / KSP.L row, so stripping the pence unit
+        is the only thing that produces the London listing at all."""
+        assert normalize_symbol("GLB.L.GBX", "Glanbia Plc") == "GLB.L"
+        assert normalize_symbol("KSP.L.GBX", "Kingspan Group Plc") == "KSP.L"
+
+    def test_bare_stem_is_dropped_not_collided(self):
+        """All ten .EUR rows are Frankfurt duplicates of a Nasdaq row that already exists.
+        Stripping would collide, and dedupe could keep the one labelled FRA."""
+        assert normalize_symbol("AAPL.EUR", "Apple") is None
+        assert normalize_symbol("NVDA.EUR", "NVIDIA Corporation") is None
+
+    def test_a_currency_word_inside_a_real_ticker_is_untouched(self):
+        assert normalize_symbol("EURO.L", "Euromoney") == "EURO.L"
+        assert normalize_symbol("IEUR", "iShares Core MSCI Europe") == "IEUR"
+
+
+class TestPlaceholderCodesBeyondTheCAFamily:
+    """The row's NAME is its own internal code. Same shape as CA141, different prefixes."""
+
+    def test_ipo_and_ca_ops_placeholders_are_dropped(self):
+        assert normalize_symbol("IPO56.L", "IPO56") is None
+        assert normalize_symbol("IPO100.L", "IPO100") is None
+        assert normalize_symbol("IPO108.AX", "IPO108") is None
+        assert normalize_symbol("CA.OPS31.L", "CA.Ops31") is None
+        assert normalize_symbol("IPO1", "IPO1") is None
+
+    def test_ip_group_is_not_a_placeholder(self):
+        """IPO.L is IP Group PLC. A prefix rule on the SYMBOL would delete it; the rule keys
+        on the company name being the code, so it survives."""
+        assert normalize_symbol("IPO.L", "IP Group PLC") == "IPO.L"

--- a/trade_modules/config_manager.py
+++ b/trade_modules/config_manager.py
@@ -12,10 +12,47 @@ from typing import Any
 
 from .yaml_config_loader import YamlConfigLoader
 
-# eToro/Bloomberg exchange suffix -> Yahoo Finance suffix, applied in get_data_fetch_ticker
-# (Yahoo 404s on the eToro form; verified via live probes). .DH (Gulf) is intentionally
+# eToro/Bloomberg spelling of an EXCHANGE -> Yahoo Finance's spelling of the SAME exchange,
+# applied in get_data_fetch_ticker (Yahoo 404s on the eToro form). .DH (Gulf) is intentionally
 # absent — Yahoo uses numeric codes there, so it needs per-name data_fetch_substitutions.
-_YAHOO_SUFFIX_MAP = {"NV": "AS", "IM": "MI", "LN": "L", "CH": "SW"}
+#
+# Audited against yahoofinance/input/etoro.csv, which carries an `exchange` column, so every
+# rule below is checkable from data in this repo rather than from recollection.
+_YAHOO_SUFFIX_MAP = {
+    "NV": "AS",  # Euronext Amsterdam
+    "IM": "MI",  # Borsa Italiana (Bloomberg code)
+    "LN": "L",  # London (Bloomberg code)
+    "ZU": "SW",  # SIX Swiss Exchange — eToro's spelling of Zurich
+    "ASX": "AX",  # Sydney — eToro uses three letters, Yahoo two
+    "LSB": "LS",  # Euronext Lisbon
+}
+
+# ".CH" USED TO BE IN THE TABLE ABOVE, MAPPED TO "SW" AND LABELLED SWITZERLAND. IT IS NOT.
+# Every .CH row in yahoofinance/input/etoro.csv is a Chinese company listed on NYSE or Nasdaq:
+#   QIHU.CH  Qihoo 360 Technology     NYSE      TCOM.CH  Trip.com Group Ltd-ADR   Nasdaq
+#   JMEI.CH  Jumei Intl Holdings      NYSE      ATHM.CH  Autohome-ADR             NYSE
+#   CYOU.CH  ChangYou.com             Nasdaq    GSOL.CH  Global Sources           Nasdaq
+#   QUNR.CH  Qunar Cayman Islands     Nasdaq
+# Switzerland in that same file is .SW on exchange SIX (NESN.SW Nestle, ROP.SW Roche, ABBN.SW
+# ABB), and eToro spells it .ZU. So the rule could only ever fire on Chinese ADRs, and it sent
+# every one to a Swiss symbol that does not exist. It survived because the names it would have
+# been right about never reached it — a mapping that only fires on the rows it is wrong about
+# looks correct indefinitely. .CH now lives in _WRAPPER_SUFFIXES, where stripping it yields the
+# real Nasdaq/NYSE line (TCOM.CH -> TCOM).
+#
+# Suffixes that mark a WRAPPER OVER a listing rather than a listing: strip, then re-resolve the
+# stem so ADR overrides and class-share rules still apply (JD.CH -> JD -> 9618.HK).
+#   US     eToro's US-listing marker; Yahoo uses the bare ticker (T.US -> T)
+#   CH     a China ADR on NYSE/Nasdaq — the ADR itself IS the US line
+#   RTH    eToro "Regular Trading Hours" session product (RSG.RTH -> RSG)
+#   24-7   eToro 24/7 session product (AAPL.24-7 "Apple 24/7")
+#   EXT    eToro extended-hours product
+# NOT here, deliberately: .CVR (contingent value rights), .WS (warrants), .RIGHT, .PFD
+# (preferred), .CALL1/.PUT1 (options). Those hang off a base ticker too, which makes stripping
+# them tempting and wrong — each is a different security with its own payoff, and folding one
+# into the common stock would overstate a position in the underlying.
+_WRAPPER_SUFFIXES = {"US", "CH", "RTH", "24-7", "EXT"}
+
 # Currency / price-unit lines eToro appends (e.g. MSFT.EUR, KSP.L.GBX) -> stripped before fetch.
 _CURRENCY_SUFFIXES = {"EUR", "USD", "GBP", "GBX"}
 # US class-share letters -> Yahoo dash form (BRK.B -> BRK-B).
@@ -429,14 +466,16 @@ class ConfigManager:
                 #    (MSFT.EUR → MSFT ; KSP.L.GBX → KSP.L).
                 if suf in _CURRENCY_SUFFIXES:
                     return self.get_data_fetch_ticker(stem)
-                # 1b. eToro .US US-listing marker: Yahoo uses the BARE US ticker (T.US → T,
-                #     AAPL.US → AAPL). Re-resolve the stem so a US class share still gets its
-                #     dash form (BRK.B.US → BRK.B → BRK-B). ADR overrides that map a .US line
-                #     to a foreign primary (e.g. JD.US → 9618.HK) win above via
+                # 1b. eToro wrapper marker over a listing: Yahoo indexes the listing underneath
+                #     (T.US → T, AAPL.US → AAPL, TCOM.CH → TCOM, RSG.RTH → RSG). Re-resolve the
+                #     stem so a US class share still gets its dash form (BRK.B.US → BRK.B →
+                #     BRK-B) and the ADR map still applies (JD.CH → JD → 9618.HK). ADR overrides
+                #     that map a .US line to a foreign primary win above via
                 #     data_fetch_substitutions, so they never reach this strip.
-                if suf == "US":
+                if suf in _WRAPPER_SUFFIXES:
                     return self.get_data_fetch_ticker(stem)
-                # 2. exchange-suffix remap (.NV→.AS, .IM→.MI, .LN→.L, .CH→.SW).
+                # 2. exchange-suffix remap (.NV→.AS, .IM→.MI, .LN→.L, .ZU→.SW, .ASX→.AX,
+                #    .LSB→.LS).
                 if suf in _YAHOO_SUFFIX_MAP:
                     return stem + "." + _YAHOO_SUFFIX_MAP[suf]
                 # 3. US class share (single letter, no further exchange suffix): BRK.B → BRK-B.


### PR DESCRIPTION
## The bug

`_YAHOO_SUFFIX_MAP` mapped `.CH` to Switzerland/`.SW`. Every `.CH` row eToro publishes is a **China ADR on NYSE or Nasdaq** — all seven checkable from this repo's own `yahoofinance/input/etoro.csv`, which carries an `exchange` column:

| symbol | company | exchange |
|---|---|---|
| QIHU.CH | Qihoo 360 Technology | NYSE |
| TCOM.CH | Trip.com Group Ltd-ADR | Nasdaq |
| ATHM.CH | Autohome-ADR | NYSE |
| CYOU.CH / QUNR.CH / GSOL.CH / JMEI.CH | … | Nasdaq / NYSE |

Switzerland is `.ZU` (NESN.SW, ROP.SW, ABBN.SW all sit on exchange `SIX`), and `.ZU` **was not in the table at all**. So the rule could only ever fire on Chinese ADRs, and it sent every one to a Swiss symbol that does not exist — while `ROP.ZU` and `NOVN.ZU` resolved to themselves and 404'd.

**Why it survived:** a mapping that only ever fires on the rows it is *wrong* about looks correct indefinitely, because the names it would have been right about never reach it. A test asserted the bug and labelled it `# Switzerland`, using QUNR — Qunar Cayman Islands, Nasdaq.

Fixed in the resolver **and** in the generator, which had no `.CH` rule at all — that is how the suffix reached the CSV to begin with.

## Three more live defects the audit found

All 161 catalogue suffixes were checked. Bar counts are 1-month `yf.download`, 2026-08-11:

| defect | before | after | evidence |
|---|---|---|---|
| Helsinki/Oslo wrongly hyphenated | `KESKO-A.HE` | `KESKOA.HE` | 0 → **21** bars; control `ASSA-B.ST` 21 vs `ASSAB.ST` 0, so `.ST`/`.CO` stay |
| HK zero-pad one-sided (`len > 4`) | `3.HK`, `288.HK` | `0003.HK`, `0288.HK` | 0 → **21** (HK & China Gas, Henderson Land, CITIC, WH Group, Techtronic) |
| `.IM`/`.LN` remapped at fetch but not by the generator | `28IA.IM` | `28IA.MI` | 0 → **22**; `SHLD.LN` 0 → `SHLD.L` 22 |

Kesko A/B and Metsä Board A/B were in the universe as ACTIVE and could never return a price.

## The guard

`normalize_symbol` returned an unrecognised suffix unchanged, with no warning. That silence is the actual bug class.

`audit_symbols()` now classifies every raw symbol against the ruling sets. **Membership in `_ALLOWED_PASSTHROUGH` means "a human decided this", not "this is valid"** — which is why `.DH` is in it while being unfetchable (Yahoo indexes the Gulf under numeric codes; that is a decided question).

Two severities, because a guard that is red on day one is a guard nobody reads:

- **FAIL** — an unruled suffix on **≥3** symbols returns `1` from `main()` *before anything is written*, so the commit step is skipped and the universe holds at its last good state. A new venue arrives in bulk (`.ASX` 244, `.DE11` 13, `.LSB` 8, `.CH` 7); stray junk is 1–2 rows.
- **WARN** — known-but-unresolved shapes (bare symbols on a non-US venue, Bloomberg `TICKER CC` forms). Pre-existing backlog, reported every run, never blocking.

On today's catalogue it does not abort: one unruled suffix (`.PC`, 1 symbol) warns below threshold.

## Everything else ruled on, so the guard starts green

`.LSB`→`.LS`, `.ASX`→`.AX`; currency lines **by shape** (strip `KSP.L.GBX`→`KSP.L`, where the stem keeps a venue and no bare twin exists; drop `AAPL.EUR`, a Frankfurt duplicate of the Nasdaq row); doubled-dot collapse `YU..L`→`YU.L` (**never** to bare `YU`, which would merge with a US ticker); Xetra artifacts `.DE11`/`.D11`/`.DE22`; and a whole-symbol junk predicate for placeholders the suffix-only check structurally cannot see — `CVR.THS` carries the marker on the *stem* side, `LSE CVR` has no dot at all.

**The junk predicate's conjunction is load-bearing, and is tested as such.** `company == its own code` selects 63 placeholder rows; a bare `^CA\d+` symbol rule selects 71, and the eight extra are real companies — CA21 is Royal Dutch Shell, CA8 Meredith Holdings, CA12908 Everfuel. Same trap on `IPO\d+`, where `IPO.L` is IP Group PLC.

## Blast radius, measured

Replayed over the whole catalogue: **214 symbols behave differently, 172 newly dropped**, and every one is accounted for — 64 CA placeholders, 32 DORMANT/DRM, 29 CVR/escrow, 15 Xetra artifacts, 1 option line (`ETOR 4 C40`), the rest lifecycle markers. **No real security is dropped and no two securities merge.**

## Tests

218 pass across the affected suites; full suite 5,292 passed / 48 skipped, the one failure being `test_vectorization_performance`, a wall-clock assertion that documents itself as flaky under parallel local load and is `skipIf(CI)`. Blocking flake8 gate clean.

Note: part of the diff is `ruff format` (pre-commit) reflowing pre-existing literals in the same files, notably `EXCHANGE_NAMES`, which this change does not otherwise touch.

## Deliberately not in scope

The audit also surfaced per-ticker work that needs hand review rather than a suffix rule, and which the new WARN bucket now surfaces every run instead of hiding: `GLB.IR` passes through into **Beacon Hill CBO III** when it is Glanbia (a genuine two-company merge, needs `GL9.IR` or a drop); ~39 bare symbols on non-US venues, including `SJNK`; and stem alias tables for `.ST`, `.CO`, `.BD`, `.HE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)