### PR TITLE
chore(deps): raise the aiohttp, lxml and requests floors to what is already locked

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6475,4 +6475,4 @@ smoketest = ["pytest", "pytest-rerunfailures"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "195fb0c31d0f8abd8190e665951ff80c2610ed6a2e12bb4c3ce031728f82895b"
+content-hash = "72bea11460a02c8e8d874c3b88241923a701fd991384ae3dfa4c2c687173d247"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6475,4 +6475,4 @@ smoketest = ["pytest", "pytest-rerunfailures"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "2a5f317371a65b7855d9d0633eec0800803b4b97ef2889f40be06dfcf34769c9"
+content-hash = "195fb0c31d0f8abd8190e665951ff80c2610ed6a2e12bb4c3ce031728f82895b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
     "numpy>=2.2.6,<3.0.0",
     "matplotlib>=3.4.0,<4.0.0",
     "yfinance==1.7.0",
-    "lxml>=5.0.0",  # yfinance declares lxml>=4.9.0 itself; this only raises the floor to 5.x
+    "lxml>=6.1.1",  # yfinance declares lxml>=4.9.0 itself; floor raised to 6.1.1, the value the sibling pts-signals package declares (this repo locks 6.1.2, above it)
     "yahooquery>=2.3.7",
-    "requests>=2.25.0,<3.0.0",
+    "requests>=2.34.2,<3.0.0",
     "urllib3>=2.7.0",  # CVE-2026-44431/44432: decompression-bomb safeguard bypass in <2.7.0
     "scipy>=1.10.0",
     "pyarrow>=14.0.0",
@@ -38,7 +38,7 @@ dependencies = [
     "colorama>=0.4.4",
     "python-dateutil>=2.8.0",
     "pytz>=2021.1",
-    "aiohttp>=3.14.1",  # GHSA: multiple advisories (req smuggling, parser, etc.) fixed in 3.14.1
+    "aiohttp>=3.14.3",  # GHSA-cq5v-8q36-5273 (high, OOB heap read in C response parser) fixed in 3.14.3; 3.14.2 fixed two more websocket/smuggling advisories
     "aiofiles>=25.1.0",
     "selenium>=4.1.0",
     "python-dotenv>=1.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,12 @@ dependencies = [
     "yfinance==1.7.0",
     "lxml>=6.1.1",  # yfinance declares lxml>=4.9.0 itself; floor raised to 6.1.1, the value the sibling pts-signals package declares (this repo locks 6.1.2, above it)
     "yahooquery>=2.3.7",
-    "requests>=2.34.2,<3.0.0",
+    # Deliberately UNCAPPED, unlike its pandas/numpy/matplotlib neighbours.
+    # The old <3.0.0 arrived as house style in a6d608b2 with no comment, no
+    # issue and no rationale; it binds nothing (no requests 3.x exists) while
+    # keeping this repo permanently divergent from the pts-* packages, which
+    # declare a bare >=2.34.2. Owner accepted the inconsistency (D1).
+    "requests>=2.34.2",
     "urllib3>=2.7.0",  # CVE-2026-44431/44432: decompression-bomb safeguard bypass in <2.7.0
     "scipy>=1.10.0",
     "pyarrow>=14.0.0",


### PR DESCRIPTION
## What

Three declared dependency floors were below the versions this repo already resolves, installs and tests against. This raises them to match, and drops one upper bound.

| dep | from | to | locked today |
|---|---|---|---|
| `aiohttp` | `>=3.14.1` | `>=3.14.3` | 3.14.3 |
| `lxml` | `>=5.0.0` | `>=6.1.1` | 6.1.2 |
| `requests` | `>=2.25.0,<3.0.0` | `>=2.34.2` (cap **dropped**) | 2.34.2 |

## `requests`: the `<3.0.0` cap is deliberately removed

This is the one edit here that is not purely mechanical, so it gets its own section. **Owner decision (D1).**

The cap has **no recorded rationale**. It arrived in `a6d608b2` "Migrate project metadata from setup.py to pyproject.toml" as house style, alongside identical caps on `pandas`, `numpy` and `matplotlib`, with no comment and no issue. Its `lxml` / `urllib3` / `aiohttp` neighbours all carry a written reason; this one never did.

It **binds nothing**. No requests 3.x has ever been published, so removing it changes no resolution today. Confirmed below: requests still exports as 2.34.2 and all three requirements files are byte-identical.

It was **the entire divergence**. The four `pts-*` packages declare a bare `requests>=2.34.2`. With the cap kept, `>=2.34.2,<3.0.0` and `>=2.34.2` are two distinct requirement keys, so raising the floor alone would have left the cross-repo drift report carrying an amber `requests` row *forever*. That is the trained-noise failure that eventually masks a real divergence.

**Stated plainly, because it is the real cost: this makes `requests` the one major dependency this repo does not cap, against its own house style. The owner accepted that inconsistency deliberately.** The comment in `pyproject.toml` records it, so nobody restores the cap "for consistency" in six months without knowing it was removed on purpose.

## Why the other two

**`aiohttp`** is the only one with a security argument. `GHSA-cq5v-8q36-5273` (high severity, an out-of-bounds heap read in the C response parser) is fixed in 3.14.3, and 3.14.2 fixed two further websocket / request-smuggling advisories. The old `>=3.14.1` floor admitted all three. Nothing was ever *installed* at a vulnerable version here, since the lock has held 3.14.3, but a fresh install resolved from `pyproject.toml` alone was permitted to land on one.

**`lxml`** goes to **6.1.1, not the 6.1.2 in the lockfile**, and that is deliberate. 6.1.1 is the value the sibling `pts-signals` package declares (`packages/signals/pyproject.toml:14`), so the two declarations converge on one string rather than merely on one resolved version. The comment states this explicitly, because the obvious phrasing ("the version this repo already locks") would have been false.

## No resolution moves, and this is the load-bearing claim

Every target equals what the lock already holds, so nothing re-resolves. Verified rather than assumed:

```
$ scripts/dev/relock.sh        # plain, NOT --regenerate
$ git diff --stat
 poetry.lock    | 2 +-
 pyproject.toml | 7 ++++++-
```

The entire `poetry.lock` diff is the `content-hash` line. No `[[package]]` version block moved. All three committed `requirements-*-lock.txt` exports came back **byte-identical**, so they do not appear in the diff at all, which is exactly what the `lockfile-sync` CI job checks.

```
$ poetry check --lock --no-interaction
All set!
$ grep -m1 '^requests==' requirements-lock.txt
requests==2.34.2 ; python_version >= "3.10" and python_version < "4.0"
```

`--regenerate` was **not** used. Plain `poetry lock` in Poetry 2.x keeps every already-locked package where it is and only moves what `pyproject.toml` forces; `--regenerate` discards the lock and re-resolves from scratch, which would have dragged unrelated transitive bumps into a dependency-hygiene commit.

## Known consequence, so nobody chases it as a regression

The moment this merges, and until the VPS `vps-pyenv-3.14.5` interpreter is updated, the nightly health check will report a true `deps.violations` row: that pyenv holds **aiohttp 3.14.1**, which is now outside this repo's declared `>=3.14.3`. That is a correct statement about an unmanaged interpreter running a version with a known high-severity advisory, not a fault introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
