### PR TITLE
perf(ci): take the per-ticker momentum fetch off the CI path

### DIFF
--- a/tests/unit/trade_modules/test_momentum_factor.py
+++ b/tests/unit/trade_modules/test_momentum_factor.py
@@ -4,7 +4,11 @@ Validates the core computation, edge cases, series-based calculation,
 and integration with the signal tracker.
 """
 
+import logging
+from unittest.mock import MagicMock, patch
+
 import numpy as np
+import pytest
 
 from trade_modules.analysis.momentum import (
     compute_momentum_12_1m,
@@ -155,3 +159,134 @@ class TestSignalTrackerIntegration:
         }
         record = SignalRecord.from_dict(old_data)
         assert record.momentum_12_1m is None
+
+
+class _MomentumSpy:
+    """Records every call to fetch_momentum_for_ticker and returns a fixed value.
+
+    fetch_momentum_for_ticker() is the sole entry point to the per-ticker
+    yfinance history() call, so "this spy was not called" is exactly
+    "no network fetch was attempted".
+    """
+
+    def __init__(self, value: float = 42.5):
+        self.calls: list[str] = []
+        self.value = value
+
+    def __call__(self, ticker: str) -> float:
+        self.calls.append(ticker)
+        return self.value
+
+
+@pytest.fixture
+def momentum_harness(monkeypatch):
+    """Drive log_signal() with every side effect except the momentum fetch stubbed.
+
+    Yields ``run(**env)`` -> ``(spy, record)``. Keys of ``env`` are applied to
+    os.environ; a value of None deletes the variable. ``record`` is the
+    SignalRecord log_signal() handed to the tracker, i.e. exactly what would
+    have been written to signal_log.jsonl.
+    """
+    import trade_modules.signal_tracker as st
+
+    def run(**env):
+        spy = _MomentumSpy()
+        for key in ("CI", "GITHUB_ACTIONS"):
+            value = env.get(key)
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+
+        captured: list = []
+        tracker = MagicMock()
+        tracker.log_signal.side_effect = lambda record: (captured.append(record), True)[1]
+
+        with (
+            patch("trade_modules.analysis.momentum.fetch_momentum_for_ticker", spy),
+            patch("trade_modules.vix_regime_provider.get_current_vix", return_value=None),
+            patch("trade_modules.regime_detector.get_current_regime", return_value=None),
+            patch.object(st, "_get_spy_price", return_value=None),
+            patch.object(st, "get_tracker", return_value=tracker),
+        ):
+            st.log_signal(ticker="AAPL", signal="H", price=100.0)
+
+        return spy, (captured[0] if captured else None)
+
+    return run
+
+
+class TestMomentumFetchIsOffTheCIPath:
+    """The per-ticker momentum fetch is skipped in CI and unchanged locally.
+
+    In CI signal_log.jsonl is destroyed with the runner, so the ~16 minutes of
+    per-ticker yfinance history() calls produce records that are thrown away.
+    Locally the records are the point, so nothing may change there.
+    """
+
+    def test_fetch_IS_attempted_when_not_in_ci(self, momentum_harness):
+        """POSITIVE CONTROL: without the CI vars the fetch still runs.
+
+        Without this, the skip assertions below cannot tell "the guard worked"
+        from "log_signal never reached the momentum branch at all".
+        """
+        spy, record = momentum_harness(CI=None, GITHUB_ACTIONS=None)
+
+        assert spy.calls == ["AAPL"], "local runs must still fetch momentum"
+        assert record is not None
+        assert record.momentum_12_1m == 42.5, "the fetched value must reach the record"
+
+    def test_fetch_is_NOT_attempted_when_ci_is_true(self, momentum_harness):
+        spy, record = momentum_harness(CI="true", GITHUB_ACTIONS=None)
+
+        assert spy.calls == [], "CI must not pay for a record it throws away"
+        assert record is not None, "the signal itself must still be logged"
+        assert record.momentum_12_1m is None
+
+    def test_fetch_is_NOT_attempted_when_github_actions_is_true(self, momentum_harness):
+        spy, record = momentum_harness(CI=None, GITHUB_ACTIONS="true")
+
+        assert spy.calls == []
+        assert record is not None
+        assert record.momentum_12_1m is None
+
+    def test_a_non_true_ci_value_does_NOT_skip(self, momentum_harness):
+        """Pins the exact comparison the rest of the suite uses (== "true").
+
+        CI=1 / CI=false are not the convention and must not silently disable a
+        local scan that happens to export CI for some other reason.
+        """
+        spy, _ = momentum_harness(CI="1", GITHUB_ACTIONS="false")
+
+        assert spy.calls == ["AAPL"]
+
+    def test_the_skip_is_ANNOUNCED_not_silent(self, momentum_harness, caplog):
+        """A silently absent column is how the next person loses a morning."""
+        import trade_modules.signal_tracker as st
+
+        st._MOMENTUM_CI_NOTICE_EMITTED = False
+        with caplog.at_level(logging.INFO, logger="trade_modules.signal_tracker"):
+            momentum_harness(CI="true", GITHUB_ACTIONS=None)
+
+        notices = [r for r in caplog.records if "momentum_12_1m logging disabled" in r.getMessage()]
+        assert len(notices) == 1, "expected exactly one INFO notice naming the skip"
+        assert notices[0].levelno == logging.INFO
+
+    def test_the_announcement_is_once_per_run_not_per_ticker(self, momentum_harness, caplog):
+        """157k records a night must not become 157k identical log lines."""
+        import trade_modules.signal_tracker as st
+
+        st._MOMENTUM_CI_NOTICE_EMITTED = False
+        with caplog.at_level(logging.INFO, logger="trade_modules.signal_tracker"):
+            momentum_harness(CI="true", GITHUB_ACTIONS=None)
+            momentum_harness(CI="true", GITHUB_ACTIONS=None)
+            momentum_harness(CI="true", GITHUB_ACTIONS=None)
+
+        notices = [r for r in caplog.records if "momentum_12_1m logging disabled" in r.getMessage()]
+        assert len(notices) == 1, "the notice must be emitted once per process"
+
+    def test_the_momentum_module_still_works_in_ci(self):
+        """Only the invocation is gated; the code itself is untouched."""
+        prices = [100.0] * 231 + [120.0] * 21
+        assert compute_momentum_from_series(prices) == 20.0
+        assert compute_momentum_12_1m(130, 125, 100) == 25.0

--- a/trade_modules/signal_tracker.py
+++ b/trade_modules/signal_tracker.py
@@ -12,6 +12,7 @@ this system enables forward validation of signal quality.
 
 import json
 import logging
+import os
 import re
 import threading
 from datetime import datetime, timedelta
@@ -437,6 +438,44 @@ def get_tracker() -> SignalTracker:
     return _tracker
 
 
+# --- Momentum logging on the CI path ----------------------------------------
+# fetch_momentum_for_ticker() does one yfinance history(period="14mo") call PER
+# TICKER (~0.7s measured; 10.17s of a 46.1s 20-ticker run, ~16 min across a
+# nightly universe scan). The value is recorded, never consumed: the only code
+# that reads the momentum_12_1m column is analysis/composite_score.py, which is
+# shadow-mode and has no production caller, so skipping the fetch cannot move a
+# signal. In CI signal_log.jsonl is destroyed with the runner, so the records
+# the fetch produces there are discarded anyway.
+#
+# Local behaviour is deliberately unchanged -- the records are the point locally.
+# Detected with the same signal the test suite already uses for CI; see
+# tests/unit/trade_modules/test_analysis_engine_coverage.py.
+_MOMENTUM_CI_NOTICE_EMITTED = False
+
+
+def _momentum_logging_disabled() -> bool:
+    """Whether to skip the per-ticker momentum fetch. True only under CI.
+
+    Announces the skip once per process at INFO, so an absent momentum_12_1m
+    column in a CI artifact is never a silent surprise to whoever finds it.
+    """
+    global _MOMENTUM_CI_NOTICE_EMITTED
+
+    if os.environ.get("CI") != "true" and os.environ.get("GITHUB_ACTIONS") != "true":
+        return False
+
+    if not _MOMENTUM_CI_NOTICE_EMITTED:
+        _MOMENTUM_CI_NOTICE_EMITTED = True
+        logger.info(
+            "momentum_12_1m logging disabled: CI detected. The per-ticker yfinance "
+            "history fetch costs ~16 min across a universe scan, and signal_log.jsonl "
+            "is destroyed with the runner, so those records would be discarded. "
+            "No signal output is affected -- the field is recorded, never consumed. "
+            "Local runs still fetch every record; unset CI/GITHUB_ACTIONS to re-enable."
+        )
+    return True
+
+
 def log_signal(
     ticker: str,
     signal: str,
@@ -527,14 +566,16 @@ def log_signal(
     except (ImportError, Exception):
         pass
 
-    # Compute 12-1m momentum factor (Jegadeesh-Titman skip-month)
+    # Compute 12-1m momentum factor (Jegadeesh-Titman skip-month).
+    # Skipped on the CI path only -- see _momentum_logging_disabled().
     momentum_12_1m = None
-    try:
-        from trade_modules.analysis.momentum import fetch_momentum_for_ticker
+    if not _momentum_logging_disabled():
+        try:
+            from trade_modules.analysis.momentum import fetch_momentum_for_ticker
 
-        momentum_12_1m = fetch_momentum_for_ticker(ticker)
-    except (ImportError, Exception):
-        pass
+            momentum_12_1m = fetch_momentum_for_ticker(ticker)
+        except (ImportError, Exception):
+            pass
 
     record = SignalRecord(
         ticker=ticker,


### PR DESCRIPTION
## What this does

`signal_tracker.log_signal()` calls `fetch_momentum_for_ticker()` **once per ticker**, and that function does a live `yf.Ticker(ticker).history(period="14mo")` network round trip (`trade_modules/analysis/momentum.py:75`). Stack-sampled on a 20-ticker run: **14 calls, 10.17s of 46.1s total** (~0.73s/ticker), roughly **16 minutes across a nightly universe scan**.

This PR skips that fetch **on the CI path only**. Nothing else changes.

## This changes NO signal output

The momentum value is **recorded, never consumed**. Evidence, traced from the production entry point:

- `momentum_12_1m` appears in exactly four non-test places: `analysis/momentum.py` (produces it), `signal_tracker.py` (stores/serialises it at `:177`, `:216`), and `analysis/composite_score.py:73` (reads it).
- **`composite_score.py` is the only reader, and it has no production caller.** Its sole importer in the entire repo is its own unit test, `tests/unit/trade_modules/test_composite_score.py`. Its module docstring says so itself: *"SHADOW MODE: This score is captured in the signal log for forward validation. It does NOT change the BS column or any live signal."*
- No signal, filter, sort, threshold or ranking reads the field. `grep -rn momentum_12_1m` over `riskfirst/`, `signals_v2/`, `committee_v2/` and `pipeline_v2/` returns **zero hits**.
- The similarly-named things are **different concepts** and are untouched: `analyst_momentum` (the `AM` column), the dual-track "momentum track", and `riskfirst/factors/momentum.py` — which uses `52W` + `AM` proxies and documents in its own header that the canonical 12-1 signal is *not* implemented there.
- Structurally decisive: `log_signal(signal=actions.loc[idx], ...)` takes the already-computed signal as an **input**. The fetch happens strictly *after* the decision exists. It cannot feed back into it.

## The records skipped in CI were being discarded anyway

`signal_log.jsonl` never survives a runner, confirmed three independent ways:

1. `git ls-files "*signal_log*"` returns nothing — **the file is not tracked**.
2. `.gitignore:212` ignores `yahoofinance/output/signal_log.jsonl` explicitly.
3. `daily-signals.yml`'s commit step only `git add`s `yahoofinance/output/*.csv`, `input/portfolio.csv`, `input/yfinance_skip.csv` and `snapshots/*.csv`. A `.jsonl` matches none of those globs.

So on a runner this fetch buys a record that is deleted minutes later. The 84MB / 157,400-record local log is built entirely by local runs, and those are untouched.

Worth noting where the time actually is: `daily-signals.yml` runs **6 parallel `scan` shards over ~12,808 tickers**, each shard's `trade e` step taking ~1h42m. GitHub Actions sets `CI=true` on those runners too, so they get the saving as well — and they discard the log for the same reason.

## Local behaviour is byte-identical, and that is tested

The **positive control** is the point of the test, not decoration: `test_fetch_IS_attempted_when_not_in_ci` asserts the fetch **is** attempted and its value **reaches the `SignalRecord`** when the CI vars are absent. Without a sibling that can tell "the guard worked" from "the code path never ran at all", asserting a counter is 0 proves nothing.

Verified against the real network at the `yfinance` layer (spying on `yf.Ticker` itself, one level *below* the wrapper, so mocking the wrapper cannot fool it):

```
no CI vars (LOCAL)      yf.Ticker calls=['AAPL']   momentum=45.07
CI=true                 yf.Ticker calls=[]         momentum=None
GITHUB_ACTIONS=true     yf.Ticker calls=[]         momentum=None
```

## Design notes

- **Same signal CI already uses**, no new env var: `os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true"` — the convention already in `test_analysis_engine_coverage.py:140`, `test_analysis_engine.py:192`/`:325`, `test_trade_engine_integration.py:636`. A test pins the exact `== "true"` comparison so `CI=1` does not silently disable a local scan.
- **No workflow file is edited.** GitHub Actions sets both vars automatically, so this is a code-only change.
- **The skip is announced, not silent** — one INFO line per process naming the reason, with a test that it fires exactly once (157k records a night must not become 157k log lines). A silently absent column is how the next person loses a morning.
- **The momentum code is not deleted and still works.** Only the invocation from `log_signal` is gated; a test asserts the module still computes correctly.
- Guarding the single fetch point covers **all nine `log_signal` call sites** in `analysis/signals.py`, rather than nine separate edits.

## Verification

Full suite via CI's own pytest invocation, `CI=true GITHUB_ACTIONS=true`, isolated worktree venv on Python 3.12:

```
5327 passed, 56 skipped, 38 warnings, 61 subtests passed in 831.83s
Required test coverage of 58% reached. Total coverage: 64.40%
```

**Zero failures.** The 56 skips include the four wall-clock assertions CI always skips (`test_vectorization_performance` among them) — they are the pre-existing CI baseline, not coverage lost here. Blocking `flake8 --select=E9,F63,F7,F82`: clean. The non-blocking `--exit-zero` pass reports the same 3 pre-existing `C901`s as master; `log_signal` moves 12 → 13 for the one added branch.

Local wall-clock before/after was **not** measured: several suites were running concurrently on the same machine, so a local timing would be noise. The trustworthy before/after is this PR's own GitHub Actions job durations against master's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
