### PR TITLE
fix(universe): the instruments endpoint returns 2,555 lines nobody can buy

### DIFF
--- a/scripts/refresh_etoro_universe.py
+++ b/scripts/refresh_etoro_universe.py
@@ -28,6 +28,41 @@ STOCK_TYPE_ID = 5
 ETF_TYPE_ID = 6
 MIN_INSTRUMENTS_THRESHOLD = 1000
 
+#: How much of the typed catalogue the openable filter may remove before it is treated as a
+#: payload change rather than a market fact. Measured 2026-08-26: 2,555 of 14,332 = **17.8%**.
+#: A ceiling rather than an equality because eToro adds and retires lines continuously; what it
+#: catches is the field going away entirely, which would silently gut the universe.
+_MAX_OPENABLE_DROP_FRACTION = 0.40
+
+
+def is_openable(item: dict) -> bool:
+    """Will eToro let an account OPEN a position in this instrument?
+
+    **THE MARKER IS THE KEY'S ABSENCE, NOT ITS VALUE**, and getting that backwards is easy: on
+    the live payload the close-only block simply omits ``distributionType``, while every openable
+    row carries it as ``5``. Measured on the 2026-08-26 catalogue, and it is a clean partition:
+
+        key present : 11,777 of 11,777 rows below instrumentID 1,000,000
+        key absent  :  2,555 of  2,555 rows at or above it
+
+    ``dict.get`` COLLAPSES ABSENT AND NULL and reports both as ``None``, which is exactly how the
+    first version of this function came to test the value and drop nothing at all. A dry run
+    against the live payload is what caught it; ``"key" in item`` is the only form that answers
+    the question actually being asked.
+
+    Validated against eToro's own account-eligibility endpoint at n=400: rows with no
+    ``distributionType`` answered ``allow_open=False`` 199 times out of 200, rows with it
+    answered ``True`` 162 of 200 (the rest are per-account bars, which are a different layer's
+    problem). See :func:`fetch_all_instruments`.
+
+    A NEW VALUE WOULD BE KEPT. This asks whether eToro said anything at all, so a third
+    ``distributionType`` appearing tomorrow reads as openable rather than silently shrinking the
+    universe. The catastrophic case — eToro dropping the field for everyone — is caught by the
+    refusal in :func:`fetch_all_instruments` rather than by guessing here.
+    """
+    return "distributionType" in item
+
+
 EXCHANGE_NAMES: dict[int, str] = {
     2: "NYSE",
     4: "Nasdaq",
@@ -553,8 +588,34 @@ def fetch_all_instruments(
 ) -> list[dict]:
     """Fetch all instruments from the market-data API (single call, no pagination).
 
-    Filters to Stocks (type 5) and ETFs (type 6), then maps fields to the
-    format expected by the rest of the pipeline.
+    Filters to Stocks (type 5) and ETFs (type 6) AND to instruments eToro will let an account
+    OPEN, then maps fields to the format expected by the rest of the pipeline.
+
+    **THE TYPE FILTER ALONE LET IN 2,555 INSTRUMENTS NOBODY CAN BUY** (2026-08-26). This endpoint
+    returns everything eToro DISPLAYS, which is a superset of what it will open a position in:
+    alongside the tradable catalogue it carries a block of close-only lines — you may hold one
+    and sell it, but you may not open it. They are indistinguishable by symbol, name or exchange.
+
+    Measured against eToro's own account-eligibility endpoint on a sample of 400, and the
+    separation is clean:
+
+        distributionType is None  ->  199 of 200 answered allow_open=FALSE
+        distributionType == 5     ->  162 of 200 answered allow_open=TRUE
+
+    The same partition holds exactly against ``/market-data/search``, which is the endpoint
+    eToro's own order routing uses: 0 of 2,555 of the ``None`` block appear in it, against 10,535
+    of 11,777 of the ``5`` block.
+
+    KEYED ON ``distributionType``, NOT ON THE INSTRUMENT ID. The two agree perfectly today — the
+    ``None`` block is exactly the ids at or above 1,000,000 — but an id range is a coincidence of
+    when eToro created the rows, and it would go wrong the day they renumber. A field that says
+    something is a rule; a number that happens to line up is not.
+
+    RESIDUAL, STATED: about 1 name in 200 of the excluded block DOES answer ``allow_open=True``,
+    so this drops roughly a dozen openable instruments to remove ~2,540 unopenable ones. That is
+    the trade, and it is the right way round — a universe that recommends what cannot be bought
+    costs a human triage on every run, while a dozen missing micro-listings cost nothing
+    measurable in a 10,000-name cross-section.
     """
     last_error: str | None = None
     for attempt in range(1, max_retries + 1):
@@ -569,9 +630,34 @@ def fetch_all_instruments(
             response = requests.get(INSTRUMENTS_URL, headers=headers, timeout=_HTTP_TIMEOUT_SEC)
             if response.status_code == 200:
                 raw = response.json().get("instrumentDisplayDatas", [])
-                filtered = [
+                typed = [
                     i for i in raw if i.get("instrumentTypeID") in (STOCK_TYPE_ID, ETF_TYPE_ID)
                 ]
+                filtered = [i for i in typed if is_openable(i)]
+                dropped = len(typed) - len(filtered)
+                if typed and not filtered:
+                    # THE FIELD STOPPED DISCRIMINATING. Every row failed the openable test, which
+                    # means eToro changed the payload rather than delisting its whole catalogue.
+                    # Refusing here keeps the last good universe on disk; the alternative is an
+                    # empty CSV and a model with nothing to score.
+                    raise RuntimeError(
+                        f"fetch_all_instruments: distributionType excluded ALL {len(typed)} "
+                        f"stocks/ETFs. The field has changed meaning — refusing to write an "
+                        f"empty universe. Inspect the payload before re-running."
+                    )
+                # THE CEILING NEEDS A SAMPLE TO BE A RATIO OF. Below a plausible catalogue
+                # size this says nothing — 1 of 2 is 50% and means nothing at all — and
+                # `MIN_INSTRUMENTS_THRESHOLD` already refuses a payload that small at :754.
+                if (
+                    len(typed) >= MIN_INSTRUMENTS_THRESHOLD
+                    and dropped / len(typed) > _MAX_OPENABLE_DROP_FRACTION
+                ):
+                    raise RuntimeError(
+                        f"fetch_all_instruments: the openable filter dropped {dropped} of "
+                        f"{len(typed)} ({dropped / len(typed):.0%}), above the "
+                        f"{_MAX_OPENABLE_DROP_FRACTION:.0%} ceiling. Expected ~18%. Refusing to "
+                        f"write; inspect the payload."
+                    )
                 items = []
                 for i in filtered:
                     items.append(

--- a/tests/unit/scripts/test_refresh_etoro_universe.py
+++ b/tests/unit/scripts/test_refresh_etoro_universe.py
@@ -264,6 +264,7 @@ class TestFetchAllInstruments:
                     "instrumentDisplayName": "Apple",
                     "instrumentTypeID": 5,
                     "exchangeID": 4,
+                    "distributionType": 5,
                 },
                 {
                     "instrumentID": 2001,
@@ -271,6 +272,7 @@ class TestFetchAllInstruments:
                     "instrumentDisplayName": "SPDR S&P 500",
                     "instrumentTypeID": 6,
                     "exchangeID": 4,
+                    "distributionType": 5,
                 },
             ]
         }
@@ -309,6 +311,7 @@ class TestFetchAllInstruments:
                             "instrumentDisplayName": "X",
                             "instrumentTypeID": 5,
                             "exchangeID": 4,
+                            "distributionType": 5,
                         },
                     ]
                 },
@@ -735,3 +738,105 @@ class TestPlaceholderCodesBeyondTheCAFamily:
         """IPO.L is IP Group PLC. A prefix rule on the SYMBOL would delete it; the rule keys
         on the company name being the code, so it survives."""
         assert normalize_symbol("IPO.L", "IP Group PLC") == "IPO.L"
+
+
+class TestOpenableFilter:
+    """eToro's ``/market-data/instruments`` returns everything it DISPLAYS, which is a superset
+    of what it will let an account OPEN. Measured 2026-08-26: 2,555 of 14,332 stocks+ETFs are a
+    close-only block — holdable and sellable, not buyable — and they are indistinguishable by
+    symbol, name or exchange. They reached the model as BUY recommendations that could not be
+    placed; three of one day's ten buys were dead this way.
+
+    ``distributionType`` separates them cleanly. Validated against eToro's own account-eligibility
+    endpoint at n=400: ``None`` -> 199/200 answered ``allow_open=False``; ``5`` -> 162/200 True.
+    """
+
+    def test_the_marker_is_the_KEYS_ABSENCE_not_its_value(self):
+        """Measured on the live payload: the close-only block OMITS ``distributionType``; every
+        openable row carries it as 5. The first version of this function tested the VALUE and
+        dropped nothing at all, because ``dict.get`` reports absent and null identically."""
+        assert refresh_etoro_universe.is_openable({"distributionType": 5}) is True
+        assert refresh_etoro_universe.is_openable({}) is False
+        assert refresh_etoro_universe.is_openable({"symbolFull": "ACL.ASX"}) is False
+
+    def test_an_UNRECOGNISED_value_is_kept(self):
+        """It asks whether eToro said anything at all, so a third value appearing tomorrow reads
+        as openable rather than silently shrinking the universe."""
+        assert refresh_etoro_universe.is_openable({"distributionType": 7}) is True
+        assert refresh_etoro_universe.is_openable({"distributionType": "whatever"}) is True
+
+    def test_an_explicit_NULL_is_still_openable_and_that_is_deliberate(self):
+        """eToro does not currently send null — it omits the key. If it ever starts, that is a
+        NEW shape nobody has measured, and the permissive direction is the safe one: the
+        fail-closed control is the per-order broker refusal, not this generator."""
+        assert refresh_etoro_universe.is_openable({"distributionType": None}) is True
+
+    def test_fetch_drops_the_close_only_rows(self):
+        api_response = {
+            "instrumentDisplayDatas": [
+                {
+                    "instrumentID": 1001,
+                    "symbolFull": "AAPL",
+                    "instrumentDisplayName": "Apple",
+                    "instrumentTypeID": 5,
+                    "exchangeID": 4,
+                    "distributionType": 5,
+                },
+                {
+                    "instrumentID": 1001690,
+                    "symbolFull": "ACL.ASX",
+                    "instrumentDisplayName": "Australian Clinical Labs",
+                    "instrumentTypeID": 5,
+                    "exchangeID": 31,
+                },  # no distributionType: the real shape
+            ]
+        }
+        with patch.object(refresh_etoro_universe.requests, "get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=200, json=lambda: api_response)
+            result = fetch_all_instruments("api", "user")
+        assert [r["symbol"] for r in result] == ["AAPL"], (
+            "ACL.ASX is real, listed and displayed — and eToro answered allow_open=False for it"
+        )
+
+    def test_it_REFUSES_rather_than_writing_an_empty_universe(self):
+        """If every row fails the test, the field changed meaning — eToro did not delist its
+        whole catalogue. Raising keeps the last good CSV on disk."""
+        api_response = {
+            "instrumentDisplayDatas": [
+                {
+                    "instrumentID": i,
+                    "symbolFull": f"X{i}",
+                    "instrumentDisplayName": "x",
+                    "instrumentTypeID": 5,
+                    "exchangeID": 4,
+                }
+                for i in range(5)
+            ]
+        }
+        with patch.object(refresh_etoro_universe.requests, "get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=200, json=lambda: api_response)
+            with pytest.raises(RuntimeError, match="excluded ALL"):
+                fetch_all_instruments("api", "user")
+
+    def test_it_REFUSES_an_implausibly_large_drop(self):
+        """~18% is the measured shape. A ceiling catches the field inverting, which would gut the
+        universe without emptying it — the failure a floor on the absolute count cannot see."""
+        # A PLAUSIBLE CATALOGUE SIZE, because the ceiling is a ratio and a ratio of two rows
+        # is noise. `MIN_INSTRUMENTS_THRESHOLD` is what refuses a payload smaller than this.
+        rows = [
+            {
+                "instrumentID": i,
+                "symbolFull": f"X{i}",
+                "instrumentDisplayName": "x",
+                "instrumentTypeID": 5,
+                "exchangeID": 4,
+                **({} if i < 900 else {"distributionType": 5}),
+            }
+            for i in range(1000)
+        ]
+        with patch.object(refresh_etoro_universe.requests, "get") as mock_get:
+            mock_get.return_value = MagicMock(
+                status_code=200, json=lambda: {"instrumentDisplayDatas": rows}
+            )
+            with pytest.raises(RuntimeError, match="above the"):
+                fetch_all_instruments("api", "user")


### PR DESCRIPTION
## `/market-data/instruments` returns 2,555 lines nobody can buy

That endpoint returns everything eToro **displays**, which is a superset of what it will let an
account **open**. Alongside the tradable catalogue it carries a close-only block — holdable and
sellable, not buyable — and they are indistinguishable by symbol, name or exchange.

They have been flowing into `input/etoro.csv`, through the signals pipeline, and out as BUY
recommendations that cannot be placed. **Three of one day's ten buys were dead this way**:
ACL.AX, BVS.AX, SKS.AX — all real, listed, displayed Australian companies.

## The marker is the *absence* of `distributionType`

Measured on the 2026-08-26 catalogue — a clean partition:

```
key present : 11,777 of 11,777 rows below instrumentID 1,000,000
key absent  :  2,555 of  2,555 rows at or above it
```

Validated against eToro's **own account-eligibility endpoint** at n=400:

| | `allow_open=True` | `False` |
|---|---|---|
| key absent | 1 | **199** |
| key present | **162** | 38 |

The remaining 38 are per-account bars — a different layer's problem. The same partition holds
exactly against `/market-data/search`, the endpoint eToro's order routing uses: **0 of 2,555** of
the absent block appear there, against 10,535 of 11,777 of the present one.

**Keyed on the field, not the ID range.** The two agree perfectly today, but an id range is a
coincidence of when eToro created the rows and would go wrong the day they renumber.

**`dict.get` collapses absent and null.** The first version of this tested the *value*, dropped
nothing at all, and passed every unit test. A dry run against the live payload is what caught it.
`"key" in item` is the only form that answers the question being asked.

## Guards

This file decides what the model may ever consider, so:

- **refuse outright** if the filter excludes every row — that means the field changed meaning, not
  that eToro delisted its catalogue, and the last good CSV should stay on disk;
- **refuse** if it removes >40% of a plausible catalogue (measured shape: 17.8%), which catches
  the field inverting — a failure a floor on the absolute count cannot see;
- the ratio guard only applies at or above `MIN_INSTRUMENTS_THRESHOLD`, because a ratio of two
  rows is noise and the existing floor already refuses a payload that small.

## Dry run against the live payload

```
payload 16,152 -> typed 14,332 -> openable 11,777   (dropped 2,555 = 17.8%)
universe 12,840 -> 10,318   removed 2,533   added 11
  ACL.AX / BVS.AX / SKS.AX removed : yes
  every currently held name kept   : yes
```

91 tests pass; ruff and the pre-commit suite (including secret detection) clean.

**Residual, stated:** ~1 in 200 of the excluded block does answer `allow_open=True`, so this drops
roughly a dozen openable instruments to remove ~2,540 unopenable ones.

**Not triggered.** This lands the code only; `weekly-universe-refresh` applies it on its Sunday
cron. The ~20% universe change re-ranks the whole cross-section and deserves to be watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
