### PR TITLE
ci: allow CI to be dispatched, to rehearse the full-history secrets scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
   schedule:
     # Run nightly at 2 AM UTC for integration tests
     - cron: '0 2 * * *'
+  # gitleaks-action scopes its scan by event: push and pull_request get a
+  # --log-opts range, everything else scans full history (src/index.js routes
+  # workflow_dispatch and schedule through the same branch). So a dispatch is
+  # the only way to rehearse the nightly full-history secrets scan without
+  # waiting for 02:00 UTC, which is what this repo needed on 2026-09-10 when
+  # the gitleaks version pin had to be validated.
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
`gitleaks-action` scopes its scan by event. At the pinned SHA `e0c47f4f`, [`src/index.js:176`](https://github.com/gitleaks/gitleaks-action/blob/e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e/src/index.js#L176) routes `workflow_dispatch` and `schedule` through one identical branch, and [`src/gitleaks.js:103-117`](https://github.com/gitleaks/gitleaks-action/blob/e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e/src/gitleaks.js#L103-L117) adds `--log-opts` **only** for `push` and `pull_request`. So schedule and dispatch both scan full history; push and PR do not.

That asymmetry is why the gitleaks pin in ae8940a5 could not be validated on demand:

- scheduled run [34447345179](https://github.com/weirdapps/etorotrade/actions/runs/34447345179) — gitleaks 8.24.3, no `--log-opts`, full history, `leaks found: 4`
- push run [34466054073](https://github.com/weirdapps/etorotrade/actions/runs/34466054073) — gitleaks 8.30.1, `--log-opts=-1`, one commit, green and therefore meaningless as proof

Adding `workflow_dispatch` makes the full-history scan reachable without waiting for 02:00 UTC.

**Local control run** (gitleaks 8.30.1, this repo's `.gitleaks.toml`, full history): 1460 commits / 334.73 MB scanned, `no leaks found`. Confirms 8.30.1 honours the top-level `[[allowlists]]` that 8.24.3 silently ignored.

No inputs, no change to the existing triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
