### PR TITLE
weekly-backtest: five green runs delivered nothing, because the paths are ignored

### DIFF
--- a/.github/workflows/weekly-backtest.yml
+++ b/.github/workflows/weekly-backtest.yml
@@ -84,11 +84,36 @@ jobs:
 
       - name: Commit backtest outputs
         run: |
-          git add yahoofinance/output/backtest_results.csv || true
-          git add yahoofinance/output/backtest_summary.csv || true
-          git add yahoofinance/output/backtest_threshold_report.csv || true
-          git add yahoofinance/output/backtest_report.json || true
-          git add data/committee/action_log.jsonl || true
+          # -f is required, and `|| true` was hiding why. Four of these five are
+          # ignored: the three backtest_*.csv by .gitignore:209, and
+          # backtest_report.json by .gitignore:202 (yahoofinance/output/* with
+          # only *.csv re-included). They are ignored on purpose, so a local
+          # backtest does not dirty the tree; publishing them is this workflow's
+          # entire job, and that is exactly what -f is for.
+          #
+          # `git add` on an ignored path exits 1 with "The following paths are
+          # ignored by one of your .gitignore files". The `|| true` swallowed it,
+          # nothing was staged, the next step reported "No changes to commit",
+          # and the run went green. Five consecutive weekly runs passed that way
+          # while delivering nothing, which is why the dashboard reads
+          # data:produced:backtest_report as failing with the workflow green.
+          #
+          # A missing artifact is now a visible warning rather than silence: if
+          # the backtest stops producing one of these, that is a finding, and the
+          # old form could not tell it apart from an ignored path.
+          for f in \
+            yahoofinance/output/backtest_results.csv \
+            yahoofinance/output/backtest_summary.csv \
+            yahoofinance/output/backtest_threshold_report.csv \
+            yahoofinance/output/backtest_report.json \
+            data/committee/action_log.jsonl
+          do
+            if [ -f "$f" ]; then
+              git add -f "$f"
+            else
+              echo "::warning::$f was not produced by this backtest run"
+            fi
+          done
 
           if git diff --staged --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
Four of the five artifacts this workflow exists to publish are gitignored:

| path | ignored by |
|---|---|
| `yahoofinance/output/backtest_results.csv` | `.gitignore:209` |
| `yahoofinance/output/backtest_summary.csv` | `.gitignore:209` |
| `yahoofinance/output/backtest_threshold_report.csv` | `.gitignore:209` |
| `yahoofinance/output/backtest_report.json` | `.gitignore:202` |

Deliberate, so a local backtest does not dirty the tree. But `git add` on an ignored path exits 1 with *"The following paths are ignored by one of your .gitignore files"*, and every line ended in `|| true`. The error was swallowed, nothing was staged, the next step reported "No changes to commit", and the run went green.

**Five consecutive weekly runs passed while delivering nothing.**

Found from the other end: the estate dashboard reads `backtest_report`, `backtest_results` and `backtest_summary` as failing on age while this workflow's history is unbroken green. That combination is only possible if the run is not doing what its name says.

`git add -f` is exactly what publishing a deliberately-ignored artifact is for. Proven against a scratch clone of this branch: the three ignored files stage, and the one that was absent produces a visible `::warning::` instead of the silence `|| true` gave it. A missing artifact is a finding, and the old form could not tell it apart from an ignored path.

`data/committee/action_log.jsonl` is **not** ignored and is already tracked, so its 67-day staleness on the dashboard is a separate question about whether the backtest still writes it. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)