### PR TITLE
fix(etoro): aggregate per-lot netProfit as a weighted mean, not a sum

### DIFF
--- a/tests/unit/yahoofinance/data/test_download.py
+++ b/tests/unit/yahoofinance/data/test_download.py
@@ -91,7 +91,189 @@ class TestProcessEToroPortfolioData:
         assert len(result) == 1
         assert result[0]["numPositions"] == 2
         assert result[0]["totalInvestmentPct"] == pytest.approx(15.0)
-        assert result[0]["totalNetProfit"] == pytest.approx(150.0)
+        # netProfit is a per-lot percentage, so the holding's contribution to
+        # portfolio return is (100%*10% + 50%*5%) = 12.5pp of NAV.
+        assert result[0]["totalNetProfit"] == pytest.approx(12.5)
+
+    def test_net_profit_is_contribution_in_nav_points(self):
+        """totalNetProfit is the holding's contribution to portfolio return.
+
+        eToro exposes no currency amount on the public portfolio endpoint, so
+        the only honest absolute figure is percentage points of NAV:
+        lot return times lot weight.
+        """
+        from yahoofinance.data.download import _process_etoro_portfolio_data
+
+        portfolio = {
+            "positions": [
+                {
+                    "instrumentId": 1,
+                    "investmentPct": 1.8487,
+                    "netProfit": -16.37,
+                    "openRate": 33.62,
+                    "openTimestamp": "2026-06-26",
+                    "isBuy": True,
+                    "leverage": 1,
+                }
+            ]
+        }
+        metadata = {1: {"symbolFull": "ETOR", "instrumentDisplayName": "eToro Group"}}
+
+        result = _process_etoro_portfolio_data(portfolio, metadata, "test_run")
+
+        # -16.37% on 1.8487% of NAV = -0.3026pp of NAV
+        assert result[0]["totalNetProfit"] == pytest.approx(-0.303, abs=0.001)
+        assert result[0]["totalNetProfitPct"] == pytest.approx(-16.37, abs=0.01)
+
+    def test_net_profit_contributions_sum_to_portfolio_return(self):
+        """Contributions are additive: they sum to the book's total return."""
+        from yahoofinance.data.download import _process_etoro_portfolio_data
+
+        # Two holdings, 40% and 60% of a fully invested book, +10% and -5%.
+        # Portfolio return = 0.4*10 + 0.6*-5 = +1.0pp
+        portfolio = {
+            "positions": [
+                {
+                    "instrumentId": 1,
+                    "investmentPct": 40.0,
+                    "netProfit": 10.0,
+                    "openRate": 100.0,
+                    "openTimestamp": "2024-01-01",
+                    "isBuy": True,
+                    "leverage": 1,
+                },
+                {
+                    "instrumentId": 2,
+                    "investmentPct": 60.0,
+                    "netProfit": -5.0,
+                    "openRate": 200.0,
+                    "openTimestamp": "2024-01-01",
+                    "isBuy": True,
+                    "leverage": 1,
+                },
+            ]
+        }
+        metadata = {
+            1: {"symbolFull": "AAA", "instrumentDisplayName": "A"},
+            2: {"symbolFull": "BBB", "instrumentDisplayName": "B"},
+        }
+
+        result = _process_etoro_portfolio_data(portfolio, metadata, "test_run")
+
+        assert sum(r["totalNetProfit"] for r in result) == pytest.approx(1.0, abs=0.001)
+
+    def test_net_profit_and_pct_stay_consistent(self):
+        """pct must equal contribution scaled back up by the holding's weight."""
+        from yahoofinance.data.download import _process_etoro_portfolio_data
+
+        portfolio = {
+            "positions": [
+                {
+                    "instrumentId": 1,
+                    "investmentPct": w,
+                    "netProfit": p,
+                    "openRate": 100.0,
+                    "openTimestamp": "2024-01-01",
+                    "isBuy": True,
+                    "leverage": 1,
+                }
+                for w, p in ((10.0, 20.0), (30.0, -4.0))
+            ]
+        }
+        metadata = {1: {"symbolFull": "AAPL", "instrumentDisplayName": "Apple"}}
+
+        row = _process_etoro_portfolio_data(portfolio, metadata, "test_run")[0]
+
+        assert row["totalNetProfitPct"] == pytest.approx(
+            row["totalNetProfit"] * 100 / row["totalInvestmentPct"], abs=0.01
+        )
+
+    def test_net_profit_pct_of_single_position_is_the_position_return(self):
+        """A single lot's return must pass through unchanged.
+
+        eToro returns `netProfit` as a per-lot percentage return, so a lone
+        position holding -12.675% must report -12.675%, not that figure
+        divided by the position's share of the account.
+        """
+        from yahoofinance.data.download import _process_etoro_portfolio_data
+
+        portfolio = {
+            "positions": [
+                {
+                    "instrumentId": 123,
+                    "investmentPct": 0.4625,
+                    "netProfit": -12.675,
+                    "openRate": 32.53,
+                    "openTimestamp": "2026-08-17",
+                    "isBuy": True,
+                    "leverage": 1,
+                }
+            ]
+        }
+        metadata = {123: {"symbolFull": "DTE.DE", "instrumentDisplayName": "Deutsche Telekom"}}
+
+        result = _process_etoro_portfolio_data(portfolio, metadata, "test_run")
+
+        assert result[0]["totalNetProfitPct"] == pytest.approx(-12.675, abs=0.01)
+
+    def test_net_profit_pct_of_grouped_positions_is_investment_weighted(self):
+        """Lot returns aggregate as an investment-weighted mean, not a sum.
+
+        Summing per-lot percentages inflates without bound as lots accumulate,
+        which is how a 23-lot holding came to report a +480% return.
+        """
+        from yahoofinance.data.download import _process_etoro_portfolio_data
+
+        portfolio = {
+            "positions": [
+                {
+                    "instrumentId": 123,
+                    "investmentPct": 10.0,
+                    "netProfit": 20.0,
+                    "openRate": 50.0,
+                    "openTimestamp": "2024-01-01",
+                    "isBuy": True,
+                    "leverage": 1,
+                },
+                {
+                    "instrumentId": 123,
+                    "investmentPct": 30.0,
+                    "netProfit": -4.0,
+                    "openRate": 55.0,
+                    "openTimestamp": "2024-01-02",
+                    "isBuy": True,
+                    "leverage": 1,
+                },
+            ]
+        }
+        metadata = {123: {"symbolFull": "AAPL", "instrumentDisplayName": "Apple Inc."}}
+
+        result = _process_etoro_portfolio_data(portfolio, metadata, "test_run")
+
+        # (10*20 + 30*-4) / 40 = +2.0
+        assert result[0]["totalNetProfitPct"] == pytest.approx(2.0, abs=0.01)
+
+    def test_net_profit_pct_never_exceeds_the_widest_lot_return(self):
+        """The aggregate must sit inside the range of its constituent lots."""
+        from yahoofinance.data.download import _process_etoro_portfolio_data
+
+        lots = [
+            {
+                "instrumentId": 123,
+                "investmentPct": 0.5,
+                "netProfit": profit,
+                "openRate": 100.0,
+                "openTimestamp": "2024-01-01",
+                "isBuy": True,
+                "leverage": 1,
+            }
+            for profit in (12.0, 8.0, 15.0, 9.0, 11.0)
+        ]
+        metadata = {123: {"symbolFull": "NVDA", "instrumentDisplayName": "NVIDIA"}}
+
+        result = _process_etoro_portfolio_data({"positions": lots}, metadata, "test_run")
+
+        assert 8.0 <= result[0]["totalNetProfitPct"] <= 15.0
 
 
 class TestSaveEToroPortfolioCsv:

--- a/yahoofinance/data/download.py
+++ b/yahoofinance/data/download.py
@@ -907,7 +907,6 @@ def _process_etoro_portfolio_data(portfolio: dict, metadata: dict, run_id: str):
         # Calculate aggregated values
         num_positions = len(symbol_positions)
         total_investment_pct = sum(p["position"].get("investmentPct", 0) for p in symbol_positions)
-        total_net_profit = sum(p["position"].get("netProfit", 0) for p in symbol_positions)
 
         # Calculate weighted average open rate
         weighted_open_rate = 0
@@ -919,6 +918,21 @@ def _process_etoro_portfolio_data(portfolio: dict, metadata: dict, run_id: str):
                 )
                 / total_investment_pct
             )
+
+        # eToro reports netProfit per lot as a percentage return, and the public
+        # portfolio endpoint carries no currency amount at all. Weighting each
+        # lot's return by its share of NAV gives the holding's contribution to
+        # portfolio return in percentage points, which is additive across the
+        # book; dividing that back out by the holding's own weight recovers the
+        # holding's own return. Summing raw lot percentages does neither.
+        weighted_net_profit = sum(
+            p["position"].get("netProfit", 0) * p["position"].get("investmentPct", 0)
+            for p in symbol_positions
+        )
+        total_net_profit = weighted_net_profit / 100
+        weighted_net_profit_pct = (
+            weighted_net_profit / total_investment_pct if total_investment_pct > 0 else 0
+        )
 
         # Get earliest open timestamp
         earliest_open = min(p["position"].get("openTimestamp", "") for p in symbol_positions)
@@ -946,9 +960,7 @@ def _process_etoro_portfolio_data(portfolio: dict, metadata: dict, run_id: str):
             "totalInvestmentPct": round(total_investment_pct, 6),
             "avgOpenRate": round(weighted_open_rate, 4),
             "totalNetProfit": round(total_net_profit, 3),
-            "totalNetProfitPct": round(
-                (total_net_profit / total_investment_pct) if total_investment_pct > 0 else 0, 3
-            ),
+            "totalNetProfitPct": round(weighted_net_profit_pct, 3),
             "earliestOpenTimestamp": earliest_open,
             "isBuy": all_buy,
             "leverage": leverage,
@@ -1009,9 +1021,10 @@ def _save_etoro_portfolio_csv(data: list, output_path: str, run_id: str):
 
     # Print compact summary
     total_investment = sum(row["totalInvestmentPct"] for row in data)
-    total_profit = sum(row["totalNetProfit"] for row in data)
+    # Contributions are additive, so the book's return is just their sum.
+    total_profit_pp = sum(row["totalNetProfit"] for row in data)
     print(
-        f"\n✅ Portfolio saved: {len(data)} symbols | Investment: {total_investment:.1f}% | Net P&L: ${total_profit:,.0f}"
+        f"\n✅ Portfolio saved: {len(data)} symbols | Investment: {total_investment:.1f}% | Net P&L: {total_profit_pp:+.2f}pp of NAV"
     )
 
 


### PR DESCRIPTION
## Problem

eToro returns `netProfit` on each position as a **percentage return**, not a currency amount. `_process_etoro_portfolio_data` treated it as currency and made two compounding errors:

1. Summed per-lot **percentages** across lots
2. Divided that sum by `totalInvestmentPct`, which is also a percentage

The error scales with lot count, so the worst offenders were the most-traded names:

| | lots | reported | true price return |
|---|---|---|---|
| NVDA | 23 | **+480.15%** | +30.34% |
| AMZN | 10 | **+187.24%** | +33.88% |
| LYXGRE.DE | 12 | **+159.07%** | +40.81% |
| META | 9 | **-70.49%** | -17.90% |

A third symptom: the summary line summed those percentages across all 57 symbols and printed the result as `Net P&L: $X`, a fabricated currency figure.

## Units evidence

Measured on 24 single-lot positions, where no aggregation can confound it:

```
median  netProfit / (price return)  =  0.981     (n=24)
```

Reading `netProfit` as currency would require each position to be worth about 1 unit.

## Fix

Mirrors the investment-weighted pattern already used for `avgOpenRate` in the same function:

```python
weighted_net_profit = sum(netProfit_i * investmentPct_i)
totalNetProfit      = weighted_net_profit / 100                    # pp of NAV
totalNetProfitPct   = weighted_net_profit / totalInvestmentPct     # holding's own return
```

The public `portfolio/live` endpoint carries no currency amount, so `totalNetProfit` becomes the holding's **contribution to portfolio return in percentage points of NAV**. That is additive across the book, so the summary line is now a genuine sum rather than invented dollars. The two columns are consistent by construction.

## Verification

Rebuilt against real positions; median error versus price return drops to **0.76pp**:

| | old pct | **new pct** | actual |
|---|---|---|---|
| DTE.DE | -13.70% | **-12.68%** | -12.73% |
| EMAAR.AE | -29.00% | **-12.07%** | -12.40% |
| INCY | +3.66% | **+3.37%** | +3.41% |

Additivity checked exactly: 40% at +10% and 60% at -5% sum to +1.000pp.

- 27 tests in `test_download.py` pass; the six new ones were confirmed **red before green**
- 185 passed / 4 skipped across the five `trade_modules` files referencing these fields
- ruff clean, format clean, flake8 CI gate 0

## Notes

`totalNetProfitPct` had **no production consumer**, so no trading decision was affected. The corruption was confined to the written record.

`test_process_grouped_positions` asserted `totalNetProfit == 150.0`, which had encoded the summing behaviour. Corrected to `12.5`.

Five semiconductor names (STX.US, WDC, LRCX, AMAT, ASML.NV) still show eToro's P&L systematically 5-13pp **below** the Yahoo-price-derived return. That is a data-source discrepancy, not an aggregation issue, and is unaffected by this change. Flagged for separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)